### PR TITLE
Aligne l'aperçu de barre disque watcher

### DIFF
--- a/frontend/src/components/MonitoringTab.vue
+++ b/frontend/src/components/MonitoringTab.vue
@@ -138,6 +138,22 @@
                                     class="form-check-input" type="radio" value="bar" />
                                 <label class="form-check-label" for="diskDisplayBar">
                                     {{ $t('watcher.monitoring.diskDisplayBar') }}
+                                    <span class="disk-display-example ms-1">
+                                        <span>/home</span>
+                                        <span class="disk-example-bar" aria-label="[⣿⣿        ]">
+                                            <span class="disk-example-bracket">[</span>
+                                            <span class="disk-example-cells" aria-hidden="true">
+                                                <span
+                                                    v-for="(filled, index) in diskDisplayExampleCells"
+                                                    :key="index"
+                                                    class="disk-example-cell"
+                                                    :class="{ filled }"
+                                                ></span>
+                                            </span>
+                                            <span class="disk-example-bracket">]</span>
+                                        </span>
+                                        <span>19% 2Tio</span>
+                                    </span>
                                 </label>
                             </div>
                         </div>
@@ -556,6 +572,7 @@ const monSettings = ref<MonitoringSettings>({
 
 const diskPartitions = ref<string[]>(["/"]);
 const diskDisplayMode = ref<"compact" | "bar">("compact");
+const diskDisplayExampleCells = [true, true, false, false, false, false, false, false, false, false];
 const newPartition   = ref("");
 const savingMon      = ref(false);
 const savingDisplay  = ref(false);
@@ -970,6 +987,43 @@ onUnmounted(() => {
     color: #d1d5db;
     &:hover { background: rgba(255,255,255,.14); color: #fff; }
     &:disabled { opacity: .5; cursor: default; }
+}
+
+.disk-display-example {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.disk-example-bar {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    font-family: "JetBrains Mono", monospace;
+    line-height: 1;
+}
+
+.disk-example-bracket {
+    line-height: 1;
+}
+
+.disk-example-cells {
+    display: inline-grid;
+    grid-template-columns: repeat(10, 0.38rem);
+    align-items: center;
+    column-gap: 1px;
+    height: 0.7rem;
+}
+
+.disk-example-cell {
+    display: block;
+    width: 0.38rem;
+    height: 0.58rem;
+    border-radius: 1px;
+}
+
+.disk-example-cell.filled {
+    background: currentColor;
 }
 
 /* ── Kula open link ── */

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -172,7 +172,7 @@
     "watcher.monitoring.diskPartitionHint": "Partitions shown in the navbar (e.g. / or /mnt/data). One per line.",
     "watcher.monitoring.diskDisplayMode": "Partition rendering",
     "watcher.monitoring.diskDisplayCompact": "Compact: /home 19%",
-    "watcher.monitoring.diskDisplayBar": "Bar: /home [⣿⣿        ] 19% 2Tio",
+    "watcher.monitoring.diskDisplayBar": "Bar:",
     "watcher.monitoring.diskDisplayModeHint": "Chooses how disk partitions are shown in the navbar.",
     "watcher.monitoring.crashHeading": "Crash Loop Detection",
     "watcher.monitoring.crashEnabled": "Enable crash loop detection",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -165,7 +165,7 @@
     "watcher.monitoring.diskPartitionHint": "Partitions affichées dans la barre de navigation (ex : / ou /mnt/data).",
     "watcher.monitoring.diskDisplayMode": "Rendu des partitions",
     "watcher.monitoring.diskDisplayCompact": "Compact : /home 19%",
-    "watcher.monitoring.diskDisplayBar": "Barre : /home [⣿⣿        ] 19% 2Tio",
+    "watcher.monitoring.diskDisplayBar": "Barre :",
     "watcher.monitoring.diskDisplayModeHint": "Choisit l'affichage des partitions dans la barre de navigation.",
     "watcher.monitoring.crashHeading": "Détection de crash loop",
     "watcher.monitoring.crashEnabled": "Activer la détection de crash loop",


### PR DESCRIPTION
## Résumé
- remplace l'ancien exemple texte en braille dans /watcher par une mini-barre CSS
- garde les libellés FR/EN simples pour le mode Barre
- conserve un libellé accessible au format texte pour la mini-barre

## Validation
- npm run check-ts
- npm.cmd run build:frontend
- git diff --check