### PR TITLE
Corriger le libellé des mesures incomplètes

### DIFF
--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -223,7 +223,7 @@
     "watcher.capacity.volumes": "Volumes",
     "watcher.capacity.images": "Images anciennes / inutilisées",
     "watcher.capacity.containers": "Top containers",
-    "watcher.capacity.warnings": "Mesures incomplÃ¨tes",
+    "watcher.capacity.warnings": "Mesures incomplètes",
     "watcher.capacity.unknown": "Inconnu",
     "watcher.capacity.col.stack": "Stack",
     "watcher.capacity.col.total": "Total connu",


### PR DESCRIPTION
## Objectifs
- Corriger le dernier libellé mal encodé de l'onglet Capacité.

## R?alisation
- Remplacement de "Mesures incompl??tes" par "Mesures incomplètes" dans la traduction française.

## Vérifications
- Vérification ciblée des clés watcher.capacity.*
- npm run check-ts
- npm.cmd run build:frontend
- git diff --check
