### PR TITLE
Corriger l’authentification des pulls depuis les registries privés

### DIFF
--- a/backend/registry-auth.ts
+++ b/backend/registry-auth.ts
@@ -1,0 +1,116 @@
+import * as fs from "fs/promises";
+import * as os from "node:os";
+import * as path from "path";
+
+export interface DockerRegistryCredential {
+    registry: string;
+    username: string;
+    token: string;
+}
+
+interface DockerAuthConfig {
+    auths?: Record<string, { auth?: string }>;
+    [key: string]: unknown;
+}
+
+const DATA_DIR = process.env.DOCKGE_DATA_DIR ?? "/opt/dockge/data";
+const MANAGED_CONFIG_DIR = path.join(DATA_DIR, "docker-config");
+const MANAGED_CONFIG_PATH = path.join(MANAGED_CONFIG_DIR, "config.json");
+
+// Capture any operator-provided config before Dockge redirects Docker clients.
+const BASE_CONFIG_DIR = process.env.DOCKER_CONFIG ?? path.join(os.homedir(), ".docker");
+const BASE_CONFIG_PATH = path.join(BASE_CONFIG_DIR, "config.json");
+
+export function normalizeRegistryHost(registry: string): string {
+    const trimmed = registry.trim();
+    if (!trimmed) {
+        return "";
+    }
+
+    try {
+        const parsed = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
+        return normalizeDockerHubAlias(parsed.host.toLowerCase());
+    } catch {
+        const host = trimmed.replace(/^https?:\/\//i, "").replace(/\/+$/, "").toLowerCase();
+        return normalizeDockerHubAlias(host);
+    }
+}
+
+function normalizeDockerHubAlias(registry: string): string {
+    if ([ "docker.io", "index.docker.io", "registry-1.docker.io" ].includes(registry)) {
+        return "registry-1.docker.io";
+    }
+    return registry;
+}
+
+function dockerAuthKey(registry: string): string {
+    return registry === "registry-1.docker.io"
+        ? "https://index.docker.io/v1/"
+        : registry;
+}
+
+export function buildDockerAuthConfig(
+    baseConfig: DockerAuthConfig,
+    credentials: DockerRegistryCredential[],
+): DockerAuthConfig {
+    const auths = { ...(baseConfig.auths ?? {}) };
+
+    for (const credential of credentials) {
+        const registry = normalizeRegistryHost(credential.registry);
+        const username = credential.username.trim();
+        if (!registry || !username || !credential.token) {
+            continue;
+        }
+
+        auths[dockerAuthKey(registry)] = {
+            auth: Buffer.from(`${username}:${credential.token}`, "utf8").toString("base64"),
+        };
+    }
+
+    return {
+        ...baseConfig,
+        auths,
+    };
+}
+
+async function readBaseConfig(): Promise<DockerAuthConfig> {
+    if (path.resolve(BASE_CONFIG_PATH) === path.resolve(MANAGED_CONFIG_PATH)) {
+        return {};
+    }
+
+    try {
+        return JSON.parse(await fs.readFile(BASE_CONFIG_PATH, "utf8")) as DockerAuthConfig;
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Writes the Docker CLI config inherited by every child `docker` process.
+ * Docker stores auth in base64 rather than encrypting it, so permissions are
+ * restricted to the Dockge process user.
+ */
+export async function syncDockerRegistryCredentials(
+    credentials: DockerRegistryCredential[],
+): Promise<void> {
+    const baseConfig = await readBaseConfig();
+    const config = buildDockerAuthConfig(baseConfig, credentials);
+    const tempPath = `${MANAGED_CONFIG_PATH}.${process.pid}.tmp`;
+
+    await fs.mkdir(MANAGED_CONFIG_DIR, {
+        recursive: true,
+        mode: 0o700,
+    });
+    await fs.chmod(MANAGED_CONFIG_DIR, 0o700).catch(() => {});
+    await fs.writeFile(tempPath, JSON.stringify(config, null, 2), {
+        mode: 0o600,
+    });
+    await fs.rename(tempPath, MANAGED_CONFIG_PATH);
+    await fs.chmod(MANAGED_CONFIG_PATH, 0o600).catch(() => {});
+
+    process.env.DOCKER_CONFIG = MANAGED_CONFIG_DIR;
+}
+
+export function getManagedDockerConfigDir(): string {
+    return MANAGED_CONFIG_DIR;
+}

--- a/backend/routers/watcher-router.ts
+++ b/backend/routers/watcher-router.ts
@@ -21,6 +21,7 @@ import { Settings } from "../settings";
 import jwt from "jsonwebtoken";
 import { JWTDecoded } from "../util-server";
 import { AuditLogger, setAuditUser } from "../audit-log";
+import { normalizeRegistryHost } from "../registry-auth";
 
 // ─── Middleware d'authentification JWT ───────────────────────────
 //
@@ -248,6 +249,8 @@ export class WatcherRouter extends Router {
             if (!cred.registry || !cred.username || !cred.token) {
                 return res.status(400).json({ ok: false, message: "registry, username et token requis" });
             }
+            cred.registry = normalizeRegistryHost(cred.registry);
+            cred.username = cred.username.trim();
             const watcher = ImageWatcher.getInstance();
             const creds = watcher.settings.credentials.filter(c => c.registry !== cred.registry);
             creds.push(cred);

--- a/backend/terminal.ts
+++ b/backend/terminal.ts
@@ -25,6 +25,7 @@ export class Terminal {
     protected file : string;
     protected args : string | string[];
     protected cwd : string;
+    protected env? : { [key: string]: string | undefined };
     protected callback? : (exitCode : number) => void;
 
     protected _rows : number = TERMINAL_ROWS;
@@ -37,13 +38,14 @@ export class Terminal {
 
     protected socketList : Record<string, DockgeSocket> = {};
 
-    constructor(server : DockgeServer, name : string, file : string, args : string | string[], cwd : string) {
+    constructor(server : DockgeServer, name : string, file : string, args : string | string[], cwd : string, env? : { [key: string]: string | undefined }) {
         this.server = server;
         this._name = name;
         //this._name = "terminal-" + Date.now() + "-" + getCryptoRandomInt(0, 1000000);
         this.file = file;
         this.args = args;
         this.cwd = cwd;
+        this.env = env;
 
         Terminal.terminalMap.set(this.name, this);
     }
@@ -118,6 +120,7 @@ export class Terminal {
                 cwd: this.cwd,
                 cols: TERMINAL_COLS,
                 rows: this.rows,
+                ...(this.env ? { env: this.env } : {}),
             });
 
             // On Data
@@ -231,7 +234,7 @@ export class Terminal {
                 return;
             }
 
-            let terminal = new Terminal(server, terminalName, file, args, cwd);
+            let terminal = new Terminal(server, terminalName, file, args, cwd, process.env);
             terminal.rows = PROGRESS_TERMINAL_ROWS;
 
             if (socket) {

--- a/backend/watchers/image-watcher.ts
+++ b/backend/watchers/image-watcher.ts
@@ -18,6 +18,11 @@ EventEmitter.defaultMaxListeners = 50;
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
 import { Settings } from "../settings";
+import {
+  DockerRegistryCredential,
+  normalizeRegistryHost,
+  syncDockerRegistryCredentials,
+} from "../registry-auth";
 
 const execAsync = promisify(exec);
 
@@ -41,7 +46,7 @@ function rollbackTag(key: string): string {
 
 // ─── Types ────────────────────────────────────────────────────────
 
-export interface RegistryCredential {
+export interface RegistryCredential extends DockerRegistryCredential {
   registry: string; // "ghcr.io", "registry.example.com"
   username: string;
   token: string; // PAT GitHub ou password
@@ -628,14 +633,20 @@ export class ImageWatcher {
 
   async saveSettings(partial: Partial<WatcherSettings>): Promise<void> {
     this.settings = { ...this.settings, ...partial };
+    this.settings.credentials = this.settings.credentials.map((credential) => ({
+      ...credential,
+      registry: normalizeRegistryHost(credential.registry),
+    }));
     await this.persistToFile();
+    await syncDockerRegistryCredentials(this.settings.credentials);
     this.restart();
   }
 
   /** Écrit les settings sur disque SANS redémarrer le watcher (usage interne) */
   private async persistToFile(): Promise<void> {
     await fs.mkdir(DATA_DIR, { recursive: true });
-    await fs.writeFile(SETTINGS_PATH, JSON.stringify(this.settings, null, 2));
+    await fs.writeFile(SETTINGS_PATH, JSON.stringify(this.settings, null, 2), { mode: 0o600 });
+    await fs.chmod(SETTINGS_PATH, 0o600).catch(() => {});
   }
 
   getSettingsSafe(): WatcherSettings {
@@ -652,6 +663,11 @@ export class ImageWatcher {
 
   async startIfEnabled(): Promise<void> {
     await this.loadSettings();
+    this.settings.credentials = this.settings.credentials.map((credential) => ({
+      ...credential,
+      registry: normalizeRegistryHost(credential.registry),
+    }));
+    await syncDockerRegistryCredentials(this.settings.credentials);
     await this.loadRollbackRegistry();
     await this._loadUpdateHistory();
     if (this.settings.enabled) this.start();


### PR DESCRIPTION
## Résumé

- génère un `DOCKER_CONFIG` persistant à partir des credentials de registries privés configurés dans la WebUI
- transmet ce contexte d'authentification aux commandes Docker non interactives, dont `docker compose pull`
- couvre les pulls manuels et les mises à jour automatiques
- normalise les adresses de registry et prend en charge les alias Docker Hub
- restreint les permissions de `watcher-settings.json` et du config Docker généré
- conserve un éventuel config Docker fourni par l'opérateur

## Validation

- `npm run check-ts`
- `npx eslint backend/registry-auth.ts`
- test isolé de génération et synchronisation du config Docker
- authentification GHCR validée sur un package privé
- `docker manifest inspect` authentifié validé depuis le conteneur Dockge

## Cause

Les credentials étaient uniquement utilisés par le watcher pour consulter les manifests Registry v2. Les vrais pulls lançaient `docker compose pull` sans configuration d'authentification Docker.