### PR TITLE
Gérer les mises à jour automatiques depuis les stacks

### DIFF
--- a/backend/routers/watcher-router.ts
+++ b/backend/routers/watcher-router.ts
@@ -178,6 +178,10 @@ export class WatcherRouter extends Router {
         // IMAGE WATCHER — Toggle auto-update par image
         // ════════════════════════════════════════════════════════════════
 
+        router.get("/image/auto-update", (_req: Request, res: Response) => {
+            res.json({ ok: true, data: ImageWatcher.getInstance().getAutoUpdateState() });
+        });
+
         router.post("/image/auto-update", async (req: Request, res: Response) => {
             const { key, mode, time } = req.body as { key: string; mode: "off" | "immediate" | "scheduled" | "ignored"; time?: string };
             if (!key) return res.status(400).json({ ok: false, message: "key requis (format: stack::image)" });

--- a/backend/watchers/image-watcher.ts
+++ b/backend/watchers/image-watcher.ts
@@ -659,6 +659,15 @@ export class ImageWatcher {
     };
   }
 
+  getAutoUpdateState() {
+    return {
+      enabled: this.settings.enabled,
+      autoUpdateConfig: this.settings.autoUpdateConfig ?? {},
+      pendingAutoUpdates: this.settings.pendingAutoUpdates ?? [],
+      updatingImages: [...this._updatingImages],
+    };
+  }
+
   // ── Cycle de vie ──────────────────────────────────────────────
 
   async startIfEnabled(): Promise<void> {

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -19,6 +19,37 @@
                         <font-awesome-icon icon="arrow-circle-up" class="me-1" />{{ $t("containerImageUpdateAvailable") }}
                     </span>
                 </div>
+                <div v-if="!isEditMode && autoUpdate" class="container-auto-update mb-2">
+                    <label class="container-auto-update-label" :for="`auto-update-${name}`">
+                        {{ $t("watcher.status.autoUpdate") }}
+                    </label>
+                    <select
+                        :id="`auto-update-${name}`"
+                        class="form-select form-select-sm container-auto-update-select"
+                        :value="autoUpdate.mode"
+                        :disabled="autoUpdateSaving"
+                        @change="changeAutoUpdateMode"
+                    >
+                        <option value="off">{{ $t("watcher.status.auOff") }}</option>
+                        <option value="ignored">{{ $t("watcher.status.auIgnored") }}</option>
+                        <option value="immediate">{{ $t("watcher.status.auImmediate") }}</option>
+                        <option value="scheduled">{{ $t("watcher.status.auScheduled") }}</option>
+                    </select>
+                    <input
+                        v-if="autoUpdate.mode === 'scheduled'"
+                        type="time"
+                        class="form-control form-control-sm container-auto-update-time"
+                        :value="autoUpdate.time"
+                        :disabled="autoUpdateSaving"
+                        @change="changeAutoUpdateTime"
+                    />
+                    <span v-if="autoUpdate.updating" class="container-auto-update-state updating">
+                        <font-awesome-icon icon="spinner" spin /> {{ $t("watcher.status.auUpdating") }}
+                    </span>
+                    <span v-else-if="autoUpdate.pending" class="container-auto-update-state pending">
+                        {{ $t("watcher.status.auPending") }}
+                    </span>
+                </div>
                 <div v-if="!isEditMode">
                     <span class="badge me-1" :class="bgStyle">{{ status }}</span>
 
@@ -203,9 +234,18 @@ export default defineComponent({
         imageUpdate: {
             type: Object,
             default: null
+        },
+        autoUpdate: {
+            type: Object,
+            default: null
+        },
+        autoUpdateSaving: {
+            type: Boolean,
+            default: false
         }
     },
     emits: [
+        "auto-update-change",
     ],
     data() {
         return {
@@ -331,6 +371,19 @@ export default defineComponent({
         }
     },
     methods: {
+        changeAutoUpdateMode(event) {
+            const mode = event.target.value;
+            this.$emit("auto-update-change", {
+                mode,
+                time: mode === "scheduled" ? this.autoUpdate.time : undefined,
+            });
+        },
+        changeAutoUpdateTime(event) {
+            this.$emit("auto-update-change", {
+                mode: "scheduled",
+                time: event.target.value,
+            });
+        },
         parsePort(port) {
             if (this.stack.endpoint) {
                 return parseDockerPort(port, this.stack.primaryHostname);
@@ -395,6 +448,46 @@ export default defineComponent({
         background: rgba(248, 163, 6, 0.14);
         border: 1px solid rgba(248, 163, 6, 0.3);
         vertical-align: middle;
+    }
+
+    .container-auto-update {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+
+    .container-auto-update-label,
+    .container-auto-update-state {
+        font-size: 0.72rem;
+        color: #6b7280;
+
+        .dark & {
+            color: $dark-font-color;
+        }
+    }
+
+    .container-auto-update-select {
+        width: auto;
+        min-width: 118px;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        font-size: 0.75rem;
+    }
+
+    .container-auto-update-time {
+        width: 104px;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        font-size: 0.75rem;
+    }
+
+    .container-auto-update-state.pending {
+        color: $warning;
+    }
+
+    .container-auto-update-state.updating {
+        color: $primary;
     }
 
     .function {

--- a/frontend/src/components/WatcherSettings.vue
+++ b/frontend/src/components/WatcherSettings.vue
@@ -1780,12 +1780,17 @@ onUnmounted(() => {
 });
 
 async function loadStatus() {
-  const [statusRes, rollbackRes] = await Promise.all([
+  const [statusRes, rollbackRes, autoUpdateRes] = await Promise.all([
     api("GET", "/image/status"),
     api("GET", "/image/rollback"),
+    api("GET", "/image/auto-update"),
   ]);
   if (statusRes.ok) imageStatuses.value = statusRes.data;
   if (rollbackRes.ok) rollbackEntries.value = rollbackRes.data;
+  if (autoUpdateRes.ok) {
+    imgSettings.value.autoUpdateConfig = autoUpdateRes.data?.autoUpdateConfig ?? {};
+    imgSettings.value.pendingAutoUpdates = autoUpdateRes.data?.pendingAutoUpdates ?? [];
+  }
 }
 
 function rollbackFor(s: ImageStatus): RollbackEntry | undefined {

--- a/frontend/src/composables/useImageStatus.ts
+++ b/frontend/src/composables/useImageStatus.ts
@@ -1,9 +1,3 @@
-/**
- * useImageStatus — Composable Vue 3 qui poll l'état des images.
- * Utilisé par le badge à injecter dans la liste des stacks Dockge.
- * Fichier : frontend/src/composables/useImageStatus.ts
- */
-
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { POLL, makePoller, type Poller } from "./useLowPower";
 
@@ -17,22 +11,58 @@ export interface ImageStatus {
     error?: string;
 }
 
-// Cache global partagé entre tous les composants qui utilisent ce composable
+export type AutoUpdateMode = "off" | "ignored" | "immediate" | "scheduled";
+
+export interface AutoUpdateStatus {
+    mode: AutoUpdateMode;
+    time: string;
+    pending: boolean;
+    updating: boolean;
+}
+
+interface AutoUpdateEntry {
+    mode: Exclude<AutoUpdateMode, "off">;
+    time?: string;
+}
+
 const statusCache = ref<ImageStatus[]>([]);
+const autoUpdateConfig = ref<Record<string, AutoUpdateEntry>>({});
+const pendingAutoUpdates = ref<string[]>([]);
+const updatingImages = ref<string[]>([]);
 let poller: Poller | null = null;
 let subscribers = 0;
 
+function authHeaders(json = false): Record<string, string> {
+    const token = localStorage.getItem("token") ?? sessionStorage.getItem("token") ?? "";
+    return {
+        ...(token ? { "Authorization": `Bearer ${token}` } : {}),
+        ...(json ? { "Content-Type": "application/json" } : {}),
+    };
+}
+
 async function fetchStatus() {
     try {
-        const token = localStorage.getItem("token") ?? sessionStorage.getItem("token") ?? "";
-        const res = await fetch("/api/watcher/image/status", {
-            headers: token ? { "Authorization": `Bearer ${token}` } : {},
-        });
-        if (res.status === 401) return; // non connecté, on ne pollue pas la console
-        const json = await res.json();
-        if (json.ok) statusCache.value = json.data;
+        const [ statusRes, autoUpdateRes ] = await Promise.all([
+            fetch("/api/watcher/image/status", { headers: authHeaders() }),
+            fetch("/api/watcher/image/auto-update", { headers: authHeaders() }),
+        ]);
+        if (statusRes.status === 401 || autoUpdateRes.status === 401) {
+            return;
+        }
+
+        const statusJson = await statusRes.json();
+        if (statusJson.ok) {
+            statusCache.value = statusJson.data;
+        }
+
+        const autoUpdateJson = await autoUpdateRes.json();
+        if (autoUpdateJson.ok) {
+            autoUpdateConfig.value = autoUpdateJson.data?.autoUpdateConfig ?? {};
+            pendingAutoUpdates.value = autoUpdateJson.data?.pendingAutoUpdates ?? [];
+            updatingImages.value = autoUpdateJson.data?.updatingImages ?? [];
+        }
     } catch {
-        // Silencieux — le watcher est peut-être désactivé
+        // The watcher can be disabled or temporarily unavailable.
     }
 }
 
@@ -40,8 +70,10 @@ export function useImageStatus() {
     onMounted(() => {
         subscribers++;
         if (subscribers === 1) {
-            // Premier abonné : démarre le polling (visibility-aware)
-            poller = makePoller({ fetch: fetchStatus, interval: POLL.image });
+            poller = makePoller({
+                fetch: fetchStatus,
+                interval: POLL.image,
+            });
             poller.start();
         }
     });
@@ -54,22 +86,18 @@ export function useImageStatus() {
         }
     });
 
-    /** Retourne les statuts d'une stack donnée */
     function statusForStack(stackName: string): ImageStatus[] {
         return statusCache.value.filter(s => s.stack === stackName);
     }
 
-    /** true si au moins une image de la stack a une mise à jour disponible */
     function hasUpdates(stackName: string): boolean {
         return statusForStack(stackName).some(s => s.hasUpdate && !s.error);
     }
 
-    /** Nombre de mises à jour disponibles sur une stack */
     function updateCount(stackName: string): number {
         return statusForStack(stackName).filter(s => s.hasUpdate && !s.error).length;
     }
 
-    /** true si au moins une image de la stack est en erreur de vérification */
     function hasErrors(stackName: string): boolean {
         return statusForStack(stackName).some(s => !!s.error);
     }
@@ -78,5 +106,65 @@ export function useImageStatus() {
         statusCache.value.filter(s => s.hasUpdate && !s.error).length
     );
 
-    return { statusCache, statusForStack, hasUpdates, updateCount, hasErrors, totalUpdates };
+    function autoUpdateFor(stackName: string, image: string): AutoUpdateStatus {
+        const key = `${stackName}::${image}`;
+        const config = autoUpdateConfig.value[key];
+        return {
+            mode: config?.mode ?? "off",
+            time: config?.time ?? "02:00",
+            pending: pendingAutoUpdates.value.includes(key),
+            updating: updatingImages.value.includes(key),
+        };
+    }
+
+    async function setAutoUpdateMode(stackName: string, image: string, mode: AutoUpdateMode, time?: string) {
+        const key = `${stackName}::${image}`;
+        try {
+            const res = await fetch("/api/watcher/image/auto-update", {
+                method: "POST",
+                headers: authHeaders(true),
+                body: JSON.stringify({
+                    key,
+                    mode,
+                    ...(mode === "scheduled" ? { time: time ?? "02:00" } : {}),
+                }),
+            });
+            const json = await res.json();
+            if (!res.ok || !json.ok) {
+                return {
+                    ok: false,
+                    message: json.message ?? res.statusText,
+                };
+            }
+
+            pendingAutoUpdates.value = pendingAutoUpdates.value.filter(item => item !== key);
+            if (mode === "off") {
+                delete autoUpdateConfig.value[key];
+            } else {
+                autoUpdateConfig.value[key] = mode === "scheduled"
+                    ? {
+                        mode,
+                        time: time ?? "02:00",
+                    }
+                    : { mode };
+            }
+            return { ok: true };
+        } catch (error) {
+            return {
+                ok: false,
+                message: error instanceof Error ? error.message : String(error),
+            };
+        }
+    }
+
+    return {
+        statusCache,
+        statusForStack,
+        hasUpdates,
+        updateCount,
+        hasErrors,
+        totalUpdates,
+        autoUpdateFor,
+        setAutoUpdateMode,
+    };
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -384,6 +384,8 @@
     "watcher.status.auImmediate": "Immediate",
     "watcher.status.auScheduled": "Scheduled",
     "watcher.status.auPendingHint": "Update pending — will be applied at the scheduled time.",
+    "watcher.status.auPending": "Pending",
+    "watcher.status.auUpdating": "Updating",
     "watcher.status.ignoreVersion": "Skip this version",
     "watcher.status.versionIgnored": "Version skipped",
     "watcher.status.clearIgnored": "Resume",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -377,6 +377,8 @@
     "watcher.status.auImmediate": "Immédiat",
     "watcher.status.auScheduled": "Planifié",
     "watcher.status.auPendingHint": "Mise à jour en attente — sera appliquée à l'heure planifiée.",
+    "watcher.status.auPending": "En attente",
+    "watcher.status.auUpdating": "Mise à jour en cours",
     "watcher.status.ignoreVersion": "Ignorer cette version",
     "watcher.status.versionIgnored": "Version ignorée",
     "watcher.status.clearIgnored": "Reprendre",

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -175,6 +175,9 @@
                                 :ports="serviceStatusList[name]?.ports"
                                 :started-at="serviceStatusList[name]?.startedAt ?? null"
                                 :image-update="imageUpdateForService(name)"
+                                :auto-update="autoUpdateForService(name)"
+                                :auto-update-saving="autoUpdateSaving[name] === true"
+                                @auto-update-change="setServiceAutoUpdate(name, $event)"
                             />
                         </div>
                     </div>
@@ -433,7 +436,11 @@ export default {
     },
     setup() {
         const editorFocus = ref(false);
-        const { statusCache: imageStatuses } = useImageStatus();
+        const {
+            statusCache: imageStatuses,
+            autoUpdateFor,
+            setAutoUpdateMode: saveAutoUpdateMode,
+        } = useImageStatus();
 
         const focusEffectHandler = (state, focusing) => {
             editorFocus.value = focusing;
@@ -470,7 +477,9 @@ export default {
         return { extensions,
             extensionsEnv,
             editorFocus,
-            imageStatuses };
+            imageStatuses,
+            autoUpdateFor,
+            saveAutoUpdateMode };
     },
     yamlDoc: null,  // For keeping the yaml comments
     data() {
@@ -501,6 +510,7 @@ export default {
             selectedLogService: "",
             joinedLogService: "",
             containersExpanded: true,
+            autoUpdateSaving: {},
         };
     },
     computed: {
@@ -889,6 +899,29 @@ export default {
                 && status.hasUpdate
                 && !status.error
             ) ?? null;
+        },
+
+        autoUpdateForService(serviceName) {
+            const image = this.envsubstJSONConfig?.services?.[serviceName]?.image;
+            if (!image || !this.stack.name || this.endpoint) {
+                return null;
+            }
+            return this.autoUpdateFor(this.stack.name, image);
+        },
+
+        async setServiceAutoUpdate(serviceName, { mode, time }) {
+            const image = this.envsubstJSONConfig?.services?.[serviceName]?.image;
+            if (!image || !this.stack.name) {
+                return;
+            }
+
+            this.autoUpdateSaving[serviceName] = true;
+            const result = await this.saveAutoUpdateMode(this.stack.name, image, mode, time);
+            this.autoUpdateSaving[serviceName] = false;
+            this.$root.toastRes({
+                ok: result.ok,
+                msg: result.ok ? this.$t("watcher.status.autoUpdateSaved") : result.message,
+            });
         },
 
         loadStack() {


### PR DESCRIPTION
## Résumé

- ajoute sous chaque image de conteneur le même sélecteur de mise à jour que dans `/watcher → Images`
- affiche et permet de modifier les modes `Manuelle`, `Ignorer`, `Immédiat` et `Planifié`
- affiche le champ horaire en mode planifié ainsi que les états `En attente` et `Mise à jour en cours`
- synchronise les réglages entre la page de stack et la page Watcher
- masque le contrôle pour les stacks d’agents distants, que le watcher local ne peut pas mettre à jour

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- validation JSON des traductions française et anglaise
- `git diff --check`