### PR TITLE
Corriger les dimensions du terminal des stacks

### DIFF
--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -1310,11 +1310,13 @@ export default {
 
 .combined-terminal {
     height: 315px;
-    transition: height 180ms ease;
+    width: 100%;
+    padding: 0;
+    overflow: hidden;
 }
 
 .combined-terminal.logs-expanded {
-    height: clamp(420px, 55vh, 720px);
+    height: clamp(340px, 38vh, 420px);
 }
 
 @media (max-width: 575px) {
@@ -1323,7 +1325,7 @@ export default {
     }
 
     .combined-terminal.logs-expanded {
-        height: 60vh;
+        height: min(45vh, 360px);
     }
 }
 


### PR DESCRIPTION
## Résumé

- réduit la hauteur du terminal lorsque la section Conteneurs est repliée
- plafonne sa hauteur à 420 px sur desktop et 360 px sur mobile
- supprime l’animation qui faisait recalculer xterm sur l’ancienne dimension
- retire la marge intérieure du `shadow-box` pour que le terminal utilise toute la largeur disponible

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`