### PR TITLE
Ajouter le bootstrap et l’authentification par proxy de confiance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Vérification TypeScript (tsc --noEmit)
         run: npm run check-ts
 
+      - name: Tests d’authentification
+        run: npx tsx --test backend/auth.test.ts
+
       - name: Build frontend (Vite)
         run: npm run build:frontend

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -51,12 +51,17 @@ jobs:
       - name: 📌 Vérifier si déjà synchronisé
         id: check
         if: steps.target.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.target.outputs.tag }}"
-          # Vérifie si on a déjà un tag synced-TAG
-          if git tag -l | grep -q "^synced-${TAG}$"; then
+          BRANCH="sync/upstream-${TAG}"
+          if git merge-base --is-ancestor "$TAG" origin/main; then
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "✅ Déjà synchronisé avec $TAG"
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "⏳ Une synchronisation de $TAG est déjà en attente"
           else
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "🆕 Nouvelle version détectée : $TAG"
@@ -80,8 +85,24 @@ jobs:
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
             echo "✅ Merge réussi sans conflit"
           else
-            # En cas de conflit, on garde NOS versions des fichiers modifiés
+            echo "conflict=true" >> $GITHUB_OUTPUT
+            # En cas de conflit, on garde NOS versions et on exige une revue explicite
             echo "⚠️ Conflits détectés — résolution automatique (ours pour nos fichiers)"
+
+            AUTH_SENSITIVE_FILES=(
+              "backend/auth.ts"
+              "backend/dockge-server.ts"
+              "backend/socket-handlers/main-socket-handler.ts"
+              "frontend/src/mixins/socket.ts"
+            )
+            AUTH_CONFLICTS=()
+            for f in "${AUTH_SENSITIVE_FILES[@]}"; do
+              if git diff --name-only --diff-filter=U | grep -q "^${f}$"; then
+                AUTH_CONFLICTS+=("$f")
+              fi
+            done
+            AUTH_CONFLICTS_CSV=$(IFS=,; echo "${AUTH_CONFLICTS[*]}")
+            echo "auth_conflicts=$AUTH_CONFLICTS_CSV" >> $GITHUB_OUTPUT
 
             ENHANCED_FILES=(
               "backend/dockge-server.ts"
@@ -111,9 +132,6 @@ jobs:
               echo "$REMAINING"
               git checkout --ours $REMAINING
               git add $REMAINING
-              echo "conflict=true" >> $GITHUB_OUTPUT
-            else
-              echo "conflict=false" >> $GITHUB_OUTPUT
             fi
 
             git commit --no-edit -m "🔄 Sync upstream Dockge $TAG (conflits résolus auto)"
@@ -128,6 +146,7 @@ jobs:
           TAG="${{ steps.target.outputs.tag }}"
           BRANCH="${{ steps.merge.outputs.branch }}"
           CONFLICT="${{ steps.merge.outputs.conflict }}"
+          AUTH_CONFLICTS="${{ steps.merge.outputs.auth_conflicts }}"
 
           git push origin "$BRANCH"
 
@@ -137,10 +156,13 @@ jobs:
 
           **Conflits ?** $([ "$CONFLICT" = "true" ] && echo "⚠️ Oui — résolus automatiquement en gardant nos modifications Enhanced. **Vérifie que tout est correct.**" || echo "✅ Non — merge propre.")
 
+          $([ -n "$AUTH_CONFLICTS" ] && echo "**⚠️ Conflits d’authentification à examiner manuellement :** \`$AUTH_CONFLICTS\`" || true)
+
           ### Checklist avant merge
           - [ ] Vérifier que le build Docker fonctionne
           - [ ] Vérifier les changements dans \`package.json\` (nouvelles dépendances upstream ?)
           - [ ] Tester l'interface Surveillance
+          - [ ] Si l’authentification est touchée, comparer manuellement les versions upstream et Enhanced
           "
 
           gh pr create \
@@ -149,10 +171,3 @@ jobs:
             --title "🔄 Sync upstream Dockge $TAG" \
             --body "$BODY" \
             --label "upstream-sync"
-
-      - name: 🏷️ Marquer comme synchronisé
-        if: steps.target.outputs.found == 'true' && steps.check.outputs.skip == 'false'
-        run: |
-          TAG="${{ steps.target.outputs.tag }}"
-          git tag "synced-${TAG}"
-          git push origin "synced-${TAG}"

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,6 +23,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 
 ## Fonctionnalités
 
+🆕 **Authentification locale, bootstrap et proxy de confiance** — Le mode historique reste inchangé par défaut, sans nouvelle variable ni modification du Compose. Les déploiements automatisés peuvent créer le premier administrateur depuis un secret, tandis que le mode optionnel `trusted-proxy` accepte une identité transmise par OAuth2 Proxy, Traefik ForwardAuth ou un autre proxy uniquement lorsque la connexion provient d’un réseau explicitement autorisé. Les API REST et Socket.IO appliquent la même politique, `/setup` est verrouillé durablement après initialisation et aucun chemin technique ne doit être rendu public.
+
 🆕 **Détection complète des images dans le watcher** — L’onglet **Images** de `/watcher` liste désormais les images déclarées par toutes les stacks locales, même lorsqu’elles sont arrêtées et que leurs conteneurs ou images locales ont été supprimés. La découverte suit les quatre noms de fichiers acceptés par Dockge (`compose.yaml`, `compose.yml`, `docker-compose.yaml` et `docker-compose.yml`) et s’appuie sur le modèle résolu par Docker Compose pour prendre en charge les variables, ancres, `extends` et `include`, sans devoir effectuer un pull au préalable.
 
 🆕 **Recherche dans les ressources Docker** — La page **Ressources Docker**, y compris lorsqu’elle est ouverte depuis `/watcher`, dispose d’un champ de recherche commun aux onglets Images, Volumes et Hors Dockge. Le filtre retrouve une ressource par nom, image, tag, identifiant, stack, service ou conteneur associé.
@@ -260,10 +262,49 @@ Ouvre **http://localhost:5001**, crée ton compte admin, puis clique sur **Surve
 | `TZ` | `UTC` | Fuseau horaire du container — **important** pour que les MàJ planifiées se déclenchent à la bonne heure locale (ex : `Europe/Paris`) |
 | `DOCKGE_PORT` | `5001` | Port de la WebUI |
 | `DOCKGE_SSL_KEY` / `DOCKGE_SSL_CERT` | — | Activer HTTPS |
+| `DOCKGE_AUTH_MODE` | *(non défini)* | Mode d’authentification : `local`, `disabled` ou `trusted-proxy`. Non défini, le comportement historique et le réglage `disableAuth` sont conservés |
+| `DOCKGE_AUTH_PROXY_HEADER` | `x-forwarded-user` | Header contenant l’identité validée par le proxy en mode `trusted-proxy` |
+| `DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS` | *(requis en mode proxy)* | Adresses ou CIDR autorisés à fournir le header d’identité, séparés par des virgules |
+| `DOCKGE_BOOTSTRAP_USERNAME` | *(aucun)* | Nom du premier administrateur à créer uniquement si la base ne contient encore aucun utilisateur |
+| `DOCKGE_BOOTSTRAP_PASSWORD_FILE` | *(aucun)* | Fichier secret contenant son mot de passe ; recommandé pour un bootstrap automatisé |
+| `DOCKGE_BOOTSTRAP_PASSWORD` | *(aucun)* | Alternative directe au fichier secret, moins sûre car visible dans l’environnement du conteneur |
 
 > ⚠️ Toujours définir `DOCKGE_DATA_DIR=/app/data` pour correspondre au montage de volume, sinon les paramètres ne seront pas persistés après un redémarrage.
 
 > ℹ️ `DOCKGE_PUBLIC_URL` est optionnel. Si absent, les notifications Discord sont envoyées sans lien. Compatible avec les reverse proxies et les domaines HTTPS.
+
+### Authentification et premier setup
+
+**Installation existante : rien à changer.** Sans les variables ci-dessus, les comptes, la page de connexion, la 2FA et le réglage **Désactiver l’authentification** fonctionnent comme avant. Au premier démarrage d’une installation neuve, ouvre simplement `/setup` et crée l’administrateur. Une fois l’installation terminée, le serveur refuse toute nouvelle tentative de setup, même si l’URL SPA reste connue.
+
+Pour un bootstrap non interactif, monte de préférence un secret puis renseigne uniquement ces variables optionnelles :
+
+```yaml
+services:
+  dockge:
+    environment:
+      - DOCKGE_BOOTSTRAP_USERNAME=admin
+      - DOCKGE_BOOTSTRAP_PASSWORD_FILE=/run/secrets/dockge_admin_password
+    secrets:
+      - dockge_admin_password
+
+secrets:
+  dockge_admin_password:
+    file: ./secrets/dockge_admin_password
+```
+
+Le bootstrap est ignoré dès qu’un utilisateur existe : il ne modifie ni mot de passe ni compte sur une installation déjà initialisée.
+
+Pour déléguer l’accès à [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/) ou à Traefik ForwardAuth :
+
+```yaml
+environment:
+  - DOCKGE_AUTH_MODE=trusted-proxy
+  - DOCKGE_AUTH_PROXY_HEADER=x-forwarded-user
+  - DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS=172.20.0.0/24
+```
+
+Remplace le CIDR d’exemple par le réseau exact de ton proxy et configure celui-ci pour transmettre le header choisi. Le port Dockge ne doit pas être accessible directement : seuls les proxies déclarés peuvent fournir une identité. Tous les utilisateurs autorisés par le proxy disposent des droits administrateur dans Dockge Enhanced, qui ne propose pas encore de rôles distincts. Ne place jamais `/setup`, `/socket.io` ou `/api/*` dans une règle sans authentification ; le proxy doit transmettre les WebSockets et protéger tout le host.
 
 ---
 
@@ -273,6 +314,7 @@ Ce fork suit les releases stables de Dockge automatiquement via GitHub Actions :
 - **Chaque jour** — vérifie si une nouvelle version est disponible
 - **Si oui** — merge les changements upstream et crée une PR
 - **Au merge** — rebuild et publie les images Docker (`amd64` + `arm64`) sur GHCR
+- **En cas de conflit d’authentification** — conserve temporairement la version Enhanced dans la branche de synchronisation et signale explicitement les fichiers à comparer avant le merge
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 
 ## Features
 
+🆕 **Local authentication, bootstrap, and trusted proxy mode** — The historical behavior remains unchanged by default, with no new variable or Compose update required. Automated deployments can create the first administrator from a secret, while the optional `trusted-proxy` mode accepts an identity supplied by OAuth2 Proxy, Traefik ForwardAuth, or another proxy only when the connection originates from an explicitly trusted network. REST APIs and Socket.IO share the same policy, `/setup` is permanently locked after initialization, and no technical path needs to be exposed publicly.
+
 🆕 **Complete image discovery in the watcher** — The **Images** tab in `/watcher` now lists images declared by every local stack, even when a stack is stopped and its containers or local images have been removed. Discovery follows all four Compose filenames accepted by Dockge (`compose.yaml`, `compose.yml`, `docker-compose.yaml`, and `docker-compose.yml`) and uses Docker Compose’s resolved model to support variables, anchors, `extends`, and `include`, with no prior pull required.
 
 🆕 **Docker resource search** — The **Docker Resources** page, including when opened from `/watcher`, now provides one search field across the Images, Volumes, and Unmanaged tabs. Resources can be filtered by name, image, tag, ID, stack, service, or linked container.
@@ -260,10 +262,49 @@ Open **http://localhost:5001**, create your admin account, then click **Monitori
 | `TZ` | `UTC` | Container timezone — **important** for scheduled auto-updates to fire at the right local time (e.g. `Europe/Paris`) |
 | `DOCKGE_PORT` | `5001` | Web UI port |
 | `DOCKGE_SSL_KEY` / `DOCKGE_SSL_CERT` | — | Enable HTTPS |
+| `DOCKGE_AUTH_MODE` | *(unset)* | Authentication mode: `local`, `disabled`, or `trusted-proxy`. When unset, the historical behavior and `disableAuth` setting are preserved |
+| `DOCKGE_AUTH_PROXY_HEADER` | `x-forwarded-user` | Header containing the proxy-validated identity in `trusted-proxy` mode |
+| `DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS` | *(required in proxy mode)* | Comma-separated addresses or CIDRs allowed to provide the identity header |
+| `DOCKGE_BOOTSTRAP_USERNAME` | *(none)* | First administrator name, created only when the database contains no users |
+| `DOCKGE_BOOTSTRAP_PASSWORD_FILE` | *(none)* | Secret file containing the password; recommended for automated bootstrap |
+| `DOCKGE_BOOTSTRAP_PASSWORD` | *(none)* | Direct password alternative, less secure because it is visible in the container environment |
 
 > ⚠️ Always set `DOCKGE_DATA_DIR=/app/data` to match the volume mount, otherwise settings won't persist after a restart.
 
 > ℹ️ `DOCKGE_PUBLIC_URL` is optional. If not set, Discord notifications are sent without a link. Works with reverse proxies and HTTPS domains.
+
+### Authentication and initial setup
+
+**Existing installations require no changes.** Without the variables above, accounts, the login page, 2FA, and the **Disable authentication** setting work exactly as before. On the first start of a new installation, open `/setup` and create the administrator normally. Once initialized, the server rejects every further setup attempt even if the SPA URL remains known.
+
+For a non-interactive bootstrap, preferably mount a secret and set only these optional variables:
+
+```yaml
+services:
+  dockge:
+    environment:
+      - DOCKGE_BOOTSTRAP_USERNAME=admin
+      - DOCKGE_BOOTSTRAP_PASSWORD_FILE=/run/secrets/dockge_admin_password
+    secrets:
+      - dockge_admin_password
+
+secrets:
+  dockge_admin_password:
+    file: ./secrets/dockge_admin_password
+```
+
+Bootstrap is ignored as soon as a user exists, so it never changes an existing account or password.
+
+To delegate access to [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/) or Traefik ForwardAuth:
+
+```yaml
+environment:
+  - DOCKGE_AUTH_MODE=trusted-proxy
+  - DOCKGE_AUTH_PROXY_HEADER=x-forwarded-user
+  - DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS=172.20.0.0/24
+```
+
+Replace the example CIDR with the proxy’s exact network and configure it to pass the selected header. The Dockge port must not be directly reachable: only declared proxies may provide an identity. Every user authorized by the proxy receives administrator rights because Dockge Enhanced does not currently provide separate roles. Never exempt `/setup`, `/socket.io`, or `/api/*` from authentication; the proxy must forward WebSockets and protect the entire host.
 
 ---
 
@@ -273,6 +314,7 @@ This fork tracks upstream Dockge releases automatically via GitHub Actions:
 - **Daily** — checks for a new stable release
 - **If found** — merges upstream changes and opens a PR
 - **On merge** — rebuilds and publishes Docker images (`amd64` + `arm64`) to GHCR
+- **On authentication conflicts** — temporarily keeps the Enhanced version in the sync branch and explicitly lists files that require comparison before merging
 
 ---
 

--- a/backend/auth.test.ts
+++ b/backend/auth.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import { R } from "redbean-node";
+import {
+    authenticateHttpRequest,
+    getTrustedProxyIdentity,
+    initializeAuthentication,
+    isSetupCompleted,
+} from "./auth";
+import { Settings } from "./settings";
+
+process.env.DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS = "172.20.0.0/24,::1";
+process.env.DOCKGE_AUTH_PROXY_HEADER = "x-forwarded-user";
+
+function proxyRequest(remoteAddress: string, username?: string) {
+    return {
+        socket: { remoteAddress },
+        headers: username ? { "x-forwarded-user": username } : {},
+        query: {},
+    } as never;
+}
+
+test("trusted proxy accepts only configured networks and a valid identity", () => {
+    assert.equal(
+        getTrustedProxyIdentity(proxyRequest("::ffff:172.20.0.8", "alice")),
+        "alice",
+    );
+    assert.throws(
+        () => getTrustedProxyIdentity(proxyRequest("172.21.0.8", "alice")),
+        /non autorisé/,
+    );
+    assert.throws(
+        () => getTrustedProxyIdentity(proxyRequest("172.20.0.8")),
+        /Header d’identité manquant/,
+    );
+});
+
+test("disabled mode keeps the historical automatic identity", async () => {
+    process.env.DOCKGE_AUTH_MODE = "disabled";
+    const identity = await authenticateHttpRequest(
+        { headers: {},
+            query: {},
+            socket: {} } as never,
+        "unused",
+    );
+    assert.deepEqual(identity, {
+        mode: "disabled",
+        username: "auth-disabled",
+    });
+});
+
+test("local mode still accepts Dockge JWT and rejects missing tokens", async () => {
+    process.env.DOCKGE_AUTH_MODE = "local";
+    const token = jwt.sign({ username: "local-user" }, "test-secret");
+    const identity = await authenticateHttpRequest({
+        headers: { authorization: `Bearer ${token}` },
+        query: {},
+        socket: {},
+    } as never, "test-secret");
+    assert.equal(identity.username, "local-user");
+
+    await assert.rejects(
+        authenticateHttpRequest(
+            { headers: {},
+                query: {},
+                socket: {} } as never,
+            "test-secret",
+        ),
+        /Authentification requise/,
+    );
+});
+
+test("bootstrap only creates the first user and never changes it later", async () => {
+    interface TestUser {
+        id?: number;
+        username?: string;
+        password?: string;
+        active?: boolean;
+    }
+    const users: TestUser[] = [];
+    const settings = new Map<string, unknown>();
+    const knexDescriptor = Object.getOwnPropertyDescriptor(R, "knex");
+    const originalDispense = R.dispense;
+    const originalStore = R.store;
+    const originalFindOne = R.findOne;
+    const originalSettingsGet = Settings.get;
+    const originalSettingsSet = Settings.set;
+
+    try {
+        Object.defineProperty(R, "knex", {
+            configurable: true,
+            value: () => ({
+                count: () => ({
+                    first: async () => ({ count: users.length }),
+                }),
+            }),
+        });
+        R.dispense = (() => ({})) as unknown as typeof R.dispense;
+        R.store = (async (bean: TestUser) => {
+            if (bean.username && !bean.id) {
+                bean.id = users.length + 1;
+                bean.active = true;
+                users.push(bean);
+            }
+            return bean.id ?? 1;
+        }) as unknown as typeof R.store;
+        R.findOne = (async (_table: string, _query?: string, params?: unknown[]) =>
+            users.find((user) => user.username === params?.[0]) ?? null
+        ) as typeof R.findOne;
+        Settings.get = (async (key: string) => settings.get(key)) as typeof Settings.get;
+        Settings.set = (async (key: string, value: unknown) => {
+            settings.set(key, value);
+        }) as typeof Settings.set;
+
+        process.env.DOCKGE_AUTH_MODE = "local";
+        process.env.DOCKGE_BOOTSTRAP_USERNAME = "bootstrap-admin";
+        process.env.DOCKGE_BOOTSTRAP_PASSWORD = "StrongPass123!";
+        assert.equal(await initializeAuthentication(), false);
+        assert.equal(users.length, 1);
+        assert.equal(users[0].username, "bootstrap-admin");
+        assert.equal(await isSetupCompleted(), true);
+
+        const originalHash = users[0].password;
+        process.env.DOCKGE_BOOTSTRAP_PASSWORD = "AnotherStrong456!";
+        assert.equal(await initializeAuthentication(), false);
+        assert.equal(users.length, 1);
+        assert.equal(users[0].password, originalHash);
+    } finally {
+        if (knexDescriptor) {
+            Object.defineProperty(R, "knex", knexDescriptor);
+        }
+        R.dispense = originalDispense;
+        R.store = originalStore;
+        R.findOne = originalFindOne;
+        Settings.get = originalSettingsGet;
+        Settings.set = originalSettingsSet;
+        delete process.env.DOCKGE_BOOTSTRAP_USERNAME;
+        delete process.env.DOCKGE_BOOTSTRAP_PASSWORD;
+    }
+});

--- a/backend/auth.ts
+++ b/backend/auth.ts
@@ -1,0 +1,358 @@
+import { promises as fs } from "fs";
+import { IncomingMessage } from "http";
+import { BlockList, isIP } from "net";
+import { randomBytes } from "crypto";
+import { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { passwordStrength } from "check-password-strength";
+import { R } from "redbean-node";
+import { log } from "./log";
+import { User } from "./models/user";
+import { generatePasswordHash } from "./password-hash";
+import { Settings } from "./settings";
+import { JWTDecoded } from "./util-server";
+
+export type AuthMode = "local" | "disabled" | "trusted-proxy";
+
+export interface AuthIdentity {
+    mode: AuthMode;
+    username: string;
+}
+
+const SETUP_COMPLETED_KEY = "setupCompleted";
+const DEFAULT_PROXY_HEADER = "x-forwarded-user";
+
+class AuthenticationError extends Error {
+}
+
+interface TrustedProxyConfig {
+    blockList: BlockList;
+    header: string;
+}
+
+let trustedProxyConfig: TrustedProxyConfig | null = null;
+const proxyUserCache = new Map<string, { user: User; expiresAt: number }>();
+const proxyUserLookups = new Map<string, Promise<User>>();
+const PROXY_USER_CACHE_MS = 30_000;
+
+function generatedInternalPassword(): string {
+    return randomBytes(48).toString("base64url");
+}
+
+function configuredAuthMode(): AuthMode | null {
+    const raw = process.env.DOCKGE_AUTH_MODE?.trim().toLowerCase();
+    if (!raw) {
+        return null;
+    }
+    if (raw === "local" || raw === "disabled" || raw === "trusted-proxy") {
+        return raw;
+    }
+    throw new Error(
+        "DOCKGE_AUTH_MODE doit être local, disabled ou trusted-proxy",
+    );
+}
+
+export async function getAuthMode(): Promise<AuthMode> {
+    const configured = configuredAuthMode();
+    if (configured) {
+        return configured;
+    }
+    return await Settings.get("disableAuth") ? "disabled" : "local";
+}
+
+function normalizeRemoteAddress(value: string | undefined): {
+    address: string;
+    type: "ipv4" | "ipv6";
+} | null {
+    if (!value) {
+        return null;
+    }
+    let address = value.split("%")[0];
+    if (address.startsWith("::ffff:") && isIP(address.slice(7)) === 4) {
+        address = address.slice(7);
+    }
+    const version = isIP(address);
+    if (version === 4) {
+        return { address,
+            type: "ipv4" };
+    }
+    if (version === 6) {
+        return { address,
+            type: "ipv6" };
+    }
+    return null;
+}
+
+function buildTrustedProxyConfig(): TrustedProxyConfig {
+    const networks = process.env.DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS?.trim() ?? "";
+    const header = (
+        process.env.DOCKGE_AUTH_PROXY_HEADER?.trim().toLowerCase() ||
+        DEFAULT_PROXY_HEADER
+    );
+
+    if (!/^[a-z0-9-]+$/.test(header)) {
+        throw new Error("DOCKGE_AUTH_PROXY_HEADER contient un nom invalide");
+    }
+    if (!networks) {
+        throw new Error(
+            "DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS est requis en mode trusted-proxy",
+        );
+    }
+
+    const blockList = new BlockList();
+    for (const entry of networks.split(",").map((item) => item.trim()).filter(Boolean)) {
+        const [ address, prefixRaw ] = entry.split("/");
+        const normalized = normalizeRemoteAddress(address);
+        if (!normalized) {
+            throw new Error(`Réseau proxy invalide : ${entry}`);
+        }
+        if (prefixRaw === undefined) {
+            blockList.addAddress(normalized.address, normalized.type);
+            continue;
+        }
+        const prefix = Number(prefixRaw);
+        const maxPrefix = normalized.type === "ipv4" ? 32 : 128;
+        if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
+            throw new Error(`Préfixe CIDR proxy invalide : ${entry}`);
+        }
+        blockList.addSubnet(normalized.address, prefix, normalized.type);
+    }
+
+    return { blockList,
+        header };
+}
+
+export function validateTrustedProxyConfiguration(): void {
+    trustedProxyConfig = buildTrustedProxyConfig();
+}
+
+function proxyConfig(): TrustedProxyConfig {
+    if (!trustedProxyConfig) {
+        trustedProxyConfig = buildTrustedProxyConfig();
+    }
+    return trustedProxyConfig;
+}
+
+export function getTrustedProxyIdentity(request: IncomingMessage): string {
+    const config = proxyConfig();
+    const remote = normalizeRemoteAddress(request.socket.remoteAddress);
+    if (!remote || !config.blockList.check(remote.address, remote.type)) {
+        throw new AuthenticationError("Proxy d’authentification non autorisé");
+    }
+
+    const rawHeader = request.headers[config.header];
+    const username = (Array.isArray(rawHeader) ? rawHeader[0] : rawHeader)?.trim();
+    if (!username) {
+        throw new AuthenticationError(
+            `Header d’identité manquant : ${config.header}`,
+        );
+    }
+    if (username.length > 255 || /[\u0000-\u001f\u007f]/.test(username)) {
+        throw new AuthenticationError("Identité proxy invalide");
+    }
+    return username;
+}
+
+async function createUser(username: string, password: string): Promise<User> {
+    const user = R.dispense("user") as User;
+    user.username = username;
+    user.password = generatePasswordHash(password);
+    await R.store(user);
+    return user;
+}
+
+async function bootstrapUserIfConfigured(): Promise<User | null> {
+    const username = process.env.DOCKGE_BOOTSTRAP_USERNAME?.trim() ?? "";
+    const passwordFile = process.env.DOCKGE_BOOTSTRAP_PASSWORD_FILE?.trim() ?? "";
+    const passwordFromEnv = process.env.DOCKGE_BOOTSTRAP_PASSWORD;
+    const requested = Boolean(username || passwordFile || passwordFromEnv);
+    if (!requested) {
+        return null;
+    }
+    if (!username) {
+        throw new Error("DOCKGE_BOOTSTRAP_USERNAME est requis pour le bootstrap");
+    }
+
+    let password = passwordFromEnv ?? "";
+    if (passwordFile) {
+        password = (await fs.readFile(passwordFile, "utf8")).replace(/\r?\n$/, "");
+    }
+    if (!password) {
+        throw new Error(
+            "DOCKGE_BOOTSTRAP_PASSWORD ou DOCKGE_BOOTSTRAP_PASSWORD_FILE est requis",
+        );
+    }
+    if (passwordStrength(password).value === "Too weak") {
+        throw new Error("Le mot de passe de bootstrap est trop faible");
+    }
+
+    const user = await createUser(username, password);
+    await markSetupCompleted();
+    log.info("auth", `Compte administrateur initial créé : ${username}`);
+    return user;
+}
+
+export async function markSetupCompleted(): Promise<void> {
+    await Settings.set(SETUP_COMPLETED_KEY, true, "security");
+}
+
+export async function isSetupCompleted(): Promise<boolean> {
+    return Boolean(await Settings.get(SETUP_COMPLETED_KEY));
+}
+
+export async function initializeAuthentication(): Promise<boolean> {
+    const mode = await getAuthMode();
+    const userCount = Number(
+        (await R.knex("user").count("id as count").first()).count,
+    );
+    log.info("auth", `Mode d’authentification : ${mode}`);
+
+    if (userCount > 0) {
+        if (!await Settings.get(SETUP_COMPLETED_KEY)) {
+            await markSetupCompleted();
+        }
+        if (
+            process.env.DOCKGE_BOOTSTRAP_USERNAME ||
+            process.env.DOCKGE_BOOTSTRAP_PASSWORD ||
+            process.env.DOCKGE_BOOTSTRAP_PASSWORD_FILE
+        ) {
+            log.info("auth", "Bootstrap ignoré : un utilisateur existe déjà");
+        }
+        if (mode === "trusted-proxy") {
+            validateTrustedProxyConfiguration();
+        }
+        return false;
+    }
+
+    const bootstrapUser = await bootstrapUserIfConfigured();
+    if (bootstrapUser) {
+        return false;
+    }
+
+    if (mode === "trusted-proxy") {
+        validateTrustedProxyConfiguration();
+        return false;
+    }
+
+    if (mode === "disabled") {
+        await createUser("admin", generatedInternalPassword());
+        await markSetupCompleted();
+        log.info("auth", "Compte interne généré pour le mode disabled");
+        return false;
+    }
+
+    if (await Settings.get(SETUP_COMPLETED_KEY)) {
+        log.error(
+            "auth",
+            "Installation déjà initialisée mais aucun utilisateur actif. " +
+            "Utilisez le bootstrap pour créer un compte de récupération.",
+        );
+        return false;
+    }
+
+    log.info("server", "No user, need setup");
+    return true;
+}
+
+async function findOrCreateTrustedProxyUser(username: string): Promise<User> {
+    const existing = await R.findOne("user", " username = ? ", [ username ]) as User;
+    if (existing) {
+        if (!existing.active) {
+            throw new AuthenticationError("Utilisateur proxy désactivé");
+        }
+        return existing;
+    }
+
+    try {
+        const user = await createUser(username, generatedInternalPassword());
+        await markSetupCompleted();
+        log.info("auth", `Utilisateur proxy créé : ${username}`);
+        return user;
+    } catch (error) {
+        const user = await R.findOne("user", " username = ? AND active = 1 ", [
+            username,
+        ]) as User;
+        if (user) {
+            return user;
+        }
+        throw error;
+    }
+}
+
+export async function ensureTrustedProxyUser(username: string): Promise<User> {
+    const cached = proxyUserCache.get(username);
+    if (cached && cached.expiresAt > Date.now()) {
+        return cached.user;
+    }
+
+    const running = proxyUserLookups.get(username);
+    if (running) {
+        return running;
+    }
+
+    const lookup = findOrCreateTrustedProxyUser(username)
+        .then((user) => {
+            proxyUserCache.set(username, {
+                user,
+                expiresAt: Date.now() + PROXY_USER_CACHE_MS,
+            });
+            return user;
+        })
+        .finally(() => proxyUserLookups.delete(username));
+    proxyUserLookups.set(username, lookup);
+    return lookup;
+}
+
+export async function authenticateHttpRequest(
+    req: Request,
+    jwtSecret: string,
+): Promise<AuthIdentity> {
+    const mode = await getAuthMode();
+    if (mode === "disabled") {
+        return { mode,
+            username: "auth-disabled" };
+    }
+    if (mode === "trusted-proxy") {
+        const username = getTrustedProxyIdentity(req);
+        await ensureTrustedProxyUser(username);
+        return { mode,
+            username };
+    }
+
+    const authHeader = req.headers.authorization;
+    const token =
+        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
+        (typeof req.query.token === "string" ? req.query.token : undefined);
+    if (!token) {
+        throw new AuthenticationError("Authentification requise");
+    }
+
+    try {
+        const decoded = jwt.verify(token, jwtSecret) as JWTDecoded;
+        return { mode,
+            username: decoded.username };
+    } catch {
+        throw new AuthenticationError("Token invalide ou expiré");
+    }
+}
+
+export async function requireHttpAuth(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    jwtSecret: string,
+    onAuthenticated?: (identity: AuthIdentity) => void,
+): Promise<void> {
+    try {
+        const identity = await authenticateHttpRequest(req, jwtSecret);
+        onAuthenticated?.(identity);
+        next();
+    } catch (error) {
+        if (error instanceof AuthenticationError) {
+            res.status(401).json({ ok: false,
+                message: error.message });
+            return;
+        }
+        next(error);
+    }
+}

--- a/backend/dockge-server.ts
+++ b/backend/dockge-server.ts
@@ -51,6 +51,12 @@ import { AgentSocketHandler } from "./agent-socket-handler";
 import { AgentSocket } from "../common/agent-socket";
 import { ManageAgentSocketHandler } from "./socket-handlers/manage-agent-socket-handler";
 import { Terminal } from "./terminal";
+import {
+    ensureTrustedProxyUser,
+    getAuthMode,
+    getTrustedProxyIdentity,
+    initializeAuthentication,
+} from "./auth";
 
 export class DockgeServer {
     app : Express;
@@ -293,11 +299,6 @@ export class DockgeServer {
 
             this.sendInfo(dockgeSocket, true);
 
-            if (this.needSetup) {
-                log.info("server", "Redirect to setup page");
-                dockgeSocket.emit("setup");
-            }
-
             // Create socket handlers (original, no agent support)
             for (const socketHandler of this.socketHandlerList) {
                 socketHandler.create(dockgeSocket, this);
@@ -318,10 +319,26 @@ export class DockgeServer {
             // Better do anything after added all socket handlers here
             // ***************************
 
-            log.debug("auth", "check auto login");
-            if (await Settings.get("disableAuth")) {
+            log.debug("auth", "check authentication mode");
+            const authMode = await getAuthMode();
+            if (authMode === "trusted-proxy") {
+                try {
+                    const username = getTrustedProxyIdentity(socket.request);
+                    const user = await ensureTrustedProxyUser(username);
+                    this.needSetup = false;
+                    await this.afterLogin(dockgeSocket, user);
+                    dockgeSocket.emit("autoLogin", username);
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    log.warn("auth", `Trusted proxy authentication failed: ${message}`);
+                    dockgeSocket.emit("authProxyError", message);
+                }
+            } else if (this.needSetup) {
+                log.info("server", "Redirect to setup page");
+                dockgeSocket.emit("setup");
+            } else if (authMode === "disabled") {
                 log.info("auth", "Disabled Auth: auto login to admin");
-                this.afterLogin(dockgeSocket, await R.findOne("user") as User);
+                await this.afterLogin(dockgeSocket, await R.findOne("user") as User);
                 dockgeSocket.emit("autoLogin");
             } else {
                 log.debug("auth", "need auth");
@@ -396,14 +413,12 @@ export class DockgeServer {
 
         this.jwtSecret = jwtSecretBean.value;
 
-        const userCount = (await R.knex("user").count("id as count").first()).count;
-
-        log.debug("server", "User count: " + userCount);
-
-        // If there is no record in user table, it is a new Dockge instance, need to setup
-        if (userCount == 0) {
-            log.info("server", "No user, need setup");
-            this.needSetup = true;
+        try {
+            this.needSetup = await initializeAuthentication();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            log.error("auth", `Invalid authentication configuration: ${message}`);
+            process.exit(1);
         }
 
         // Listen
@@ -475,6 +490,8 @@ export class DockgeServer {
             latestVersion: latestVersionProperty,
             isContainer,
             primaryHostname: await Settings.get("primaryHostname"),
+            authMode: await getAuthMode(),
+            authModeManaged: Boolean(process.env.DOCKGE_AUTH_MODE),
             turnstileEnabled: !!generalSettings.turnstileEnabled && !!generalSettings.turnstileSiteKey,
             turnstileSiteKey: generalSettings.turnstileEnabled ? (generalSettings.turnstileSiteKey ?? "") : "",
             //serverTimezone: await this.getTimezone(),

--- a/backend/routers/audit-log-router.ts
+++ b/backend/routers/audit-log-router.ts
@@ -1,41 +1,8 @@
 import express, { Express, Router as ExpressRouter, Request, Response, NextFunction } from "express";
-import jwt from "jsonwebtoken";
 import { DockgeServer } from "../dockge-server";
 import { Router } from "../router";
-import { Settings } from "../settings";
-import { JWTDecoded } from "../util-server";
 import { AuditLogger, setAuditUser } from "../audit-log";
-
-async function requireAuth(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-    jwtSecret: string
-): Promise<void> {
-    if (await Settings.get("disableAuth")) {
-        setAuditUser(req, { username: "auth-disabled" });
-        next();
-        return;
-    }
-
-    const authHeader = req.headers["authorization"];
-    const token =
-        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
-        (typeof req.query.token === "string" ? req.query.token : undefined);
-
-    if (!token) {
-        res.status(401).json({ ok: false, message: "Authentification requise" });
-        return;
-    }
-
-    try {
-        const decoded = jwt.verify(token, jwtSecret) as JWTDecoded;
-        setAuditUser(req, { username: decoded.username });
-        next();
-    } catch {
-        res.status(401).json({ ok: false, message: "Token invalide ou expiré" });
-    }
-}
+import { requireHttpAuth } from "../auth";
 
 export class AuditLogRouter extends Router {
     create(app: Express, server: DockgeServer): ExpressRouter {
@@ -44,7 +11,9 @@ export class AuditLogRouter extends Router {
 
         router.use(express.json());
         router.use((req: Request, res: Response, next: NextFunction) => {
-            requireAuth(req, res, next, server.jwtSecret).catch(next);
+            requireHttpAuth(req, res, next, server.jwtSecret, (identity) => {
+                setAuditUser(req, { username: identity.username });
+            }).catch(next);
         });
 
         router.get("/entries", async (req: Request, res: Response) => {

--- a/backend/routers/docker-resources-router.ts
+++ b/backend/routers/docker-resources-router.ts
@@ -13,45 +13,13 @@
 import { DockgeServer } from "../dockge-server";
 import { Router } from "../router";
 import express, { Express, Router as ExpressRouter, Request, Response, NextFunction } from "express";
-import { Settings } from "../settings";
-import jwt from "jsonwebtoken";
-import { JWTDecoded } from "../util-server";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { AutoPruneManager } from "../watchers/auto-prune-manager";
 import { AuditLogger, setAuditUser } from "../audit-log";
+import { requireHttpAuth } from "../auth";
 
 const execAsync = promisify(exec);
-
-// ─── Auth middleware (identique à WatcherRouter) ──────────────────
-
-async function requireAuth(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-    jwtSecret: string
-): Promise<void> {
-    if (await Settings.get("disableAuth")) {
-        setAuditUser(req, { username: "auth-disabled" });
-        next();
-        return;
-    }
-    const authHeader = req.headers["authorization"];
-    const token =
-        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
-        (typeof req.query.token === "string" ? req.query.token : undefined);
-    if (!token) {
-        res.status(401).json({ ok: false, message: "Authentification requise" });
-        return;
-    }
-    try {
-        const decoded = jwt.verify(token, jwtSecret) as JWTDecoded;
-        setAuditUser(req, { username: decoded.username });
-        next();
-    } catch {
-        res.status(401).json({ ok: false, message: "Token invalide ou expiré" });
-    }
-}
 
 // ─── Types internes ───────────────────────────────────────────────
 
@@ -172,7 +140,9 @@ export class DockerResourcesRouter extends Router {
         const router = express.Router();
         router.use(express.json());
         const auth = (req: Request, res: Response, next: NextFunction) =>
-            requireAuth(req, res, next, server.jwtSecret);
+            requireHttpAuth(req, res, next, server.jwtSecret, (identity) => {
+                setAuditUser(req, { username: identity.username });
+            }).catch(next);
 
         // ── Images ────────────────────────────────────────────────
 

--- a/backend/routers/monitoring-router.ts
+++ b/backend/routers/monitoring-router.ts
@@ -11,39 +11,7 @@ import { BackupManager } from "../watchers/backup-manager";
 import { TrivyScanner } from "../watchers/trivy-scanner";
 import { imageStatusStore } from "../watchers/image-watcher";
 import { Settings } from "../settings";
-import jwt from "jsonwebtoken";
-import { JWTDecoded } from "../util-server";
-
-// ─── Auth middleware (même pattern exact que watcher-router) ──────
-
-async function requireAuth(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-    jwtSecret: string
-): Promise<void> {
-    if (await Settings.get("disableAuth")) {
-        next();
-        return;
-    }
-
-    const authHeader = req.headers["authorization"];
-    const token =
-        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
-        (typeof req.query.token === "string" ? req.query.token : undefined);
-
-    if (!token) {
-        res.status(401).json({ ok: false, message: "Authentification requise" });
-        return;
-    }
-
-    try {
-        jwt.verify(token, jwtSecret) as JWTDecoded;
-        next();
-    } catch {
-        res.status(401).json({ ok: false, message: "Token invalide ou expiré" });
-    }
-}
+import { requireHttpAuth } from "../auth";
 
 // ─── Router ───────────────────────────────────────────────────────
 
@@ -55,7 +23,7 @@ export class MonitoringRouter extends Router {
 
         // Auth middleware on all routes — uses server.jwtSecret like WatcherRouter
         router.use((req: Request, res: Response, next: NextFunction) => {
-            requireAuth(req, res, next, server.jwtSecret).catch(next);
+            requireHttpAuth(req, res, next, server.jwtSecret).catch(next);
         });
 
         // ── Settings ──────────────────────────────────────────────

--- a/backend/routers/system-stats-router.ts
+++ b/backend/routers/system-stats-router.ts
@@ -17,8 +17,7 @@ import express, { Express, Router as ExpressRouter, Request, Response, NextFunct
 import { DockgeServer } from "../dockge-server";
 import { Settings } from "../settings";
 import { isLowPower, intervals } from "../low-power";
-import jwt from "jsonwebtoken";
-import { JWTDecoded } from "../util-server";
+import { requireHttpAuth } from "../auth";
 
 const execAsync = promisify(exec);
 
@@ -64,33 +63,6 @@ async function sampleCpuIfDue(): Promise<void> {
     }
     lastCpuTimes   = current;
     lastCpuSampleAt = Date.now();
-}
-
-// ─── Auth (même pattern que les autres routers Enhanced) ─────────
-
-async function requireAuth(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-    jwtSecret: string
-): Promise<void> {
-    if (await Settings.get("disableAuth")) { next(); return; }
-
-    const authHeader = req.headers["authorization"];
-    const token =
-        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
-        (typeof req.query["token"] === "string" ? req.query["token"] : undefined);
-
-    if (!token) {
-        res.status(401).json({ ok: false, message: "Authentification requise" });
-        return;
-    }
-    try {
-        jwt.verify(token, jwtSecret) as JWTDecoded;
-        next();
-    } catch {
-        res.status(401).json({ ok: false, message: "Token invalide ou expiré" });
-    }
 }
 
 // ─── Stack stats collector ───────────────────────────────────────
@@ -231,7 +203,7 @@ export class SystemStatsRouter extends Router {
         // aucun poll → aucun `docker stats` / `df` / lecture /proc/stat.
 
         const auth = (req: Request, res: Response, next: NextFunction) =>
-            requireAuth(req, res, next, server.jwtSecret);
+            requireHttpAuth(req, res, next, server.jwtSecret);
 
         router.get("/stats", auth, async (_req: Request, res: Response) => {
             try {

--- a/backend/routers/watcher-router.ts
+++ b/backend/routers/watcher-router.ts
@@ -17,52 +17,10 @@ import { BackupManager } from "../watchers/backup-manager";
 import { KulaManager } from "../watchers/kula-manager";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { Settings } from "../settings";
-import jwt from "jsonwebtoken";
-import { JWTDecoded } from "../util-server";
 import { AuditLogger, setAuditUser } from "../audit-log";
 import { normalizeRegistryHost } from "../registry-auth";
 import { StackScheduler } from "../watchers/stack-scheduler";
-
-// ─── Middleware d'authentification JWT ───────────────────────────
-//
-// Accepte le token dans :
-//   - Header Authorization: Bearer <token>
-//   - Query param   ?token=<token>  (pratique pour les appels fetch frontend)
-//
-// Respecte le setting "disableAuth" de Dockge (cohérent avec le reste de l'app).
-
-async function requireAuth(
-    req: Request,
-    res: Response,
-    next: NextFunction,
-    jwtSecret: string
-): Promise<void> {
-    // Si l'auth est globalement désactivée dans Dockge, on laisse passer
-    if (await Settings.get("disableAuth")) {
-        setAuditUser(req, { username: "auth-disabled" });
-        next();
-        return;
-    }
-
-    const authHeader = req.headers["authorization"];
-    const token =
-        (authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined) ??
-        (typeof req.query.token === "string" ? req.query.token : undefined);
-
-    if (!token) {
-        res.status(401).json({ ok: false, message: "Authentification requise" });
-        return;
-    }
-
-    try {
-        const decoded = jwt.verify(token, jwtSecret) as JWTDecoded;
-        setAuditUser(req, { username: decoded.username });
-        next();
-    } catch {
-        res.status(401).json({ ok: false, message: "Token invalide ou expiré" });
-    }
-}
+import { requireHttpAuth } from "../auth";
 
 async function auditWatcherAction(
     req: Request,
@@ -93,7 +51,9 @@ export class WatcherRouter extends Router {
 
         // Middleware auth sur toutes les routes de ce router
         router.use((req: Request, res: Response, next: NextFunction) => {
-            requireAuth(req, res, next, server.jwtSecret).catch(next);
+            requireHttpAuth(req, res, next, server.jwtSecret, (identity) => {
+                setAuditUser(req, { username: identity.username });
+            }).catch(next);
         });
 
         // ════════════════════════════════════════════════════════════════

--- a/backend/socket-handlers/main-socket-handler.ts
+++ b/backend/socket-handlers/main-socket-handler.ts
@@ -21,6 +21,7 @@ import { Settings } from "../settings";
 import fs, { promises as fsAsync } from "fs";
 import path from "path";
 import axios from "axios";
+import { getAuthMode, isSetupCompleted, markSetupCompleted } from "../auth";
 
 /**
  * Vérifie un token Cloudflare Turnstile côté serveur via l'API siteverify.
@@ -62,7 +63,15 @@ export class MainSocketHandler extends SocketHandler {
 
         // Setup
         socket.on("setup", async (username, password, callback) => {
+            let setupClaimed = false;
             try {
+                if (
+                    await getAuthMode() !== "local" ||
+                    !server.needSetup ||
+                    await isSetupCompleted()
+                ) {
+                    throw new Error("Dockge has already been initialized.");
+                }
                 if (passwordStrength(password).value === "Too weak") {
                     throw new Error("Password is too weak. It should contain alphabetic and numeric characters. It must be at least 6 characters in length.");
                 }
@@ -71,12 +80,14 @@ export class MainSocketHandler extends SocketHandler {
                     throw new Error("Dockge has been initialized. If you want to run setup again, please delete the database.");
                 }
 
+                server.needSetup = false;
+                setupClaimed = true;
+
                 const user = R.dispense("user");
                 user.username = username;
                 user.password = generatePasswordHash(password);
                 await R.store(user);
-
-                server.needSetup = false;
+                await markSetupCompleted();
 
                 callback({
                     ok: true,
@@ -85,6 +96,13 @@ export class MainSocketHandler extends SocketHandler {
                 });
 
             } catch (e) {
+                if (
+                    setupClaimed &&
+                    await getAuthMode().catch(() => "local") === "local" &&
+                    Number((await R.knex("user").count("id as count").first()).count) === 0
+                ) {
+                    server.needSetup = true;
+                }
                 if (e instanceof Error) {
                     callback({
                         ok: false,
@@ -94,6 +112,10 @@ export class MainSocketHandler extends SocketHandler {
             }
         });
 
+        socket.on("needSetup", (callback) => {
+            if (typeof callback === "function") callback(server.needSetup);
+        });
+
         // Login by token
         socket.on("loginByToken", async (token, callback) => {
             const clientIP = await server.getClientIP(socket);
@@ -101,6 +123,9 @@ export class MainSocketHandler extends SocketHandler {
             log.info("auth", `Login by token. IP=${clientIP}`);
 
             try {
+                if (await getAuthMode() !== "local") {
+                    throw new Error("Local authentication is disabled.");
+                }
                 const decoded = jwt.verify(token, server.jwtSecret) as JWTDecoded;
 
                 log.info("auth", "Username from JWT: " + decoded.username);
@@ -164,6 +189,14 @@ export class MainSocketHandler extends SocketHandler {
             }
 
             if (!data) {
+                return;
+            }
+
+            if (await getAuthMode() !== "local") {
+                callback({
+                    ok: false,
+                    msg: "Local authentication is disabled.",
+                });
                 return;
             }
 
@@ -321,8 +354,12 @@ export class MainSocketHandler extends SocketHandler {
                 // Disabled Auth + Want to Enable Auth => No Check
                 // Enabled Auth + Want to Disable Auth => Check!!
                 // Enabled Auth + Want to Enable Auth => No Check
-                const currentDisabledAuth = await Settings.get("disableAuth");
-                if (!currentDisabledAuth && data.disableAuth) {
+                const currentAuthMode = await getAuthMode();
+                if (
+                    !process.env.DOCKGE_AUTH_MODE &&
+                    currentAuthMode === "local" &&
+                    data.disableAuth
+                ) {
                     await doubleCheckPassword(socket, currentPassword);
                 }
                 // Handle global.env

--- a/frontend/src/components/settings/Security.vue
+++ b/frontend/src/components/settings/Security.vue
@@ -1,11 +1,15 @@
 <template>
     <div>
         <div v-if="settingsLoaded" class="my-4">
+            <div v-if="authModeManaged" class="alert alert-info">
+                {{ $t("authModeManaged", { mode: authMode }) }}
+            </div>
+
             <!-- Change Password -->
-            <template v-if="!settings.disableAuth">
+            <template v-if="authMode === 'local'">
                 <p>
                     {{ $t("Current User") }}: <strong>{{ $root.username }}</strong>
-                    <button v-if="! settings.disableAuth" id="logout-btn" class="btn btn-danger ms-4 me-2 mb-2" @click="$root.logout">{{ $t("Logout") }}</button>
+                    <button id="logout-btn" class="btn btn-danger ms-4 me-2 mb-2" @click="$root.logout">{{ $t("Logout") }}</button>
                 </p>
 
                 <h5 class="my-4 settings-subheading">{{ $t("Change Password") }}</h5>
@@ -65,7 +69,7 @@
             </template>
 
             <!-- TODO: Hidden for now -->
-            <div v-if="! settings.disableAuth && false" class="mt-5 mb-3">
+            <div v-if="authMode === 'local' && false" class="mt-5 mb-3">
                 <h5 class="my-4 settings-subheading">
                     {{ $t("Two Factor Authentication") }}
                 </h5>
@@ -81,7 +85,7 @@
             </div>
 
             <!-- Cloudflare Turnstile -->
-            <div v-if="! settings.disableAuth" class="my-4">
+            <div v-if="authMode === 'local'" class="my-4">
                 <h5 class="my-4 settings-subheading">{{ $t("Cloudflare Turnstile") }}</h5>
                 <div class="form-text mb-3">{{ $t("turnstileHint") }}</div>
 
@@ -104,7 +108,7 @@
                 <button class="btn btn-primary" type="button" @click="saveTurnstile">{{ $t("Save") }}</button>
             </div>
 
-            <div class="my-4">
+            <div v-if="!authModeManaged" class="my-4">
                 <!-- Advanced -->
                 <h5 class="my-4 settings-subheading">{{ $t("Advanced") }}</h5>
 
@@ -172,6 +176,12 @@ export default {
         },
         settingsLoaded() {
             return this.$parent.$parent.$parent.settingsLoaded;
+        },
+        authMode() {
+            return this.$root.info.authMode || (this.settings.disableAuth ? "disabled" : "local");
+        },
+        authModeManaged() {
+            return this.$root.info.authModeManaged === true;
         }
     },
 

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -110,6 +110,7 @@
     "Please use this option carefully!": "Please use this option carefully!",
     "Enable Auth": "Enable Auth",
     "Disable Auth": "Disable Auth",
+    "authModeManaged": "Authentication mode “{mode}” is managed by environment variables. Incompatible local controls are disabled.",
     "I understand, please disable": "I understand, please disable",
     "Leave": "Leave",
     "Frontend Version": "Frontend Version",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -108,6 +108,7 @@
     "Please use this option carefully!": "Veuillez utiliser cette option avec précaution !",
     "Enable Auth": "Activer l'Authentification",
     "Disable Auth": "Désactiver l'Authentification",
+    "authModeManaged": "Le mode d’authentification « {mode} » est géré par les variables d’environnement. Les contrôles locaux incompatibles sont désactivés.",
     "I understand, please disable": "Je comprends, veuillez désactiver",
     "Leave": "Quitter",
     "Frontend Version": "Version Frontend",

--- a/frontend/src/mixins/socket.ts
+++ b/frontend/src/mixins/socket.ts
@@ -222,12 +222,20 @@ export default defineComponent({
                 this.info = info;
             });
 
-            socket.on("autoLogin", () => {
+            socket.on("autoLogin", (username?: string) => {
                 this.loggedIn = true;
                 this.storage().token = "autoLogin";
                 this.socketIO.token = "autoLogin";
+                if (username) this.username = username;
                 this.allowLoginDialog = false;
                 this.afterLogin();
+            });
+
+            socket.on("authProxyError", (message: string) => {
+                this.loggedIn = false;
+                this.allowLoginDialog = false;
+                this.socketIO.connectionErrorMsg = message;
+                this.toastError(message);
             });
 
             socket.on("setup", () => {


### PR DESCRIPTION
## Résumé

- conserve le comportement historique sans variable obligatoire ni modification du Compose pour les installations existantes
- ajoute les modes explicites `local`, `disabled` et `trusted-proxy`
- accepte une identité OAuth2 Proxy/ForwardAuth uniquement depuis une adresse ou un CIDR autorisé
- applique la même authentification aux API REST et à Socket.IO, sans ouvrir `/setup`, `/socket.io` ou `/api/*`
- provisionne automatiquement les identités proxy et les conserve dans l’audit
- ajoute un bootstrap non interactif du premier administrateur par variable ou fichier secret, sans jamais modifier un compte existant
- verrouille durablement le setup après initialisation et rétablit le contrôle `needSetup` côté interface
- adapte la page Sécurité lorsque le mode est géré par l’environnement
- centralise l’authentification des routes Enhanced

## Compatibilité

Sans `DOCKGE_AUTH_MODE` ni variables de bootstrap, le login local, la 2FA, `disableAuth`, les comptes et la base existante fonctionnent comme auparavant. Aucun nouveau `compose.yaml` ou `.env` n’est requis.

## Synchronisation upstream

- conserve le workflow quotidien de synchronisation Dockge
- détecte l’intégration réelle du tag dans `main` au lieu de marquer le tag avant le merge de la PR
- signale explicitement les conflits sur les fichiers d’authentification pour revue manuelle

## Documentation

Les README français et anglais documentent le setup interactif, le bootstrap par secret, les variables optionnelles du mode proxy, le CIDR de confiance et les précautions de reverse proxy.

## Validation

- `npx tsx --test backend/auth.test.ts` : 4 tests réussis
- `npm run check-ts`
- `npm run build:frontend`
- validation JSON des traductions
- validation YAML des workflows
- contrôle UTF-8 des README
- `git diff --check`
