### PR TITLE
Corrige recherche logs, volumes et liens de ports

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -23,7 +23,7 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 
 ## Fonctionnalités
 
-🆕 **Tailles des volumes montés par conteneur** — Chaque page de stack regroupe les volumes montés par conteneur, avec le service associé, le point de montage, le calcul de taille à la demande et un accès direct au navigateur **Fichiers** existant pour chaque mount.
+🆕 **Tailles des volumes montés dans les cartes conteneurs** — Chaque page de stack affiche les volumes montés directement dans l'encart de chaque conteneur, avec point de montage, calcul de taille à la demande et accès direct au navigateur **Fichiers** existant pour chaque mount.
 
 🆕 **Logs de stack avec période et recherche** — Le terminal de logs des pages compose peut charger les dernières lignes ou une fenêtre `24 h`, `3 jours`, `7 jours` ou `14 jours` via `docker compose logs --since`, tout en conservant le filtre par service et l'option d'horodatage. Une recherche intégrée permet de naviguer entre les occurrences dans le scrollback affiché.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 
 ## Features
 
-🆕 **Mounted volume sizes per container** — Each stack page now groups mounted volumes by container, with the linked service, mount point, on-demand size calculation and direct access to the existing **Files** browser for each mount.
+🆕 **Mounted volume sizes inside container cards** — Each stack page now shows mounted volumes directly inside each container card, with mount point, on-demand size calculation and direct access to the existing **Files** browser for each mount.
 
 🆕 **Stack logs with range and search** — The compose-page log terminal can load the latest lines or a `24 h`, `3 days`, `7 days` or `14 days` window through `docker compose logs --since`, while keeping the service filter and timestamp toggle. Built-in search lets you jump between matches in the displayed scrollback.
 

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -62,6 +62,38 @@
                         {{ relativeTime(startedAt) }}
                     </span>
                 </div>
+                <div v-if="!isEditMode && (volumeLoading || volumeUsage.length > 0)" class="container-volumes mt-2">
+                    <div class="container-volumes-title">
+                        <span>
+                            <font-awesome-icon icon="hard-drive" class="me-1" />{{ $t("stackVolumeUsage") }}
+                            <span v-if="volumeLoading" class="spinner-border spinner-border-sm ms-1" />
+                        </span>
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-link container-volume-refresh"
+                            :title="$t('refresh')"
+                            :disabled="volumeLoading"
+                            @click="$emit('refresh-volume-usage')"
+                        >
+                            <font-awesome-icon icon="sync" />
+                        </button>
+                    </div>
+                    <button
+                        v-for="volume in volumeUsage"
+                        :key="volume.source + volume.destination"
+                        type="button"
+                        class="container-volume-row"
+                        :title="volume.source"
+                        @click="openVolumeBrowser(volume.destination)"
+                    >
+                        <code>{{ volume.destination }}</code>
+                        <span class="container-volume-name">{{ volume.type === "volume" ? (volume.name || volume.source) : volume.source }}</span>
+                        <strong>
+                            <template v-if="volume.size !== null">{{ formatBytes(volume.size) }}</template>
+                            <template v-else>{{ $t("notAvailableShort") }}</template>
+                        </strong>
+                    </button>
+                </div>
             </div>
             <div class="col-5">
                 <div class="function">
@@ -242,10 +274,19 @@ export default defineComponent({
         autoUpdateSaving: {
             type: Boolean,
             default: false
+        },
+        volumeUsage: {
+            type: Array,
+            default: () => []
+        },
+        volumeLoading: {
+            type: Boolean,
+            default: false
         }
     },
     emits: [
         "auto-update-change",
+        "refresh-volume-usage",
     ],
     data() {
         return {
@@ -385,18 +426,20 @@ export default defineComponent({
             });
         },
         parsePort(port) {
-            if (this.stack.endpoint) {
-                return parseDockerPort(port, this.stack.primaryHostname);
-            } else {
-                let hostname = this.$root.info.primaryHostname || location.hostname;
-                return parseDockerPort(port, hostname);
-            }
+            return parseDockerPort(port, location.hostname);
         },
         remove() {
             delete this.jsonObject.services[this.name];
         },
-        openVolumeBrowser() {
-            this.$refs.volumeBrowser?.open();
+        openVolumeBrowser(destination = "") {
+            this.$refs.volumeBrowser?.open(destination);
+        },
+        formatBytes(bytes) {
+            if (bytes >= 1024 ** 4) return (bytes / 1024 ** 4).toFixed(1) + " TB";
+            if (bytes >= 1024 ** 3) return (bytes / 1024 ** 3).toFixed(1) + " GB";
+            if (bytes >= 1024 ** 2) return Math.round(bytes / 1024 ** 2) + " MB";
+            if (bytes >= 1024) return Math.round(bytes / 1024) + " KB";
+            return bytes + " B";
         },
         relativeTime(iso) {
             if (!iso) return null;
@@ -497,6 +540,61 @@ export default defineComponent({
         width: 100%;
         align-items: center;
         justify-content: end;
+    }
+
+    .container-volumes {
+        display: grid;
+        gap: 4px;
+        max-width: 100%;
+    }
+
+    .container-volumes-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        color: #6b7280;
+        font-size: 0.72rem;
+        font-weight: 600;
+
+        .dark & {
+            color: $dark-font-color;
+        }
+    }
+
+    .container-volume-refresh {
+        padding: 0;
+        line-height: 1;
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .container-volume-row {
+        display: grid;
+        grid-template-columns: minmax(72px, auto) minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        max-width: 100%;
+        padding: 4px 8px;
+        border: 1px solid rgba(127, 127, 127, 0.14);
+        border-radius: 6px;
+        background: rgba(127, 127, 127, 0.05);
+        color: inherit;
+        text-align: left;
+        font-size: 0.75rem;
+
+        &:hover {
+            border-color: rgba(13, 110, 253, 0.35);
+            background: rgba(13, 110, 253, 0.08);
+        }
+
+        code,
+        .container-volume-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     }
 }
 

--- a/frontend/src/components/Terminal.vue
+++ b/frontend/src/components/Terminal.vue
@@ -70,6 +70,8 @@ export default {
             first: true,
             terminalInputBuffer: "",
             cursorPosition: 0,
+            lastSearchTerm: "",
+            lastSearchLine: -1,
         };
     },
     created() {
@@ -288,6 +290,8 @@ export default {
         search(term, previous = false) {
             if (!term) {
                 this.terminalSearchAddOn.clearDecorations();
+                this.lastSearchTerm = "";
+                this.lastSearchLine = -1;
                 return false;
             }
             const options = {
@@ -301,9 +305,42 @@ export default {
                     activeMatchColorOverviewRuler: "#0d6efd",
                 },
             };
-            return previous
+            const addonFound = previous
                 ? this.terminalSearchAddOn.findPrevious(term, options)
                 : this.terminalSearchAddOn.findNext(term, options);
+            const foundLine = this.findInBuffer(term, previous);
+            if (foundLine >= 0) {
+                this.terminal.scrollToLine(foundLine);
+            }
+            return addonFound || foundLine >= 0;
+        },
+
+        findInBuffer(term, previous = false) {
+            const needle = term.toLowerCase();
+            const buffer = this.terminal.buffer.active;
+            const total = buffer.length;
+            if (!needle || total <= 0) {
+                return -1;
+            }
+
+            let start;
+            if (this.lastSearchTerm === needle && this.lastSearchLine >= 0) {
+                start = this.lastSearchLine + (previous ? -1 : 1);
+            } else {
+                start = previous ? total - 1 : 0;
+            }
+
+            const step = previous ? -1 : 1;
+            for (let offset = 0; offset < total; offset++) {
+                const lineIndex = (start + offset * step + total) % total;
+                const line = buffer.getLine(lineIndex)?.translateToString(true).toLowerCase() ?? "";
+                if (line.includes(needle)) {
+                    this.lastSearchTerm = needle;
+                    this.lastSearchLine = lineIndex;
+                    return lineIndex;
+                }
+            }
+            return -1;
         },
         /**
          * Handles the resize event of the terminal component.

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -183,6 +183,7 @@
     "logSince7d": "7 days",
     "logSince14d": "14 days",
     "logSearchPlaceholder": "Search logs",
+    "logSearchNoMatch": "No match in loaded logs.",
     "logSearchPrevious": "Previous match",
     "logSearchNext": "Next match",
     "stackVolumeUsage": "Mounted volumes",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -179,6 +179,7 @@
     "logSince7d": "7 jours",
     "logSince14d": "14 jours",
     "logSearchPlaceholder": "Rechercher dans les logs",
+    "logSearchNoMatch": "Aucune occurrence dans les logs chargés.",
     "logSearchPrevious": "Occurrence précédente",
     "logSearchNext": "Occurrence suivante",
     "stackVolumeUsage": "Volumes montés",

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -184,7 +184,10 @@
                                 :image-update="imageUpdateForService(name)"
                                 :auto-update="autoUpdateForService(name)"
                                 :auto-update-saving="autoUpdateSaving[name] === true"
+                                :volume-usage="volumeUsageForService(name)"
+                                :volume-loading="volumeUsageLoading"
                                 @auto-update-change="setServiceAutoUpdate(name, $event)"
+                                @refresh-volume-usage="loadVolumeUsage"
                             />
                         </div>
                     </div>
@@ -278,57 +281,6 @@
                         ></Terminal>
                     </div>
 
-                    <div v-show="!isEditMode" class="mb-3">
-                        <div class="d-flex align-items-center justify-content-between mb-2">
-                            <h4 class="mb-0">{{ $t("stackVolumeUsage") }}</h4>
-                            <button class="btn btn-sm btn-normal" :disabled="volumeUsageLoading" @click="loadVolumeUsage">
-                                <span v-if="volumeUsageLoading" class="spinner-border spinner-border-sm me-1" />
-                                <font-awesome-icon v-else icon="sync" class="me-1" />{{ $t("refresh") }}
-                            </button>
-                        </div>
-                        <div class="shadow-box stack-volume-box">
-                            <div v-if="volumeUsage.length === 0 && !volumeUsageLoading" class="text-muted small">
-                                {{ $t("stackVolumeUsageEmpty") }}
-                            </div>
-                            <div v-for="container in volumeUsage" :key="container.id || container.name" class="stack-volume-container">
-                                <div class="stack-volume-container-header">
-                                    <div>
-                                        <strong>{{ container.service || container.name }}</strong>
-                                        <span class="text-muted small ms-2">{{ container.name }}</span>
-                                    </div>
-                                    <span class="badge bg-secondary">{{ container.state }}</span>
-                                </div>
-                                <div
-                                    v-for="volume in container.mounts"
-                                    :key="container.name + volume.source + volume.destination"
-                                    class="stack-volume-row"
-                                >
-                                    <div class="stack-volume-main">
-                                        <code>{{ volume.destination }}</code>
-                                        <span class="text-muted small text-truncate" :title="volume.source">
-                                            {{ volume.type === "volume" ? (volume.name || volume.source) : volume.source }}
-                                        </span>
-                                    </div>
-                                    <div class="stack-volume-actions">
-                                        <span class="stack-volume-size" :title="volume.error || volume.source">
-                                            <span v-if="volume.size !== null">{{ formatBytes(volume.size) }}</span>
-                                            <span v-else class="text-muted">{{ $t("notAvailableShort") }}</span>
-                                        </span>
-                                        <button class="btn btn-sm btn-normal" :title="$t('volumeBrowserTitle')" @click="openVolumeBrowser(container.service, volume.destination)">
-                                            <font-awesome-icon icon="folder-open" class="me-1" />{{ $t("files") }}
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <VolumeBrowser
-                            v-if="volumeBrowserService"
-                            ref="volumeBrowser"
-                            :stack-name="stack.name"
-                            :service-name="volumeBrowserService"
-                            :endpoint="endpoint"
-                        />
-                    </div>
                 </div>
                 <div class="col-lg-6">
                     <div class="editor-header mb-3">
@@ -496,7 +448,6 @@ import { ref } from "vue";
 import { setLowPower, POLL, isVisible } from "../composables/useLowPower";
 import { useImageStatus } from "../composables/useImageStatus";
 import StackScheduleEditor from "../components/StackScheduleEditor.vue";
-import VolumeBrowser from "../components/VolumeBrowser.vue";
 
 const template = `
 services:
@@ -519,7 +470,6 @@ export default {
         CodeMirror,
         BModal,
         StackScheduleEditor,
-        VolumeBrowser,
     },
     beforeRouteUpdate(to, from, next) {
         this.containersExpanded = true;
@@ -608,7 +558,6 @@ export default {
             logSearch: "",
             volumeUsage: [],
             volumeUsageLoading: false,
-            volumeBrowserService: "",
             containersExpanded: true,
             autoUpdateSaving: {},
         };
@@ -965,7 +914,10 @@ export default {
         },
 
         searchLogs(previous) {
-            this.$refs.combinedTerminal?.search(this.logSearch, previous);
+            const found = this.$refs.combinedTerminal?.search(this.logSearch, previous);
+            if (this.logSearch && found === false) {
+                this.$root.toastError(this.$t("logSearchNoMatch"));
+            }
         },
 
         loadVolumeUsage() {
@@ -983,19 +935,10 @@ export default {
             });
         },
 
-        openVolumeBrowser(serviceName, destination) {
-            this.volumeBrowserService = serviceName;
-            this.$nextTick(() => {
-                this.$refs.volumeBrowser?.open(destination);
-            });
-        },
-
-        formatBytes(bytes) {
-            if (bytes >= 1024 ** 4) return (bytes / 1024 ** 4).toFixed(1) + " TB";
-            if (bytes >= 1024 ** 3) return (bytes / 1024 ** 3).toFixed(1) + " GB";
-            if (bytes >= 1024 ** 2) return Math.round(bytes / 1024 ** 2) + " MB";
-            if (bytes >= 1024) return Math.round(bytes / 1024) + " KB";
-            return bytes + " B";
+        volumeUsageForService(serviceName) {
+            return this.volumeUsage
+                .filter((item) => item.service === serviceName)
+                .flatMap((item) => item.mounts ?? []);
         },
 
         toggleContainers() {
@@ -1502,65 +1445,6 @@ export default {
 
 .terminal-log-search {
     width: min(300px, 72vw);
-}
-
-.stack-volume-box {
-    padding: 10px 12px;
-}
-
-.stack-volume-container {
-    padding: 8px 0;
-    border-bottom: 1px solid rgba(127, 127, 127, 0.16);
-
-    &:last-child {
-        border-bottom: 0;
-    }
-}
-
-.stack-volume-container-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 4px;
-}
-
-.stack-volume-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 6px 0 6px 12px;
-
-    &:last-child {
-        border-bottom: 0;
-    }
-}
-
-.stack-volume-main {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-
-    code {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-}
-
-.stack-volume-size {
-    flex: 0 0 auto;
-    font-weight: 600;
-}
-
-.stack-volume-actions {
-    display: inline-flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 8px;
-    flex: 0 0 auto;
 }
 
 .stack-meta-bar {


### PR DESCRIPTION
## Résumé

- Corrige la recherche dans les logs en scannant aussi le buffer affiché du terminal et en faisant défiler directement vers l’occurrence trouvée.
- Déplace l’affichage des tailles de volumes montés dans l’encart de chaque conteneur, à côté des infos déjà visibles.
- Corrige les liens de ports des conteneurs pour utiliser l’hôte courant de l’interface Dockge au lieu du nom type `LincStation`.

## Détails

- Les volumes sont maintenant listés par conteneur, avec leur point de montage, leur source/nom et leur taille.
- Le bouton `Fichiers` reste disponible et un clic sur un volume ouvre directement le navigateur de fichiers sur le montage concerné.
- Si une recherche dans les logs ne trouve rien dans les logs chargés, un message indique qu’aucune occurrence n’a été trouvée.

## Validation

- `npm run check-ts`
- Validation JSON des fichiers de langue `fr.json` et `en.json`
- `npm run build:frontend`
- `git diff --check`