### PR TITLE
Ajuste les tooltips monitoring et la recherche logs

### DIFF
--- a/frontend/src/components/Terminal.vue
+++ b/frontend/src/components/Terminal.vue
@@ -308,11 +308,17 @@ export default {
             const addonFound = previous
                 ? this.terminalSearchAddOn.findPrevious(term, options)
                 : this.terminalSearchAddOn.findNext(term, options);
-            const foundLine = this.findInBuffer(term, previous);
-            if (foundLine >= 0) {
-                this.terminal.scrollToLine(foundLine);
+            if (addonFound) {
+                return true;
             }
-            return addonFound || foundLine >= 0;
+            const match = this.findInBuffer(term, previous);
+            if (match) {
+                this.terminal.scrollToLine(match.line);
+                this.terminal.select(match.column, match.line, term.length);
+                this.terminal.focus();
+                return true;
+            }
+            return false;
         },
 
         findInBuffer(term, previous = false) {
@@ -320,7 +326,7 @@ export default {
             const buffer = this.terminal.buffer.active;
             const total = buffer.length;
             if (!needle || total <= 0) {
-                return -1;
+                return null;
             }
 
             let start;
@@ -337,10 +343,13 @@ export default {
                 if (line.includes(needle)) {
                     this.lastSearchTerm = needle;
                     this.lastSearchLine = lineIndex;
-                    return lineIndex;
+                    return {
+                        line: lineIndex,
+                        column: line.indexOf(needle),
+                    };
                 }
             }
-            return -1;
+            return null;
         },
         /**
          * Handles the resize event of the terminal component.

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -278,6 +278,7 @@
     "watcher.monitoring.navbarCpuModel": "CPU name",
     "watcher.monitoring.navbarPerCoreCpu": "Per-core usage",
     "watcher.monitoring.navbarUptime": "System uptime",
+    "watcher.monitoring.navbarUptimeShort": "Uptime",
     "watcher.monitoring.navbarCpuTemps": "CPU temperatures",
     "watcher.monitoring.navbarDiskTemps": "Disk temperatures",
     "watcher.monitoring.navbarHostDisplayHint": "Adds these details to the compact system stats in the navigation bar.",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -271,6 +271,7 @@
     "watcher.monitoring.navbarCpuModel": "Nom du processeur",
     "watcher.monitoring.navbarPerCoreCpu": "Utilisation par cœur",
     "watcher.monitoring.navbarUptime": "Uptime de la machine",
+    "watcher.monitoring.navbarUptimeShort": "Uptime",
     "watcher.monitoring.navbarCpuTemps": "Températures CPU",
     "watcher.monitoring.navbarDiskTemps": "Températures disques",
     "watcher.monitoring.navbarHostDisplayHint": "Ajoute ces infos aux stats système compactes de la barre de navigation.",

--- a/frontend/src/layouts/Layout.vue
+++ b/frontend/src/layouts/Layout.vue
@@ -42,10 +42,7 @@
 
             <!-- System Stats (desktop uniquement) -->
             <div v-if="$root.loggedIn && systemStats" class="system-stats d-none d-lg-flex align-items-center gap-3 me-auto ms-4">
-                <span v-if="systemStats.hostNavbarDisplay?.cpuModel" class="stat-pill stat-neutral" :title="systemStats.host?.cpuModel">
-                    <font-awesome-icon icon="microchip" class="me-1" />{{ shortCpuModel(systemStats.host?.cpuModel) }}
-                </span>
-                <span class="stat-pill" :class="statClass(systemStats.cpu)">
+                <span class="stat-pill" :class="statClass(systemStats.cpu)" :title="cpuStatTooltip()">
                     <font-awesome-icon icon="microchip" class="me-1" />CPU
                     <span class="disk-bar ms-1" :aria-label="diskUsageBarLabel(systemStats.cpu)">
                         <span class="disk-bar-bracket">[</span>
@@ -61,10 +58,7 @@
                     </span>
                     <span class="ms-1">{{ systemStats.cpu }}%</span>
                 </span>
-                <span v-if="systemStats.hostNavbarDisplay?.perCoreCpu && systemStats.host?.perCoreCpu?.length" class="stat-pill stat-neutral">
-                    <font-awesome-icon icon="chart-simple" class="me-1" />{{ coreSummary(systemStats.host.perCoreCpu) }}
-                </span>
-                <span class="stat-pill" :class="statClass(systemStats.ram.percent)">
+                <span class="stat-pill" :class="statClass(systemStats.ram.percent)" :title="ramStatTooltip()">
                     <font-awesome-icon icon="memory" class="me-1" />RAM
                     <span class="disk-bar ms-1" :aria-label="diskUsageBarLabel(systemStats.ram.percent)">
                         <span class="disk-bar-bracket">[</span>
@@ -108,7 +102,7 @@
                     <font-awesome-icon icon="chart-bar" class="me-1" />Kula
                 </a>
                 <span v-if="systemStats.hostNavbarDisplay?.uptime" class="stat-pill stat-neutral">
-                    <font-awesome-icon icon="clock" class="me-1" />{{ formatUptime(systemStats.host?.uptimeSeconds) }}
+                    <font-awesome-icon icon="clock" class="me-1" />{{ $t("watcher.monitoring.navbarUptimeShort") }} : {{ formatUptime(systemStats.host?.uptimeSeconds) }}
                 </span>
                 <span v-if="systemStats.hostNavbarDisplay?.cpuTemperatures && systemStats.host?.temperatures?.cpu?.length" class="stat-pill stat-neutral">
                     <font-awesome-icon icon="temperature-half" class="me-1" />CPU {{ tempSummary(systemStats.host.temperatures.cpu) }}
@@ -375,16 +369,27 @@ export default {
             return `${value.toFixed(precision)}${units[unitIndex]}`;
         },
 
-        shortCpuModel(model) {
-            return (model || "CPU")
-                .replace(/\(R\)|\(TM\)|CPU|Processor/gi, "")
-                .replace(/\s*@\s*.*/, "")
-                .replace(/\s+/g, " ")
-                .trim() || "CPU";
-        },
-
         coreSummary(values) {
             return values.map((value, index) => `C${index + 1} ${value}%`).join(" ");
+        },
+
+        cpuStatTooltip() {
+            const details = [];
+            if (this.systemStats?.hostNavbarDisplay?.cpuModel && this.systemStats?.host?.cpuModel) {
+                details.push(this.systemStats.host.cpuModel);
+            }
+            if (this.systemStats?.hostNavbarDisplay?.perCoreCpu && this.systemStats?.host?.perCoreCpu?.length) {
+                details.push(this.coreSummary(this.systemStats.host.perCoreCpu));
+            }
+            return details.join("\n");
+        },
+
+        ramStatTooltip() {
+            const ram = this.systemStats?.ram;
+            if (!ram) {
+                return "";
+            }
+            return `${this.formatBytes(ram.used)} / ${this.formatBytes(ram.total)}`;
         },
 
         formatUptime(seconds) {


### PR DESCRIPTION
## Résumé

- Déplace le nom du CPU et l'utilisation par cœur dans le tooltip de la stat CPU globale de la barre du haut.
- Ajoute un tooltip RAM avec l'utilisation sur le total.
- Affiche l'uptime sous la forme `Uptime : ...` en français et en anglais.
- Corrige la recherche dans les logs pour laisser xterm gérer le scroll quand il trouve une occurrence et sélectionner explicitement le résultat en fallback.

## Validation

- `npm run check-ts`
- Validation JSON des fichiers de langue `fr.json` et `en.json`
- `npm run build:frontend`
- `git diff --check`