### PR TITLE
Corrige la recherche logs

### DIFF
--- a/frontend/src/components/Terminal.vue
+++ b/frontend/src/components/Terminal.vue
@@ -337,7 +337,11 @@ export default {
 
         search(term, previous = false) {
             if (!term) {
-                this.terminalSearchAddOn.clearDecorations();
+                try {
+                    this.terminalSearchAddOn.clearDecorations();
+                } catch (error) {
+                    console.debug("xterm search addon cleanup failed", error);
+                }
                 this.terminal.clearSelection();
                 this.lastSearchTerm = "";
                 this.lastSearchLine = -1;
@@ -347,17 +351,16 @@ export default {
                 caseSensitive: false,
                 wholeWord: false,
                 regex: false,
-                decorations: {
-                    matchBackground: "#664d03",
-                    matchOverviewRuler: "#f59e0b",
-                    activeMatchBackground: "#0d6efd",
-                    activeMatchColorOverviewRuler: "#0d6efd",
-                },
             };
             this.suppressSelectionCopy = true;
-            const addonFound = previous
-                ? this.terminalSearchAddOn.findPrevious(term, options)
-                : this.terminalSearchAddOn.findNext(term, options);
+            let addonFound = false;
+            try {
+                addonFound = previous
+                    ? this.terminalSearchAddOn.findPrevious(term, options)
+                    : this.terminalSearchAddOn.findNext(term, options);
+            } catch (error) {
+                console.debug("xterm search addon failed, using log search fallback", error);
+            }
             const match = this.findInBuffer(term, previous);
             if (match) {
                 this.revealSearchMatch(match);

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -235,6 +235,7 @@
                                         type="search"
                                         class="form-control"
                                         :placeholder="$t('logSearchPlaceholder')"
+                                        @input="scheduleLogSearch"
                                         @keyup.enter="searchLogs(false)"
                                     />
                                     <button class="btn btn-normal" :title="$t('logSearchPrevious')" @click="searchLogs(true)">
@@ -556,6 +557,7 @@ export default {
             selectedLogSince: "",
             joinedLogSince: "",
             logSearch: "",
+            logSearchTimer: null,
             volumeUsage: [],
             volumeUsageLoading: false,
             containersExpanded: true,
@@ -789,6 +791,9 @@ export default {
     unmounted() {
         document.removeEventListener("visibilitychange", this.onVisibilityServiceStatus);
         clearTimeout(serviceStatusTimeout);
+        if (this.logSearchTimer) {
+            clearTimeout(this.logSearchTimer);
+        }
     },
     methods: {
         relativeTime(iso) {
@@ -918,6 +923,16 @@ export default {
             if (this.logSearch && found === false) {
                 this.$root.toastError(this.$t("logSearchNoMatch"));
             }
+        },
+
+        scheduleLogSearch() {
+            if (this.logSearchTimer) {
+                clearTimeout(this.logSearchTimer);
+            }
+            this.logSearchTimer = setTimeout(() => {
+                this.logSearchTimer = null;
+                this.$refs.combinedTerminal?.search(this.logSearch, false);
+            }, 250);
         },
 
         loadVolumeUsage() {
@@ -1437,6 +1452,10 @@ export default {
     display: flex;
     align-items: center;
     gap: 8px;
+
+    .form-label {
+        color: #9ca3af !important;
+    }
 
     .form-select {
         width: min(220px, 42vw);


### PR DESCRIPTION
## Résumé

- Corrige l'exception réelle de `@xterm/addon-search` qui bloquait toute la recherche dans les logs.
- Supprime les décorations xterm qui nécessitaient l'API proposée non activée.
- Encapsule l'addon de recherche pour que le fallback maison continue même si xterm échoue.
- Lance automatiquement la recherche pendant la saisie dans le champ des logs.
- Rend le libellé `Période` lisible sur fond sombre.

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`
- Reproduction sur `http://192.168.0.196:5001/compose/stremio-wastream` : l'erreur console xterm était bien la cause du blocage.