### PR TITLE
Empêche les mises à jour Xterm bêta incohérentes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
       # Une mise à jour automatique pourrait casser le terminal ou les toasts.
       - dependency-name: "@xterm/xterm"
       - dependency-name: "@xterm/addon-fit"
+      - dependency-name: "@xterm/addon-search"
       - dependency-name: "xterm-addon-web-links"
       - dependency-name: "vue-toastification"
 


### PR DESCRIPTION
## Résumé

- ignore les mises à jour Dependabot de `@xterm/addon-search`
- évite les propositions de versions bêta incompatibles avec les autres paquets Xterm épinglés
- conserve les autres mises à jour mineures groupées

## Contexte

La PR #59 propose `@xterm/addon-search` `0.17.0-beta.288` alors que les autres paquets Xterm restent sur leur série bêta actuelle. Cette combinaison rend l’arbre de dépendances incohérent et fait échouer `npm ci`.

## Validation

- configuration Dependabot vérifiée
- diff limité à `.github/dependabot.yml`
- absence d’erreur de format ou d’espace avec `git diff --check`

La PR #59 ne doit pas être fusionnée.
