### PR TITLE
Ajoute les actions par conteneur des stacks

### DIFF
--- a/backend/agent-socket-handlers/docker-socket-handler.ts
+++ b/backend/agent-socket-handlers/docker-socket-handler.ts
@@ -326,6 +326,25 @@ export class DockerSocketHandler extends AgentSocketHandler {
             }
         });
 
+        agentSocket.on("serviceAction", async (stackName: unknown, serviceName: unknown, action: unknown, callback) => {
+            try {
+                checkLogin(socket);
+                if (typeof stackName !== "string" || typeof serviceName !== "string") {
+                    throw new ValidationError("Stack and service names must be strings");
+                }
+                if (![ "start", "stop", "restart", "update", "recreate", "pull-recreate" ].includes(String(action))) {
+                    throw new ValidationError("Unsupported service action");
+                }
+                const stack = await Stack.getStack(server, stackName);
+                const affectedServices = await stack.serviceAction(socket, serviceName, action as "start" | "stop" | "restart" | "update" | "recreate" | "pull-recreate");
+                await this.auditStack(socket, `service.${action}`, `${stackName}/${serviceName}`, "success", null, { affectedServices });
+                server.sendStackList();
+                callbackResult({ ok: true, msg: "Service action completed", affectedServices }, callback);
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
         // Services status
         agentSocket.on("serviceStatusList", async (stackName : unknown, callback) => {
             try {
@@ -549,4 +568,3 @@ export class DockerSocketHandler extends AgentSocketHandler {
     }
 
 }
-

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -592,6 +592,70 @@ export class Stack {
         return exitCode;
     }
 
+    /**
+     * Returns the service being acted on and every service that shares its
+     * network namespace (`network_mode: service:<name>`). Recreating a VPN
+     * container without its dependants would leave those containers attached
+     * to the old namespace, so they must be recreated as one Compose action.
+     */
+    private async getServiceActionTargets(serviceName: string): Promise<string[]> {
+        if (!/^[a-zA-Z0-9_.-]+$/.test(serviceName)) {
+            throw new ValidationError("Invalid service name");
+        }
+        const result = await childProcessAsync.spawn("docker", this.getComposeOptions("config", "--format", "json"), {
+            cwd: this.path,
+            encoding: "utf-8",
+        });
+        const config = JSON.parse(result.stdout?.toString() || "{}");
+        const services = config.services ?? {};
+        if (!services[serviceName]) {
+            throw new ValidationError("Service not found in this stack");
+        }
+
+        const targets = new Set<string>([ serviceName ]);
+        let changed = true;
+        while (changed) {
+            changed = false;
+            for (const [ name, service ] of Object.entries(services) as Array<[string, { network_mode?: string }]>) {
+                const owner = typeof service.network_mode === "string" && service.network_mode.startsWith("service:")
+                    ? service.network_mode.slice("service:".length)
+                    : "";
+                if (owner && targets.has(owner) && !targets.has(name)) {
+                    targets.add(name);
+                    changed = true;
+                }
+            }
+        }
+        return [ serviceName, ...[ ...targets ].filter(name => name !== serviceName).sort() ];
+    }
+
+    async serviceAction(socket: DockgeSocket, serviceName: string, action: "start" | "stop" | "restart" | "update" | "recreate" | "pull-recreate"): Promise<string[]> {
+        const targets = await this.getServiceActionTargets(serviceName);
+        const terminalName = getComposeTerminalName(socket.endpoint, this.name);
+        const exec = async (command: string, ...args: string[]) => {
+            const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions(command, ...args), this.path);
+            if (exitCode !== 0) {
+                throw new Error(`Failed to ${action} service ${serviceName}; check the terminal for details.`);
+            }
+        };
+
+        if (action === "start") {
+            await exec("up", "-d", serviceName);
+        } else if (action === "stop") {
+            await exec("stop", ...[ ...targets ].reverse());
+        } else if (action === "restart") {
+            await exec("restart", ...targets);
+        } else {
+            if (action === "update" || action === "pull-recreate") {
+                await exec("pull", serviceName);
+            }
+            await exec("up", "-d", "--force-recreate", "--no-deps", ...targets);
+            await this.writeMeta({ lastUpdated: new Date().toISOString(), lastStartedAt: new Date().toISOString() });
+        }
+        serviceStatusCache.delete(this.name);
+        return targets;
+    }
+
     async recreate(socket: DockgeSocket) : Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("up", "-d", "--force-recreate", "--remove-orphans"), this.path);

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -97,6 +97,14 @@
             </div>
             <div class="col-5">
                 <div class="function">
+                    <div v-if="!isEditMode" class="container-actions mb-2">
+                        <button v-if="status !== 'running' && status !== 'healthy'" class="btn btn-sm btn-primary" :title="$t('startStack')" :disabled="actionProcessing" @click="runAction('start')"><font-awesome-icon icon="play" /></button>
+                        <button v-if="status === 'running' || status === 'healthy'" class="btn btn-sm btn-normal" :title="$t('stopStack')" :disabled="actionProcessing" @click="runAction('stop')"><font-awesome-icon icon="stop" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('restartStack')" :disabled="actionProcessing" @click="runAction('restart')"><font-awesome-icon icon="sync-alt" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('updateStack')" :disabled="actionProcessing" @click="runAction('update')"><font-awesome-icon icon="cloud-arrow-down" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('recreateStack')" :disabled="actionProcessing" @click="runAction('recreate')"><font-awesome-icon icon="rotate" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('pullAndRecreateStack')" :disabled="actionProcessing" @click="runAction('pull-recreate')"><font-awesome-icon icon="cloud-upload-alt" /></button>
+                    </div>
                     <button v-if="!isEditMode" class="btn btn-normal me-2" :title="$t('volumeBrowserTitle')" @click="openVolumeBrowser">
                         <font-awesome-icon icon="folder-open" />
                         {{ $t("files") }}
@@ -282,11 +290,16 @@ export default defineComponent({
         volumeLoading: {
             type: Boolean,
             default: false
+        },
+        actionProcessing: {
+            type: Boolean,
+            default: false,
         }
     },
     emits: [
         "auto-update-change",
         "refresh-volume-usage",
+        "service-action",
     ],
     data() {
         return {
@@ -419,6 +432,9 @@ export default defineComponent({
                 time: mode === "scheduled" ? this.autoUpdate.time : undefined,
             });
         },
+        runAction(action) {
+            this.$emit("service-action", action);
+        },
         changeAutoUpdateTime(event) {
             this.$emit("auto-update-change", {
                 mode: "scheduled",
@@ -457,6 +473,11 @@ export default defineComponent({
 @import "../styles/vars";
 
 .container {
+    .container-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .3rem;
+    }
     .image {
         font-size: 0.8rem;
         color: #6c757d;

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -215,8 +215,10 @@
                                 :auto-update-saving="autoUpdateSaving[name] === true"
                                 :volume-usage="volumeUsageForService(name)"
                                 :volume-loading="volumeUsageLoading"
+                                :action-processing="serviceActionProcessing[name] === true"
                                 @auto-update-change="setServiceAutoUpdate(name, $event)"
                                 @refresh-volume-usage="loadVolumeUsage"
+                                @service-action="runServiceAction(name, $event)"
                             />
                         </div>
                     </div>
@@ -607,6 +609,7 @@ export default {
             volumeUsageLoading: false,
             containersExpanded: true,
             autoUpdateSaving: {},
+            serviceActionProcessing: {},
             stackActionLabels: localStorage.getItem("stackActionLabels") === "1",
         };
     },
@@ -1066,6 +1069,20 @@ export default {
             this.$root.toastRes({
                 ok: result.ok,
                 msg: result.ok ? this.$t("watcher.status.autoUpdateSaved") : result.message,
+            });
+        },
+
+        runServiceAction(serviceName, action) {
+            if ([ "recreate", "pull-recreate" ].includes(action) && !confirm(this.$t(action === "recreate" ? "recreateStackMsg" : "pullAndRecreateStackMsg"))) {
+                return;
+            }
+            this.serviceActionProcessing[serviceName] = true;
+            this.$root.emitAgent(this.endpoint, "serviceAction", this.stack.name, serviceName, action, (res) => {
+                this.serviceActionProcessing[serviceName] = false;
+                this.$root.toastRes(res);
+                if (res.ok) {
+                    this.loadStack();
+                }
             });
         },
 


### PR DESCRIPTION
## Résumé

Ajoute des actions Compose ciblées sur un service : démarrer, arrêter, redémarrer, mettre à jour, recréer et pull + recréer.

Les actions résolvent la configuration Compose et incluent les services dépendants de `network_mode: service:<service>` : recréer ou mettre à jour un service VPN recrée aussi ses conteneurs associés pour préserver leur namespace réseau.

## Validation

- `npm run build:frontend`
- `npx tsc --noEmit --project tsconfig.json`