### PR TITLE
Corrige l’affichage des actions conteneur et la planification

### DIFF
--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="shadow-box big-padding mb-3 container">
         <div class="row">
-            <div class="col-7">
+            <div class="col-12">
                 <h4>{{ name }}</h4>
                 <div class="image mb-2">
                     <span class="me-1">{{ imageName }}:</span><span class="tag">{{ imageTag }}</span>
@@ -94,10 +94,8 @@
                         </strong>
                     </button>
                 </div>
-            </div>
-            <div class="col-5">
-                <div class="function">
-                    <div v-if="!isEditMode" class="container-actions mb-2">
+                <div v-if="!isEditMode" class="container-action-bar mt-3">
+                    <div class="container-actions">
                         <button v-if="status !== 'running' && status !== 'healthy'" class="btn btn-sm btn-primary" :title="$t('startStack')" :disabled="actionProcessing" @click="runAction('start')"><font-awesome-icon icon="play" /></button>
                         <button v-if="status === 'running' || status === 'healthy'" class="btn btn-sm btn-normal" :title="$t('stopStack')" :disabled="actionProcessing" @click="runAction('stop')"><font-awesome-icon icon="stop" /></button>
                         <button class="btn btn-sm btn-normal" :title="$t('restartStack')" :disabled="actionProcessing" @click="runAction('restart')"><font-awesome-icon icon="sync-alt" /></button>
@@ -105,14 +103,16 @@
                         <button class="btn btn-sm btn-normal" :title="$t('recreateStack')" :disabled="actionProcessing" @click="runAction('recreate')"><font-awesome-icon icon="rotate" /></button>
                         <button class="btn btn-sm btn-normal" :title="$t('pullAndRecreateStack')" :disabled="actionProcessing" @click="runAction('pull-recreate')"><font-awesome-icon icon="cloud-upload-alt" /></button>
                     </div>
-                    <button v-if="!isEditMode" class="btn btn-normal me-2" :title="$t('volumeBrowserTitle')" @click="openVolumeBrowser">
-                        <font-awesome-icon icon="folder-open" />
-                        {{ $t("files") }}
-                    </button>
-                    <router-link v-if="!isEditMode" class="btn btn-normal" :to="terminalRouteLink" disabled="">
-                        <font-awesome-icon icon="terminal" />
-                        Bash
-                    </router-link>
+                    <div class="container-utility-actions">
+                        <button class="btn btn-normal" :title="$t('volumeBrowserTitle')" @click="openVolumeBrowser">
+                            <font-awesome-icon icon="folder-open" />
+                            {{ $t("files") }}
+                        </button>
+                        <router-link class="btn btn-normal" :to="terminalRouteLink" disabled="">
+                            <font-awesome-icon icon="terminal" />
+                            Bash
+                        </router-link>
+                    </div>
                 </div>
             </div>
         </div>
@@ -473,10 +473,21 @@ export default defineComponent({
 @import "../styles/vars";
 
 .container {
-    .container-actions {
+    .container-action-bar,
+    .container-actions,
+    .container-utility-actions {
         display: flex;
+        align-items: center;
         flex-wrap: wrap;
         gap: .3rem;
+    }
+
+    .container-action-bar {
+        justify-content: space-between;
+    }
+
+    .container-utility-actions {
+        margin-left: auto;
     }
     .image {
         font-size: 0.8rem;
@@ -554,15 +565,6 @@ export default defineComponent({
         color: $primary;
     }
 
-    .function {
-        align-content: center;
-        display: flex;
-        height: 100%;
-        width: 100%;
-        align-items: center;
-        justify-content: end;
-    }
-
     .container-volumes {
         display: grid;
         gap: 4px;
@@ -615,6 +617,17 @@ export default defineComponent({
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+        }
+    }
+
+    @media (max-width: 575.98px) {
+        .container-action-bar {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+
+        .container-utility-actions {
+            margin-left: 0;
         }
     }
 }

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -17,11 +17,15 @@
                 </div>
             </h1>
 
-            <div v-if="schedulerEnabled && !isAdd && stack.isManagedByDockge && !endpoint" class="stack-scheduler-inline mb-3">
+            <div v-if="!isAdd && stack.isManagedByDockge && !endpoint" class="stack-scheduler-inline mb-3">
                 <div class="stack-scheduler-inline-title">
                     <font-awesome-icon icon="calendar-days" class="me-1" />{{ $t("stackScheduler.heading") }}
+                    <div class="form-check form-switch stack-scheduler-toggle">
+                        <input id="stackSchedulerEnabledOnCompose" v-model="schedulerEnabled" class="form-check-input" type="checkbox" role="switch" :disabled="schedulerToggleSaving" @change="toggleStackScheduler">
+                        <label class="form-check-label" for="stackSchedulerEnabledOnCompose">{{ $t("stackScheduler.enable") }}</label>
+                    </div>
                 </div>
-                <StackScheduleEditor :stack-name="stack.name" compact :show-heading="false" />
+                <StackScheduleEditor v-if="schedulerEnabled" :stack-name="stack.name" compact :show-heading="false" />
             </div>
 
             <StackReplicationStatus
@@ -525,7 +529,7 @@ export default {
         this.exitConfirm(next);
     },
     setup() {
-        const { enabled: schedulerEnabled } = useStackSchedules();
+        const { enabled: schedulerEnabled, setEnabled: setSchedulerEnabled } = useStackSchedules();
         const editorFocus = ref(false);
         const {
             statusCache: imageStatuses,
@@ -571,7 +575,8 @@ export default {
             imageStatuses,
             autoUpdateFor,
             saveAutoUpdateMode,
-            schedulerEnabled };
+            schedulerEnabled,
+            setSchedulerEnabled };
     },
     yamlDoc: null,  // For keeping the yaml comments
     data() {
@@ -610,6 +615,7 @@ export default {
             containersExpanded: true,
             autoUpdateSaving: {},
             serviceActionProcessing: {},
+            schedulerToggleSaving: false,
             stackActionLabels: localStorage.getItem("stackActionLabels") === "1",
         };
     },
@@ -1086,6 +1092,19 @@ export default {
             });
         },
 
+        async toggleStackScheduler() {
+            const requested = this.schedulerEnabled;
+            this.schedulerToggleSaving = true;
+            try {
+                await this.setSchedulerEnabled(requested);
+            } catch (error) {
+                this.schedulerEnabled = !requested;
+                this.$root.toastError(error instanceof Error ? error.message : String(error));
+            } finally {
+                this.schedulerToggleSaving = false;
+            }
+        },
+
         loadStack() {
             this.processing = true;
             this.$root.emitAgent(this.endpoint, "getStack", this.stack.name, (res) => {
@@ -1459,9 +1478,19 @@ export default {
 }
 
 .stack-scheduler-inline-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
     color: $dark-font-color3;
     font-size: 0.78rem;
     font-weight: 600;
+}
+
+.stack-scheduler-toggle {
+    margin-bottom: 0;
+    font-size: .75rem;
+    font-weight: 400;
 }
 
 /* Terminal de progression (deploy/restart/update) : plus haut pour afficher


### PR DESCRIPTION
## Résumé

- rend l’interrupteur « Activer la planification » directement accessible sur chaque stack locale ; le panneau reste masqué tant qu’il est désactivé ;
- place les actions de service, Fichiers et Bash sur une barre horizontale sous les volumes montés ;
- conserve un retour à la ligne propre sur mobile.

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`

`eslint` relève uniquement des règles historiques préexistantes dans les deux composants.