### PR TITLE
Affiche les ressources par conteneur

### DIFF
--- a/backend/routers/system-stats-router.ts
+++ b/backend/routers/system-stats-router.ts
@@ -315,6 +315,7 @@ function parseDockerBytes(str: string): number {
 }
 
 const stackStatsCache = new Map<string, StackStat>();
+const containerStatsCache = new Map<string, StackStat>();
 let lastStackCollectAt = 0;
 let stackCollectInFlight: Promise<void> | null = null;
 
@@ -325,32 +326,39 @@ async function updateStackStats(): Promise<void> {
             execAsync("docker ps --format '{{json .}}'"),
         ]);
 
-        // Index : short ID ET noms de container → stackName
+        // Index : short ID ET noms de container → projet/service Compose.
         // Robuste face aux socket-proxies qui peuvent changer le format de l'ID
-        const containerToStack = new Map<string, string>();
+        const containerToCompose = new Map<string, { stackName: string; serviceName: string }>();
         for (const line of psOut.trim().split("\n")) {
             if (!line.trim()) continue;
             try {
                 const c = JSON.parse(line);
                 const labels: string = c["Labels"] ?? "";
-                const m = labels.match(/com\.docker\.compose\.project=([^,]+)/);
-                if (!m) continue;
-                const stackName = m[1].trim();
+                const project = labels.match(/com\.docker\.compose\.project=([^,]+)/);
+                const service = labels.match(/com\.docker\.compose\.service=([^,]+)/);
+                if (!project || !service) {
+                    continue;
+                }
+                const compose = {
+                    stackName: project[1].trim(),
+                    serviceName: service[1].trim(),
+                };
 
                 // Par ID court (12 chars)
-                if (c["ID"]) containerToStack.set((c["ID"] as string).trim(), stackName);
+                if (c["ID"]) containerToCompose.set((c["ID"] as string).trim(), compose);
 
                 // Par nom(s) — docker ps retourne parfois "/nom1,/nom2"
                 const names: string = c["Names"] ?? "";
                 for (const n of names.split(",")) {
                     const clean = n.trim().replace(/^\//, "");
-                    if (clean) containerToStack.set(clean, stackName);
+                    if (clean) containerToCompose.set(clean, compose);
                 }
             } catch { /* ligne invalide */ }
         }
 
         // Agrégation par stack — cherche le stackName par ID, Container ou Name
         const aggr = new Map<string, StackStat>();
+        containerStatsCache.clear();
         for (const line of statsOut.trim().split("\n")) {
             if (!line.trim()) continue;
             try {
@@ -363,19 +371,28 @@ async function updateStackStats(): Promise<void> {
                 ].map((v: unknown) => (typeof v === "string" ? v.replace(/^\//, "").trim() : ""))
                     .filter(Boolean);
 
-                let stackName: string | undefined;
+                let compose: { stackName: string; serviceName: string } | undefined;
                 for (const key of candidates) {
-                    stackName = containerToStack.get(key);
-                    if (stackName) break;
+                    compose = containerToCompose.get(key);
+                    if (compose) break;
                 }
-                if (!stackName) continue;
+                if (!compose) continue;
 
                 const cpu     = parseFloat((s["CPUPerc"] ?? "0").replace("%", "")) || 0;
                 const memUsed = parseDockerBytes((s["MemUsage"] ?? "0B / 0B").split("/")[0]);
 
-                const cur = aggr.get(stackName);
+                const cur = aggr.get(compose.stackName);
                 if (cur) { cur.cpu += cpu; cur.memUsed += memUsed; }
-                else aggr.set(stackName, { cpu, memUsed });
+                else aggr.set(compose.stackName, { cpu, memUsed });
+
+                const containerKey = `${compose.stackName}:${compose.serviceName}`;
+                const container = containerStatsCache.get(containerKey);
+                if (container) {
+                    container.cpu += cpu;
+                    container.memUsed += memUsed;
+                } else {
+                    containerStatsCache.set(containerKey, { cpu, memUsed });
+                }
             } catch { /* ligne invalide */ }
         }
 
@@ -383,6 +400,12 @@ async function updateStackStats(): Promise<void> {
         for (const [name, stat] of aggr) {
             stackStatsCache.set(name, {
                 cpu:     Math.round(stat.cpu * 10) / 10,
+                memUsed: stat.memUsed,
+            });
+        }
+        for (const [key, stat] of containerStatsCache) {
+            containerStatsCache.set(key, {
+                cpu: Math.round(stat.cpu * 10) / 10,
                 memUsed: stat.memUsed,
             });
         }
@@ -501,7 +524,16 @@ export class SystemStatsRouter extends Router {
             await collectStackStatsIfDue();
             const data: Record<string, StackStat> = {};
             for (const [k, v] of stackStatsCache) data[k] = v;
-            res.json({ ok: true, data, lowPowerMode: isLowPower() });
+            const containerData: Record<string, StackStat> = {};
+            for (const [k, v] of containerStatsCache) {
+                containerData[k] = v;
+            }
+            res.json({
+                ok: true,
+                data,
+                containerData,
+                lowPowerMode: isLowPower(),
+            });
         });
 
         const mountRouter = express.Router();

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -61,6 +61,7 @@
                         <font-awesome-icon icon="rotate" />
                         {{ relativeTime(startedAt) }}
                     </span>
+                    <ContainerStatsBadge v-if="showResourceStats" :stack-name="stackName" :service-name="name" />
                 </div>
                 <div v-if="!isEditMode && (volumeLoading || volumeUsage.length > 0)" class="container-volumes mt-2">
                     <div class="container-volumes-title">
@@ -240,11 +241,13 @@ import { defineComponent } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { parseDockerPort, imageRegistryUrl } from "../../../common/util-common";
 import VolumeBrowser from "./VolumeBrowser.vue";
+import ContainerStatsBadge from "./ContainerStatsBadge.vue";
 
 export default defineComponent({
     components: {
         FontAwesomeIcon,
         VolumeBrowser,
+        ContainerStatsBadge,
     },
     props: {
         name: {
@@ -292,6 +295,14 @@ export default defineComponent({
             default: false
         },
         actionProcessing: {
+            type: Boolean,
+            default: false,
+        },
+        stackName: {
+            type: String,
+            default: "",
+        },
+        showResourceStats: {
             type: Boolean,
             default: false,
         }

--- a/frontend/src/components/ContainerStatsBadge.vue
+++ b/frontend/src/components/ContainerStatsBadge.vue
@@ -1,0 +1,45 @@
+<template>
+    <span v-if="stackStatsEnabled && stat" class="container-stats-badge ms-2" :class="cpuClass">
+        <font-awesome-icon icon="microchip" class="me-1" />{{ stat.cpu.toFixed(1) }}%
+        <span class="sep">·</span>
+        <font-awesome-icon icon="memory" class="me-1" />{{ formatMem(stat.memUsed) }}
+    </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStackStats, stackStatsEnabled, formatMem } from "../composables/useStackStats";
+
+const props = defineProps<{ stackName: string; serviceName: string }>();
+const { containerStatsCache } = useStackStats();
+const stat = computed(() => containerStatsCache.value[`${props.stackName}:${props.serviceName}`] ?? null);
+
+const cpuClass = computed(() => {
+    const cpu = stat.value?.cpu ?? 0;
+    if (cpu >= 85) {
+        return "stat-danger";
+    }
+    if (cpu >= 70) {
+        return "stat-warning";
+    }
+    return "stat-ok";
+});
+</script>
+
+<style lang="scss" scoped>
+.container-stats-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 10px;
+    font-weight: 500;
+    vertical-align: middle;
+    letter-spacing: 0.01em;
+
+    &.stat-ok { color: #a8d8b0; }
+    &.stat-warning { color: #f0d898; }
+    &.stat-danger { color: #f0a8a8; }
+
+    .sep { opacity: 0.35; margin: 0 1px; }
+}
+</style>

--- a/frontend/src/composables/useStackStats.ts
+++ b/frontend/src/composables/useStackStats.ts
@@ -16,6 +16,7 @@ export interface StackStat {
 // ─── État global partagé ─────────────────────────────────────────
 
 const statsCache   = ref<Record<string, StackStat>>({});
+const containerStatsCache = ref<Record<string, StackStat>>({});
 let poller: Poller | null = null;
 let subscribers = 0;
 
@@ -42,7 +43,10 @@ async function fetchStackStats(): Promise<void> {
         });
         if (res.status === 401) return;
         const json = await res.json();
-        if (json.ok) statsCache.value = json.data;
+        if (json.ok) {
+            statsCache.value = json.data;
+            containerStatsCache.value = json.containerData ?? {};
+        }
         setLowPower(json.lowPowerMode);
     } catch {
         // Silencieux — docker ou réseau indisponible
@@ -68,7 +72,7 @@ export function useStackStats() {
         }
     });
 
-    return { statsCache };
+    return { statsCache, containerStatsCache };
 }
 
 // ─── Helper format mémoire ───────────────────────────────────────

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -415,7 +415,7 @@
     "watcher.monitoring.navbarDiskTemps": "Disk temperatures",
     "watcher.monitoring.navbarHostDisplayHint": "Adds these details to the compact system stats in the navigation bar.",
     "watcher.monitoring.stackStats": "Show CPU / RAM stats per stack",
-    "watcher.monitoring.stackStatsHint": "Shows resource usage for each compose in the list (updated every 10 s).",
+    "watcher.monitoring.stackStatsHint": "Shows resource usage for each compose in the list and each container on its stack page (updated every 10 s).",
     "watcher.monitoring.lowPower": "Synology / low-power mode",
     "watcher.monitoring.lowPowerHint": "Slows down refreshes (system stats 30 s, container stats 60 s) and pauses collection when no tab is open or visible. Ideal for NAS / small setups.",
     "watcher.monitoring.diskPartition": "Monitored disk partitions",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -409,7 +409,7 @@
     "watcher.monitoring.navbarDiskTemps": "Températures disques",
     "watcher.monitoring.navbarHostDisplayHint": "Ajoute ces infos aux stats système compactes de la barre de navigation.",
     "watcher.monitoring.stackStats": "Afficher les stats CPU / RAM par stack",
-    "watcher.monitoring.stackStatsHint": "Affiche la consommation de chaque compose dans la liste (mis à jour toutes les 10 s).",
+    "watcher.monitoring.stackStatsHint": "Affiche la consommation de chaque compose dans la liste et de chaque conteneur dans ses stacks (mis à jour toutes les 10 s).",
     "watcher.monitoring.lowPower": "Mode Synology / faible consommation",
     "watcher.monitoring.lowPowerHint": "Ralentit les rafraîchissements (stats système 30 s, stats conteneurs 60 s) et met en pause la collecte quand aucun onglet n'est ouvert ou visible. Idéal pour NAS / petites configs.",
     "watcher.monitoring.diskPartition": "Partitions disque surveillées",

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -220,6 +220,8 @@
                                 :volume-usage="volumeUsageForService(name)"
                                 :volume-loading="volumeUsageLoading"
                                 :action-processing="serviceActionProcessing[name] === true"
+                                :stack-name="stack.name"
+                                :show-resource-stats="!endpoint"
                                 @auto-update-change="setServiceAutoUpdate(name, $event)"
                                 @refresh-volume-usage="loadVolumeUsage"
                                 @service-action="runServiceAction(name, $event)"


### PR DESCRIPTION
## Résumé

Ajoute les badges CPU et RAM pour chaque conteneur sur la page d’une stack lorsque les statistiques de ressources sont activées.

Les données réutilisent la collecte globale `docker stats` existante : aucun polling Docker supplémentaire. Les valeurs sont aussi agrégées par service si Compose utilise plusieurs répliques.

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`
- ESLint du nouveau composant de badge