### PR TITLE
Corrige les stacks partiellement actives et distingue les actions

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -467,14 +467,15 @@ export class Stack {
      * @param status
      */
     static statusConvert(status : string) : number {
-        if (status.startsWith("created")) {
-            return CREATED_STACK;
-        } else if (status.includes("exited")) {
-            // If one of the service is exited, we consider the stack is exited
-            return EXITED;
-        } else if (status.startsWith("running")) {
-            // If there is no exited services, there should be only running services
+        const normalizedStatus = status.toLowerCase();
+        if (normalizedStatus.includes("running")) {
+            // Une stack reste active tant qu'au moins un service tourne.
+            // Exemple : "exited(1), running(2)" après l'arrêt ciblé d'un service.
             return RUNNING;
+        } else if (normalizedStatus.includes("exited")) {
+            return EXITED;
+        } else if (normalizedStatus.includes("created")) {
+            return CREATED_STACK;
         } else {
             return UNKNOWN;
         }

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -639,6 +639,13 @@ export class Stack {
                 throw new Error(`Failed to ${action} service ${serviceName}; check the terminal for details.`);
             }
         };
+        const getServiceContainerIds = async () => {
+            const result = await childProcessAsync.spawn("docker", this.getComposeOptions("ps", "--all", "--quiet", serviceName), {
+                cwd: this.path,
+                encoding: "utf-8",
+            });
+            return result.stdout?.toString().trim() ?? "";
+        };
 
         if (action === "start") {
             await exec("up", "-d", serviceName);
@@ -646,8 +653,21 @@ export class Stack {
             await exec("stop", ...[ ...targets ].reverse());
         } else if (action === "restart") {
             await exec("restart", ...targets);
+        } else if (action === "update") {
+            const previousContainerIds = await getServiceContainerIds();
+            await exec("pull", serviceName);
+            await exec("up", "-d", "--no-deps", serviceName);
+
+            // If Compose replaced a VPN/network namespace owner, its sharing
+            // services must also be replaced so they join the new namespace.
+            const currentContainerIds = await getServiceContainerIds();
+            const networkDependants = targets.slice(1);
+            if (currentContainerIds && currentContainerIds !== previousContainerIds && networkDependants.length > 0) {
+                await exec("up", "-d", "--force-recreate", "--no-deps", ...networkDependants);
+            }
+            await this.writeMeta({ lastUpdated: new Date().toISOString(), lastStartedAt: new Date().toISOString() });
         } else {
-            if (action === "update" || action === "pull-recreate") {
+            if (action === "pull-recreate") {
                 await exec("pull", serviceName);
             }
             await exec("up", "-d", "--force-recreate", "--no-deps", ...targets);

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -99,10 +99,10 @@
                     <div class="container-actions">
                         <button v-if="status !== 'running' && status !== 'healthy'" class="btn btn-sm btn-primary" :title="$t('startStack')" :disabled="actionProcessing" @click="runAction('start')"><font-awesome-icon icon="play" /></button>
                         <button v-if="status === 'running' || status === 'healthy'" class="btn btn-sm btn-normal" :title="$t('stopStack')" :disabled="actionProcessing" @click="runAction('stop')"><font-awesome-icon icon="stop" /></button>
-                        <button class="btn btn-sm btn-normal" :title="$t('restartStack')" :disabled="actionProcessing" @click="runAction('restart')"><font-awesome-icon icon="sync-alt" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('restartStack')" :disabled="actionProcessing" @click="runAction('restart')"><font-awesome-icon icon="arrows-rotate" /></button>
                         <button class="btn btn-sm btn-normal" :title="$t('updateStack')" :disabled="actionProcessing" @click="runAction('update')"><font-awesome-icon icon="cloud-arrow-down" /></button>
-                        <button class="btn btn-sm btn-normal" :title="$t('recreateStack')" :disabled="actionProcessing" @click="runAction('recreate')"><font-awesome-icon icon="rotate" /></button>
-                        <button class="btn btn-sm btn-normal" :title="$t('pullAndRecreateStack')" :disabled="actionProcessing" @click="runAction('pull-recreate')"><font-awesome-icon icon="cloud-upload-alt" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('recreateStack')" :disabled="actionProcessing" @click="runAction('recreate')"><font-awesome-icon icon="recycle" /></button>
+                        <button class="btn btn-sm btn-normal" :title="$t('pullAndRecreateStack')" :disabled="actionProcessing" @click="runAction('pull-recreate')"><font-awesome-icon icon="boxes-stacked" /></button>
                     </div>
                     <div class="container-utility-actions">
                         <button class="btn btn-normal" :title="$t('volumeBrowserTitle')" @click="openVolumeBrowser">

--- a/frontend/src/icon.ts
+++ b/frontend/src/icon.ts
@@ -89,6 +89,8 @@ import {
     faFolder,
     faFolderOpen,
     faCalendarDays,
+    faRecycle,
+    faBoxesStacked,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -179,7 +181,8 @@ library.add(
     faFolder,
     faFolderOpen,
     faCalendarDays,
+    faRecycle,
+    faBoxesStacked,
 );
 
 export { FontAwesomeIcon };
-

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -57,7 +57,7 @@
                     </button>
 
                     <button v-if="!isEditMode && active" class="btn btn-normal stack-action" :title="$t('restartStack')" :aria-label="$t('restartStack')" :disabled="processing" @click="restartStack">
-                        <font-awesome-icon icon="sync-alt" />
+                        <font-awesome-icon icon="arrows-rotate" />
                         <span class="stack-action-label">{{ $t("restartStack") }}</span>
                     </button>
 
@@ -67,12 +67,12 @@
                     </button>
 
                     <button v-if="!isEditMode" class="btn btn-normal stack-action" :title="$t('recreateStack')" :aria-label="$t('recreateStack')" :disabled="processing" @click="recreateStack">
-                        <font-awesome-icon icon="rotate" />
+                        <font-awesome-icon icon="recycle" />
                         <span class="stack-action-label">{{ $t("recreateStack") }}</span>
                     </button>
 
                     <button v-if="!isEditMode" class="btn btn-normal stack-action" :title="$t('pullAndRecreateStack')" :aria-label="$t('pullAndRecreateStack')" :disabled="processing" @click="pullAndRecreateStack">
-                        <font-awesome-icon icon="cloud-upload-alt" />
+                        <font-awesome-icon icon="boxes-stacked" />
                         <span class="stack-action-label">{{ $t("pullAndRecreateStack") }}</span>
                     </button>
 


### PR DESCRIPTION
## Résumé

- considère une stack comme active tant qu’au moins un de ses conteneurs fonctionne
- attribue des icônes distinctes à Redémarrer, Mettre à jour, Recreate et Pull + recreate
- sépare réellement la mise à jour normale d’un conteneur du remplacement forcé
- recrée les conteneurs partageant le réseau d’un service VPN uniquement si ce service a été remplacé pendant la mise à jour

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`
- vérification des états mixtes `exited(...), running(...)`