### PR TITLE
Corrige l’assistant de transfert

### DIFF
--- a/backend/transfers/stack-transfer.integration.test.ts
+++ b/backend/transfers/stack-transfer.integration.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import { promises as fsAsync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { importStackTransfer, StackTransferRequest } from "./stack-transfer";
+import { importStackTransfer, preflightStackTransfer, StackTransferRequest } from "./stack-transfer";
 import { Settings } from "../settings";
 import { Terminal } from "../terminal";
 import { DockgeServer } from "../dockge-server";
@@ -82,7 +82,10 @@ test("copies, atomically deploys and verifies a stack in an isolated target inst
         emitAgent() {} } as unknown as DockgeSocket;
     try {
         const transferRequest = request(targetName);
-        transferRequest.mappings[0].targetSource = "./mapped-data";
+        const targetBind = path.join(root, "new-target-bind");
+        transferRequest.mappings[0].targetSource = targetBind;
+        const preflight = await preflightStackTransfer(server, transferRequest);
+        assert.equal(preflight.issues.some(issue => issue.code === "bind-create" && issue.severity === "success"), true);
         const result = await importStackTransfer(server, socket, transferRequest);
         const targetDir = path.join(root, targetName);
         assert.equal(result.job.status, "succeeded");
@@ -90,7 +93,8 @@ test("copies, atomically deploys and verifies a stack in an isolated target inst
         assert.equal(fs.existsSync(path.join(targetDir, ".env")), true);
         assert.equal(fs.existsSync(path.join(targetDir, "compose.override.yaml")), true);
         const rendered = JSON.parse(String((await execFileAsync("docker", [ "compose", "-p", targetName, "config", "--format", "json" ], { cwd: targetDir })).stdout));
-        assert.match(String(rendered.services.worker.volumes[0].source), /mapped-data$/);
+        assert.equal(String(rendered.services.worker.volumes[0].source), targetBind);
+        assert.equal(fs.existsSync(targetBind), true);
         const ps = await execFileAsync("docker", [ "compose", "-p", targetName, "ps", "--status", "running", "--services" ], { cwd: targetDir });
         assert.match(String(ps.stdout), /worker/);
     } finally {

--- a/backend/transfers/stack-transfer.ts
+++ b/backend/transfers/stack-transfer.ts
@@ -528,6 +528,31 @@ async function probeBindPath(hostPath: string): Promise<boolean | null> {
     }
 }
 
+async function ensureTargetBindPaths(paths: Iterable<string>): Promise<void> {
+    const uniquePaths = new Set(Array.from(paths)
+        .filter(hostPath => path.isAbsolute(hostPath))
+        .map(hostPath => path.normalize(hostPath)));
+    for (const hostPath of uniquePaths) {
+        if (hostPath === path.parse(hostPath).root) {
+            throw new ValidationError("Refusing to create the host root as a bind path");
+        }
+        if (await probeBindPath(hostPath) === true) {
+            continue;
+        }
+        await runDocker([
+            "run", "--rm", "--network", "none",
+            "--mount", "type=bind,src=/,dst=/host",
+            HELPER_IMAGE, "sh", "-c", "mkdir -p -- \"/host$1\"", "dockge-transfer", hostPath,
+        ], undefined, 120_000);
+    }
+}
+
+async function ensureComposeBindPaths(config: Record<string, unknown>): Promise<void> {
+    await ensureTargetBindPaths(Array.from(resolvedMounts(config).values())
+        .filter(mount => mount.type === "bind")
+        .map(mount => mount.source));
+}
+
 function publishedPorts(config: Record<string, unknown>): Array<{ service: string; published: string; protocol: string }> {
     const result: Array<{ service: string; published: string; protocol: string }> = [];
     for (const [ service, rawService ] of Object.entries(asRecord(config.services))) {
@@ -656,10 +681,10 @@ export async function preflightStackTransfer(server: DockgeServer, request: Stac
         if (mount.type === "bind" && path.isAbsolute(mount.targetSource)) {
             const exists = await probeBindPath(mount.targetSource);
             issues.push({
-                severity: exists === null ? "warning" : exists ? "success" : "error",
+                severity: exists === null ? "warning" : "success",
                 scope: "deploy",
-                code: exists === null ? "bind-unchecked" : exists ? "bind-found" : "bind-missing",
-                message: exists === null ? `${mount.targetSource}: target path could not be checked because the helper image is unavailable` : exists ? `${mount.targetSource}: target path is available` : `${mount.targetSource}: target path is missing or inaccessible`,
+                code: exists === null ? "bind-unchecked" : exists ? "bind-found" : "bind-create",
+                message: exists === null ? `${mount.targetSource}: target path could not be checked because the helper image is unavailable` : exists ? `${mount.targetSource}: target path is available` : `${mount.targetSource}: target path will be created automatically during deployment`,
                 params: { path: mount.targetSource },
             });
         }
@@ -995,6 +1020,7 @@ export async function importStackTransfer(server: DockgeServer, socket: DockgeSo
                     await advanceJob(previous, "deploying", 65);
                     const stack = await Stack.getStack(server, request.targetName);
                     const config = await resolvedComposeForStack(server, stack);
+                    await ensureComposeBindPaths(config);
                     await stack.deploy(socket);
                     await advanceJob(previous, "verifying", 85);
                     await verifyDeployment(server, request.targetName, Object.keys(asRecord(config.services)));
@@ -1058,9 +1084,10 @@ export async function importStackTransfer(server: DockgeServer, socket: DockgeSo
         if (request.deploy) {
             await advanceJob(job, "deploying", 65);
             const stack = await Stack.getStack(server, request.targetName);
+            const config = await resolvedComposeForStack(server, stack);
+            await ensureComposeBindPaths(config);
             await stack.deploy(socket);
             await advanceJob(job, "verifying", 85);
-            const config = preflight.config || {};
             await verifyDeployment(server, request.targetName, Object.keys(asRecord(config.services)));
         }
 
@@ -1094,12 +1121,14 @@ export async function importStackTransfer(server: DockgeServer, socket: DockgeSo
 
 export async function createImportedStackStorage(server: DockgeServer, targetName: string): Promise<void> {
     const stack = await Stack.getStack(server, targetName);
+    await ensureComposeBindPaths(await resolvedComposeForStack(server, stack));
     await runDocker(stack.getComposeOptions("create"), stack.fullPath, 30 * 60_000);
 }
 
 export async function deployAndVerifyImportedStack(server: DockgeServer, socket: DockgeSocket, targetName: string): Promise<void> {
     const stack = await Stack.getStack(server, targetName);
     const config = await resolvedComposeForStack(server, stack);
+    await ensureComposeBindPaths(config);
     await stack.deploy(socket);
     await verifyDeployment(server, targetName, Object.keys(asRecord(config.services)));
 }

--- a/frontend/src/components/StackTransferModal.vue
+++ b/frontend/src/components/StackTransferModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <BModal v-model="visible" size="xl" :title="modalTitle" hide-footer @hidden="reset">
+    <BModal v-model="visible" size="xl" :title="modalTitle" content-class="stack-transfer-modal" hide-footer @hidden="reset">
         <div v-if="loading" class="text-center py-5">
             <span class="spinner-border me-2" />{{ $t("stackTransfer.loading") }}
         </div>
@@ -23,7 +23,7 @@
                         <label class="form-label">{{ $t("stackTransfer.targetName") }}</label>
                         <input v-model="targetName" class="form-control" maxlength="100" :disabled="operation === 'replicate' && Boolean(replicationId)" @input="invalidatePreflight" />
                     </div>
-                    <div class="col-md-3 d-flex align-items-end">
+                    <div v-if="operation !== 'replicate'" class="col-md-3 d-flex align-items-end">
                         <div class="form-check mb-2">
                             <input id="stack-transfer-deploy" v-model="deploy" type="checkbox" class="form-check-input" :disabled="operation === 'move' || operation === 'replicate'" @change="invalidatePreflight" />
                             <label for="stack-transfer-deploy" class="form-check-label">{{ $t("stackTransfer.deployTarget") }}</label>
@@ -37,9 +37,13 @@
                 </div>
 
                 <div class="shadow-box big-padding mb-4">
-                    <div class="form-check mb-3">
+                    <div v-if="operation !== 'replicate'" class="form-check mb-3">
                         <input id="stack-transfer-data" v-model="includeData" type="checkbox" class="form-check-input" :disabled="availableRepositories.length === 0 || operation === 'replicate'" @change="dataModeChanged" />
                         <label for="stack-transfer-data" class="form-check-label fw-semibold">{{ $t("stackTransfer.includeData") }}</label>
+                        <div class="form-text">{{ $t("stackTransfer.includeDataHint") }}</div>
+                    </div>
+                    <div v-else class="mb-3">
+                        <div class="fw-semibold">{{ $t("stackReplication.dataRequired") }}</div>
                         <div class="form-text">{{ $t("stackTransfer.includeDataHint") }}</div>
                     </div>
                     <div v-if="availableRepositories.length === 0" class="alert alert-secondary mb-0 py-2">
@@ -145,9 +149,9 @@
                     </div>
                 </div>
 
-                <div class="mb-4">
-                    <strong class="me-2">{{ $t("stackTransfer.filesCopied") }}</strong>
-                    <span v-for="file in copiedFiles" :key="file" class="badge bg-secondary me-1"><code>{{ file }}</code></span>
+                <div class="transfer-files mb-4">
+                    <strong>{{ $t("stackTransfer.filesCopied") }}</strong>
+                    <span v-for="file in copiedFiles" :key="file" class="badge bg-secondary"><code>{{ file }}</code></span>
                 </div>
 
                 <h5>{{ $t("stackTransfer.storageMapping") }}</h5>
@@ -941,7 +945,7 @@ export default {
                 size /= 1024;
                 unit++;
             }
-            return `${size.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+            return `${new Intl.NumberFormat(this.$i18n.locale, { maximumFractionDigits: unit === 0 ? 0 : 1 }).format(size)} ${units[unit]}`;
         },
         confidenceClass(confidence) {
             return { high: "bg-success",
@@ -953,7 +957,13 @@ export default {
         },
         issueText(issue) {
             const key = `stackTransfer.issue.${issue.code}`;
-            return this.$te(key) ? this.$t(key, issue.params || {}) : issue.message;
+            const params = { ...(issue.params || {}) };
+            if ([ "space-available", "space-insufficient" ].includes(issue.code)) {
+                params.available = this.formatBytes(Number(params.available));
+                params.required = this.formatBytes(Number(params.required));
+            }
+            const translated = this.$t(key, params);
+            return translated === key ? issue.message : translated;
         },
     },
 };
@@ -964,6 +974,7 @@ export default {
     min-width: 900px;
     code { white-space: normal; }
 }
+.transfer-files { display: flex; align-items: center; flex-wrap: wrap; gap: .45rem; }
 .transfer-rules-summary { cursor: pointer; font-weight: 600; }
 .transfer-issues { display: grid; gap: .4rem; }
 .transfer-issue { display: flex; align-items: center; border-radius: .4rem; padding: .55rem .75rem; }
@@ -971,4 +982,32 @@ export default {
 .transfer-issue-warning { background: rgba(255, 193, 7, .14); color: #ffd76a; }
 .transfer-issue-error { background: rgba(220, 53, 69, .14); color: #ff8793; }
 .transfer-override-preview { max-height: 260px; overflow: auto; border-radius: .4rem; padding: .75rem; background: rgba(0, 0, 0, .25); font-size: .8rem; }
+</style>
+
+<style lang="scss">
+.dark .stack-transfer-modal {
+    .modal-title,
+    .form-label,
+    .form-check-label,
+    h5,
+    .transfer-files strong,
+    .transfer-rules-summary,
+    .fw-semibold {
+        color: #e5e7eb;
+    }
+
+    .form-text,
+    .text-muted {
+        color: #aab4c0 !important;
+    }
+
+    .form-check-input:disabled ~ .form-check-label {
+        color: #aab4c0;
+        opacity: 1;
+    }
+
+    .transfer-mapping-table code {
+        color: #536273;
+    }
+}
 </style>

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -242,7 +242,8 @@
     "stackTransfer.issue.compose-invalid": "Invalid Compose configuration: {error}",
     "stackTransfer.issue.port-conflict": "{service}: port {published}/{protocol} is already in use on the target.",
     "stackTransfer.issue.bind-found": "Target path {path} is available.",
-    "stackTransfer.issue.bind-missing": "Target path {path} is missing or inaccessible.",
+    "stackTransfer.issue.bind-create": "Target path {path} does not exist yet; it will be created automatically during deployment.",
+    "stackTransfer.issue.bind-missing": "Target path {path} does not exist yet; it will be created automatically during deployment.",
     "stackTransfer.issue.bind-unchecked": "Target path {path} could not be checked because the Docker helper image is unavailable.",
     "stackTransfer.issue.bind-relative-escape": "Relative path {path} escapes the target stack directory.",
     "stackTransfer.issue.mapping-empty": "{service}:{target}: a target source is required.",
@@ -844,8 +845,8 @@
     "stackTransfer.overwriteExisting": "Transactionally overwrite the existing target stack",
     "stackTransfer.overwriteExistingHint": "Dockge checks free space, requires the target to be stopped, keeps a rollback snapshot of its configuration and selected data, then restores the previous target automatically if any step fails.",
     "stackTransfer.overwriteConfirm": "Confirm the transactional replacement of the target stack? It must be stopped and will be restored automatically on failure.",
-    "stackTransfer.issue.space-insufficient": "Insufficient free space: {available} bytes available, {required} required.",
-    "stackTransfer.issue.space-available": "Free-space check passed: {available} bytes available.",
+    "stackTransfer.issue.space-insufficient": "Insufficient free space: {available} available, {required} required.",
+    "stackTransfer.issue.space-available": "Free-space check passed: {available} available.",
     "stackTransfer.issue.space-unchecked": "Free space could not be verified.",
     "stackTransfer.issue.target-running": "The target stack must be stopped before overwrite. Running services: {services}.",
     "stackTransfer.issue.target-state-unchecked": "The target stack state could not be verified.",
@@ -860,5 +861,6 @@
     "stackReplication.lastHealthcheck": "Last healthcheck",
     "stackReplication.health.passed": "passed",
     "stackReplication.health.failed": "failed",
-    "stackReplication.driftSuspended": "Replication was automatically suspended after detecting a target write or drift"
+    "stackReplication.driftSuspended": "Replication was automatically suspended after detecting a target write or drift",
+    "stackReplication.dataRequired": "Replica data"
 }

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -236,7 +236,8 @@
     "stackTransfer.issue.compose-invalid": "Configuration Compose invalide : {error}",
     "stackTransfer.issue.port-conflict": "{service} : le port {published}/{protocol} est déjà utilisé sur la cible.",
     "stackTransfer.issue.bind-found": "Le chemin cible {path} est disponible.",
-    "stackTransfer.issue.bind-missing": "Le chemin cible {path} est absent ou inaccessible.",
+    "stackTransfer.issue.bind-create": "Le chemin cible {path} n’existe pas encore ; il sera créé automatiquement lors du déploiement.",
+    "stackTransfer.issue.bind-missing": "Le chemin cible {path} n’existe pas encore ; il sera créé automatiquement lors du déploiement.",
     "stackTransfer.issue.bind-unchecked": "Le chemin cible {path} n'a pas pu être vérifié car l'image auxiliaire Docker n'est pas disponible.",
     "stackTransfer.issue.bind-relative-escape": "Le chemin relatif {path} sort du dossier de la stack cible.",
     "stackTransfer.issue.mapping-empty": "{service}:{target} : une source cible est obligatoire.",
@@ -838,8 +839,8 @@
     "stackTransfer.overwriteExisting": "Écraser la stack cible existante de façon transactionnelle",
     "stackTransfer.overwriteExistingHint": "Dockge vérifie l’espace libre, arrête obligatoirement la cible, conserve un snapshot de rollback de sa configuration et de ses données sélectionnées, puis restaure automatiquement l’ancienne cible si une étape échoue.",
     "stackTransfer.overwriteConfirm": "Confirmer le remplacement transactionnel de la stack cible ? Elle doit être arrêtée et sera restaurée automatiquement en cas d’échec.",
-    "stackTransfer.issue.space-insufficient": "Espace libre insuffisant : {available} octets disponibles, {required} requis.",
-    "stackTransfer.issue.space-available": "Contrôle d’espace validé : {available} octets disponibles.",
+    "stackTransfer.issue.space-insufficient": "Espace libre insuffisant : {available} disponibles, {required} requis.",
+    "stackTransfer.issue.space-available": "Contrôle d’espace validé : {available} disponibles.",
     "stackTransfer.issue.space-unchecked": "L’espace libre n’a pas pu être vérifié.",
     "stackTransfer.issue.target-running": "La stack cible doit être arrêtée avant l’écrasement. Services actifs : {services}.",
     "stackTransfer.issue.target-state-unchecked": "L’état de la stack cible n’a pas pu être vérifié.",
@@ -854,5 +855,6 @@
     "stackReplication.lastHealthcheck": "Dernier healthcheck",
     "stackReplication.health.passed": "réussi",
     "stackReplication.health.failed": "échoué",
-    "stackReplication.driftSuspended": "Réplication suspendue automatiquement après détection d’une écriture ou d’une dérive sur la cible"
+    "stackReplication.driftSuspended": "Réplication suspendue automatiquement après détection d’une écriture ou d’une dérive sur la cible",
+    "stackReplication.dataRequired": "Données de la réplique"
 }


### PR DESCRIPTION
## Résumé

- renforce le contraste de tous les titres, libellés, aides et résumés de l’assistant de transfert en thème sombre ;
- masque les contrôles sans objet pendant la configuration d’une réplication et présente clairement les données obligatoires de la réplique ;
- force la traduction des diagnostics de prévalidation dans la langue active, avec compatibilité pour les agents pas encore mis à jour ;
- affiche l’espace libre dans une unité lisible et avec le format numérique de la langue active ;
- considère un bind cible absent comme créable au lieu d’en faire une erreur bloquante ;
- crée explicitement les dossiers de bind absents sur l’hôte cible avant `create` ou `deploy`, y compris lors d’une activation de réplique ;
- espace correctement la liste des fichiers Compose copiés.

## Validation

- `npm run check-ts`
- ESLint ciblé sans erreur
- `npm run build:frontend`
- 20 tests transfert/réplication : 20 réussis
- test Docker réel d’un bind absolu absent : prévalidation non bloquante, création automatique, montage et déploiement réussis
- validation des trois scénarios d’intégration configuration : copie, rollback et écrasement transactionnel
- `docker build -t dockge-enhanced:transfer-ui-fix .`
- validation JSON français/anglais et `git diff --check`
