### PR TITLE
Sécurise la copie et la réplication

### DIFF
--- a/backend/transfers/stack-transfer.integration.test.ts
+++ b/backend/transfers/stack-transfer.integration.test.ts
@@ -108,6 +108,24 @@ test("copies, atomically deploys and verifies a stack in an isolated target inst
     }
 });
 
+test("blocks deployment when a Compose device is missing on the target", { skip: !dockerAvailable,
+    timeout: 30_000 }, async () => {
+    const root = await fsAsync.mkdtemp(path.join(os.tmpdir(), "dockge-transfer-device-check-"));
+    const targetName = `transfer-device-${Date.now()}`;
+    const server = { stacksDir: root } as DockgeServer;
+    try {
+        const transferRequest = request(targetName);
+        transferRequest.composeYAML += "    devices:\n      - /dev/dockge-definitely-missing-device:/dev/test-device\n";
+        const preflight = await preflightStackTransfer(server, transferRequest);
+        const issue = preflight.issues.find(item => item.code === "device-missing");
+        assert.equal(issue?.severity, "error");
+        assert.equal(issue?.params?.path, "/dev/dockge-definitely-missing-device");
+    } finally {
+        await fsAsync.rm(root, { recursive: true,
+            force: true });
+    }
+});
+
 test("rolls configuration and containers back when target verification fails", { skip: !dockerAvailable,
     timeout: 90_000 }, async () => {
     const root = await fsAsync.mkdtemp(path.join(os.tmpdir(), "dockge-transfer-rollback-"));

--- a/backend/transfers/stack-transfer.ts
+++ b/backend/transfers/stack-transfer.ts
@@ -786,12 +786,45 @@ export async function preflightStackTransfer(server: DockgeServer, request: Stac
     }
     for (const [ service, rawService ] of Object.entries(asRecord(config.services))) {
         const devices = asRecord(rawService).devices;
-        if (Array.isArray(devices) && devices.length > 0) {
-            issues.push({ severity: "warning",
+        if (!Array.isArray(devices)) {
+            continue;
+        }
+        let checkedDevices = 0;
+        let deviceProblems = 0;
+        for (const rawDevice of devices) {
+            const device = asRecord(rawDevice);
+            const source = typeof rawDevice === "string" ? rawDevice.split(":")[0] : typeof device.source === "string" ? device.source : "";
+            if (!source || !path.isAbsolute(source)) {
+                issues.push({ severity: "warning",
+                    scope: "deploy",
+                    code: "devices-manual",
+                    message: `${service}: Docker device mapping requires manual verification on the target`,
+                    params: { service } });
+                deviceProblems++;
+                continue;
+            }
+            const exists = await probeBindPath(source);
+            if (exists === true) {
+                checkedDevices++;
+                continue;
+            }
+            deviceProblems++;
+            issues.push({
+                severity: exists === null ? "warning" : "error",
                 scope: "deploy",
-                code: "devices-manual",
-                message: `${service}: Docker devices require manual verification on the target`,
-                params: { service } });
+                code: exists === null ? "device-unchecked" : "device-missing",
+                message: exists === null ? `${service}: ${source} could not be checked on the target` : `${service}: ${source} does not exist on the target`,
+                params: { service,
+                    path: source },
+            });
+        }
+        if (checkedDevices > 0 && deviceProblems === 0) {
+            issues.push({ severity: "success",
+                scope: "deploy",
+                code: "devices-found",
+                message: `${service}: all ${checkedDevices} Docker devices are available on the target`,
+                params: { service,
+                    count: String(checkedDevices) } });
         }
     }
     if (!issues.some(issue => issue.severity === "error")) {

--- a/backend/watchers/stack-replication-manager.test.ts
+++ b/backend/watchers/stack-replication-manager.test.ts
@@ -128,3 +128,16 @@ test("rejects unsupported replication intervals", async () => {
         mock.restoreAll();
     }
 });
+
+test("rejects replication without a shared repository using a translatable error", async () => {
+    await assert.rejects(StackReplicationManager.getInstance().save({
+        sourceEndpoint: "",
+        sourceStackName: "source",
+        targetEndpoint: "remote:5001",
+        targetName: "source-replica",
+        repositoryId: "",
+        intervalMinutes: 60,
+        mappings: [ mapping() ],
+        consistency: { mode: "hot" },
+    }), /stackReplication\.repositoryRequired/);
+});

--- a/backend/watchers/stack-replication-manager.ts
+++ b/backend/watchers/stack-replication-manager.ts
@@ -127,13 +127,16 @@ function normalizeInput(raw: StackReplicationInput): StackReplicationInput {
     if (!ALLOWED_INTERVALS.has(intervalMinutes)) {
         throw new ValidationError("Replication interval must be 15 minutes, 1 hour, 6 hours or 24 hours");
     }
+    if (typeof raw.repositoryId !== "string" || !raw.repositoryId.trim()) {
+        throw new ValidationError("stackReplication.repositoryRequired");
+    }
     const input = {
         id: raw.id ? stringField(raw.id, "id") : undefined,
         sourceEndpoint: stringField(raw.sourceEndpoint, "sourceEndpoint", true),
         sourceStackName: stringField(raw.sourceStackName, "sourceStackName"),
         targetEndpoint: stringField(raw.targetEndpoint, "targetEndpoint", true),
         targetName: stringField(raw.targetName, "targetName"),
-        repositoryId: stringField(raw.repositoryId, "repositoryId"),
+        repositoryId: raw.repositoryId.trim(),
         intervalMinutes,
         mappings: normalizeMappings(raw.mappings),
         consistency: normalizeStackBackupPolicy(raw.consistency),

--- a/frontend/src/components/StackTransferModal.vue
+++ b/frontend/src/components/StackTransferModal.vue
@@ -365,6 +365,9 @@ export default {
             if (!this.targetName || this.preflightSignature !== this.currentSignature) {
                 return false;
             }
+            if (this.operation === "replicate" && (!this.repositoryId || !this.mappings.some(mapping => mapping.transferData && (mapping.type === "bind" || mapping.type === "volume")))) {
+                return false;
+            }
             if (this.includeData) {
                 if (!this.repositoryId || !this.mappings.some(mapping => mapping.transferData && (mapping.type === "bind" || mapping.type === "volume"))) {
                     return false;
@@ -551,7 +554,7 @@ export default {
             this.targetDataCapabilities = response.data;
             if (!this.availableRepositories.some(item => item.id === this.repositoryId)) {
                 this.repositoryId = this.availableRepositories[0]?.id || "";
-                if (!this.repositoryId) {
+                if (!this.repositoryId && this.operation !== "replicate") {
                     this.includeData = false;
                 }
             }
@@ -785,6 +788,9 @@ export default {
             }
         },
         async executeReplication() {
+            if (!this.repositoryId) {
+                throw new Error(this.$t("stackReplication.repositoryRequired"));
+            }
             this.transferPhase = "replication";
             const saved = await new Promise(resolve => this.$root.getSocket().emit("saveStackReplication", {
                 id: this.replicationId || undefined,

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -256,6 +256,9 @@
     "stackTransfer.issue.secret-found": "External secret {name} is available.",
     "stackTransfer.issue.secret-missing": "External secret {name} is missing.",
     "stackTransfer.issue.devices-manual": "{service}: Docker devices require manual verification on the target.",
+    "stackTransfer.issue.devices-found": "{service}: all {count} Docker devices are available on the target.",
+    "stackTransfer.issue.device-missing": "{service}: device {path} does not exist on the target. Remove or replace it in the Compose file before deployment.",
+    "stackTransfer.issue.device-unchecked": "{service}: device {path} could not be checked on the target.",
     "stackTransfer.issue.target-ready": "The target is ready.",
     "stackReplication.heading": "Cold replica",
     "stackReplication.title": "Replicate stack {0}",
@@ -862,5 +865,6 @@
     "stackReplication.health.passed": "passed",
     "stackReplication.health.failed": "failed",
     "stackReplication.driftSuspended": "Replication was automatically suspended after detecting a target write or drift",
-    "stackReplication.dataRequired": "Replica data"
+    "stackReplication.dataRequired": "Replica data",
+    "stackReplication.repositoryRequired": "Replication requires a shared Restic repository configured identically on both instances."
 }

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -250,6 +250,9 @@
     "stackTransfer.issue.secret-found": "Le secret externe {name} est disponible.",
     "stackTransfer.issue.secret-missing": "Le secret externe {name} est absent.",
     "stackTransfer.issue.devices-manual": "{service} : les périphériques Docker doivent être vérifiés manuellement sur la cible.",
+    "stackTransfer.issue.devices-found": "{service} : les {count} périphériques Docker sont disponibles sur la cible.",
+    "stackTransfer.issue.device-missing": "{service} : le périphérique {path} n’existe pas sur la cible. Retirez-le ou remplacez-le dans le Compose avant le déploiement.",
+    "stackTransfer.issue.device-unchecked": "{service} : le périphérique {path} n’a pas pu être vérifié sur la cible.",
     "stackTransfer.issue.target-ready": "La cible est prête.",
     "stackReplication.heading": "Réplique froide",
     "stackReplication.title": "Répliquer la stack {0}",
@@ -856,5 +859,6 @@
     "stackReplication.health.passed": "réussi",
     "stackReplication.health.failed": "échoué",
     "stackReplication.driftSuspended": "Réplication suspendue automatiquement après détection d’une écriture ou d’une dérive sur la cible",
-    "stackReplication.dataRequired": "Données de la réplique"
+    "stackReplication.dataRequired": "Données de la réplique",
+    "stackReplication.repositoryRequired": "La réplication nécessite un dépôt Restic partagé configuré à l’identique sur les deux instances."
 }


### PR DESCRIPTION
## Résumé

- empêche la configuration d’une réplication tant qu’aucun dépôt Restic partagé n’est sélectionné ;
- conserve le transfert de données obligatoire lors d’un changement d’instance cible en mode réplication ;
- remplace une erreur technique interne par un message traduit et explicite, y compris côté backend ;
- vérifie chaque périphérique Docker déclaré dans le Compose sur l’hôte cible avant copie ou réplication ;
- bloque le déploiement avant toute mutation lorsqu’un périphérique est absent ;
- agrège les périphériques présents dans un seul diagnostic afin de garder la prévalidation lisible.

## Validation

- tests de prévalidation avec périphériques présents et absents ;
- 28 tests transfert/réplication : 22 réussis, 6 scénarios nécessitant un binaire externe ignorés, aucun échec ;
- nouveau test Docker d’un périphérique Compose absent sur la cible ;
- nouveau test de rejet d’une réplication sans dépôt partagé avec erreur traduisible ;
- `npm run check-ts` ;
- ESLint ciblé sans erreur ;
- `npm run build:frontend` ;
- build Docker local ;
- validation JSON français/anglais et `git diff --check`.
