### PR TITLE
Corrige les liens de ports des instances distantes

### DIFF
--- a/common/util-common.test.ts
+++ b/common/util-common.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseDockerPort, resolveEndpointHostname } from "./util-common";
+
+test("builds published-port links with the stack instance hostname", () => {
+    const hostname = resolveEndpointHostname("target.example.test:5001", "http://target.example.test:5001", "source.example.test", "http:");
+    assert.equal(hostname, "target.example.test");
+    assert.deepEqual(parseDockerPort("0.0.0.0:6462->8080/tcp", hostname), {
+        url: "http://target.example.test:6462",
+        display: "6462",
+    });
+});
+
+test("keeps the browser hostname for the local instance", () => {
+    assert.equal(resolveEndpointHostname("", undefined, "local.example.test", "https:"), "local.example.test");
+});

--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -460,6 +460,21 @@ export function parseDockerPort(input : string, hostname : string) {
     };
 }
 
+export function resolveEndpointHostname(endpoint: string, agentUrl: string | undefined, localHostname: string, protocol = "http:"): string {
+    if (!endpoint) {
+        return localHostname;
+    }
+    try {
+        return new URL(agentUrl || `${protocol}//${endpoint}`).hostname;
+    } catch {
+        const ipv6 = /^\[([^\]]+)\](?::\d+)?$/.exec(endpoint);
+        if (ipv6) {
+            return `[${ipv6[1]}]`;
+        }
+        return endpoint.replace(/:\d+$/, "");
+    }
+}
+
 export function envsubst(string : string, variables : LooseObject) : string {
     return replaceVariablesSync(string, variables)[0];
 }

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -239,7 +239,7 @@
 <script>
 import { defineComponent } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { parseDockerPort, imageRegistryUrl } from "../../../common/util-common";
+import { parseDockerPort, imageRegistryUrl, resolveEndpointHostname } from "../../../common/util-common";
 import VolumeBrowser from "./VolumeBrowser.vue";
 import ContainerStatsBadge from "./ContainerStatsBadge.vue";
 
@@ -302,6 +302,10 @@ export default defineComponent({
             type: String,
             default: "",
         },
+        endpoint: {
+            type: String,
+            default: "",
+        },
         showResourceStats: {
             type: Boolean,
             default: false,
@@ -360,16 +364,8 @@ export default defineComponent({
             }
         },
 
-        endpoint() {
-            return this.$parent.$parent.endpoint;
-        },
-
         stack() {
             return this.$parent.$parent.stack;
-        },
-
-        stackName() {
-            return this.$parent.$parent.stack.name;
         },
 
         service() {
@@ -453,7 +449,8 @@ export default defineComponent({
             });
         },
         parsePort(port) {
-            return parseDockerPort(port, location.hostname);
+            const hostname = resolveEndpointHostname(this.endpoint, this.$root.agentList[this.endpoint]?.url, location.hostname, location.protocol);
+            return parseDockerPort(port, hostname);
         },
         remove() {
             delete this.jsonObject.services[this.name];
@@ -462,18 +459,34 @@ export default defineComponent({
             this.$refs.volumeBrowser?.open(destination);
         },
         formatBytes(bytes) {
-            if (bytes >= 1024 ** 4) return (bytes / 1024 ** 4).toFixed(1) + " TB";
-            if (bytes >= 1024 ** 3) return (bytes / 1024 ** 3).toFixed(1) + " GB";
-            if (bytes >= 1024 ** 2) return Math.round(bytes / 1024 ** 2) + " MB";
-            if (bytes >= 1024) return Math.round(bytes / 1024) + " KB";
+            if (bytes >= 1024 ** 4) {
+                return (bytes / 1024 ** 4).toFixed(1) + " TB";
+            }
+            if (bytes >= 1024 ** 3) {
+                return (bytes / 1024 ** 3).toFixed(1) + " GB";
+            }
+            if (bytes >= 1024 ** 2) {
+                return Math.round(bytes / 1024 ** 2) + " MB";
+            }
+            if (bytes >= 1024) {
+                return Math.round(bytes / 1024) + " KB";
+            }
             return bytes + " B";
         },
         relativeTime(iso) {
-            if (!iso) return null;
+            if (!iso) {
+                return null;
+            }
             const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
-            if (diff < 60)    return diff + "s";
-            if (diff < 3600)  return Math.floor(diff / 60) + " min";
-            if (diff < 86400) return Math.floor(diff / 3600) + " h";
+            if (diff < 60) {
+                return diff + "s";
+            }
+            if (diff < 3600) {
+                return Math.floor(diff / 60) + " min";
+            }
+            if (diff < 86400) {
+                return Math.floor(diff / 3600) + " h";
+            }
             return Math.floor(diff / 86400) + " j";
         },
     }

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -227,6 +227,7 @@
                                 :volume-loading="volumeUsageLoading"
                                 :action-processing="serviceActionProcessing[name] === true"
                                 :stack-name="stack.name"
+                                :endpoint="endpoint"
                                 :show-resource-stats="!endpoint"
                                 @auto-update-change="setServiceAutoUpdate(name, $event)"
                                 @refresh-volume-usage="loadVolumeUsage"


### PR DESCRIPTION
## Résumé

- transmet explicitement l’endpoint de la stack à chaque carte de conteneur
- construit les liens des ports publiés avec l’hôte de l’instance qui exécute réellement la stack
- conserve l’hôte du navigateur uniquement pour l’instance locale
- ajoute un test de non-régression couvrant une interface ouverte depuis une instance différente de la cible
- simplifie au passage l’accès au nom de stack et normalise les fonctions de formatage concernées

## Validation

- `node --import tsx --test common/util-common.test.ts`
- `npm run check-ts`
- lint ciblé sans erreur
- `npm run build:frontend`