### PR TITLE
Optimise la mesure des volumes et l’état Kula

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -21,10 +21,7 @@ import { InteractiveTerminal, Terminal } from "./terminal";
 import childProcessAsync from "promisify-child-process";
 import { Settings } from "./settings";
 import { intervals } from "./low-power";
-import { execFile } from "child_process";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
+import { getVolumeSourceSize } from "./volume-usage";
 
 // ─── Cache court de getServiceStatusList (point #9 : éviter `docker inspect`
 // de TOUS les containers à chaque refresh / chaque onglet ouvert). TTL piloté
@@ -855,31 +852,11 @@ export class Stack {
         }).filter((container: StackContainerVolumeUsage) => container.mounts.length > 0)
             .sort((a: StackContainerVolumeUsage, b: StackContainerVolumeUsage) => a.service.localeCompare(b.service));
 
-        const sizeCache = new Map<string, Promise<{ size: number | null; error?: string }>>();
+        const sizeCache = new Map<string, ReturnType<typeof getVolumeSourceSize>>();
         const measure = (volume: StackVolumeMountUsage) => {
             const src = volume.type === "volume" && volume.name ? volume.name : volume.source;
             if (!sizeCache.has(src)) {
-                sizeCache.set(src, (async () => {
-                    try {
-                        const { stdout } = await execFileAsync("docker", [
-                            "run",
-                            "--rm",
-                            "--network",
-                            "none",
-                            "-v",
-                            `${src}:/mnt:ro`,
-                            process.env.DOCKGE_VOLUME_HELPER_IMAGE || "busybox:stable",
-                            "du",
-                            "-sb",
-                            "/mnt",
-                        ], { timeout: 120_000 });
-                        const first = String(stdout).trim().split(/\s+/)[0];
-                        const size = Number.parseInt(first, 10);
-                        return { size: Number.isFinite(size) ? size : null };
-                    } catch (e) {
-                        return { size: null, error: e instanceof Error ? e.message : String(e) };
-                    }
-                })());
+                sizeCache.set(src, getVolumeSourceSize(src));
             }
             return sizeCache.get(src)!;
         };

--- a/backend/volume-usage.test.ts
+++ b/backend/volume-usage.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { CommandRunner, measureVolumeSource } from "./volume-usage";
+
+describe("volume usage measurement", () => {
+    test("limits the helper and keeps the scan on one filesystem", async () => {
+        const calls: Array<{ file: string; args: string[]; timeout: number }> = [];
+        const runner: CommandRunner = async (file, args, options) => {
+            calls.push({
+                file,
+                args,
+                timeout: options.timeout
+            });
+            if (args[0] === "run") {
+                return { stdout: "12345\t/mnt\n" };
+            }
+            throw new Error("already removed");
+        };
+
+        const result = await measureVolumeSource("/srv/app", {
+            commandRunner: runner,
+            helperName: "dockge-volume-test",
+            timeoutMs: 5_000,
+        });
+
+        assert.deepEqual(result, { size: 12345 });
+        assert.deepEqual(calls[0], {
+            file: "docker",
+            args: [
+                "run", "--rm", "--name", "dockge-volume-test",
+                "--network", "none", "--read-only",
+                "--cpus", "0.50", "--memory", "128m", "--pids-limit", "32",
+                "-v", "/srv/app:/mnt:ro",
+                "busybox:stable", "du", "-sbx", "/mnt",
+            ],
+            timeout: 5_000,
+        });
+        assert.deepEqual(calls[1].args, [ "rm", "-f", "dockge-volume-test" ]);
+    });
+
+    test("force-removes the helper after a timeout or failure", async () => {
+        const calls: string[][] = [];
+        const runner: CommandRunner = async (_file, args) => {
+            calls.push(args);
+            if (args[0] === "run") {
+                throw new Error("timed out");
+            }
+            return { stdout: "" };
+        };
+
+        const result = await measureVolumeSource("/mnt", {
+            commandRunner: runner,
+            helperName: "dockge-volume-timeout",
+        });
+
+        assert.equal(result.size, null);
+        assert.match(result.error ?? "", /timed out/);
+        assert.deepEqual(calls.at(-1), [ "rm", "-f", "dockge-volume-timeout" ]);
+    });
+});

--- a/backend/volume-usage.ts
+++ b/backend/volume-usage.ts
@@ -1,0 +1,130 @@
+import { execFile } from "child_process";
+import { randomUUID } from "crypto";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export interface VolumeUsageResult {
+    size: number | null;
+    error?: string;
+}
+
+interface CommandOptions {
+    timeout: number;
+}
+
+export type CommandRunner = (
+    file: string,
+    args: string[],
+    options: CommandOptions
+) => Promise<{ stdout: string | Buffer }>;
+
+interface MeasureOptions {
+    commandRunner?: CommandRunner;
+    helperName?: string;
+    timeoutMs?: number;
+}
+
+const CACHE_TTL_MS = 5 * 60_000;
+const ERROR_CACHE_TTL_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const cache = new Map<string, { expiresAt: number; result: Promise<VolumeUsageResult> }>();
+
+let activeMeasurements = 0;
+const measurementQueue: Array<() => void> = [];
+
+function runWithMeasurementSlot<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const run = () => {
+            activeMeasurements++;
+            task().then(resolve, reject).finally(() => {
+                activeMeasurements--;
+                measurementQueue.shift()?.();
+            });
+        };
+
+        if (activeMeasurements < 1) {
+            run();
+        } else {
+            measurementQueue.push(run);
+        }
+    });
+}
+
+const defaultCommandRunner: CommandRunner = async (file, args, options) => {
+    const result = await execFileAsync(file, args, options);
+    return { stdout: result.stdout };
+};
+
+/**
+ * Measure one Docker volume or bind mount without allowing the helper to
+ * monopolize the host or survive a timeout.
+ */
+export async function measureVolumeSource(source: string, options: MeasureOptions = {}): Promise<VolumeUsageResult> {
+    const commandRunner = options.commandRunner ?? defaultCommandRunner;
+    const helperName = options.helperName ?? `dockge-volume-usage-${process.pid}-${randomUUID()}`;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    try {
+        const { stdout } = await commandRunner("docker", [
+            "run",
+            "--rm",
+            "--name",
+            helperName,
+            "--network",
+            "none",
+            "--read-only",
+            "--cpus",
+            "0.50",
+            "--memory",
+            "128m",
+            "--pids-limit",
+            "32",
+            "-v",
+            `${source}:/mnt:ro`,
+            process.env.DOCKGE_VOLUME_HELPER_IMAGE || "busybox:stable",
+            "du",
+            "-sbx",
+            "/mnt",
+        ], { timeout: timeoutMs });
+        const first = String(stdout).trim().split(/\s+/)[0];
+        const size = Number.parseInt(first, 10);
+        return {
+            size: Number.isFinite(size) ? size : null
+        };
+    } catch (e) {
+        return {
+            size: null,
+            error: e instanceof Error ? e.message : String(e)
+        };
+    } finally {
+        // `docker run --rm` normally removes the helper. A timed-out client can
+        // leave it running, so force cleanup by its deterministic name.
+        await commandRunner("docker", [ "rm", "-f", helperName ], { timeout: 10_000 }).catch(() => undefined);
+    }
+}
+
+export function getVolumeSourceSize(source: string): Promise<VolumeUsageResult> {
+    const now = Date.now();
+    const cached = cache.get(source);
+    if (cached && cached.expiresAt > now) {
+        return cached.result;
+    }
+
+    const result = runWithMeasurementSlot(() => measureVolumeSource(source));
+    const entry = {
+        expiresAt: now + CACHE_TTL_MS,
+        result
+    };
+    cache.set(source, entry);
+    void result.then(value => {
+        if (value.error) {
+            entry.expiresAt = Date.now() + ERROR_CACHE_TTL_MS;
+        }
+    });
+    return result;
+}
+
+export function clearVolumeUsageCache(): void {
+    cache.clear();
+}

--- a/frontend/src/layouts/Layout.vue
+++ b/frontend/src/layouts/Layout.vue
@@ -268,7 +268,7 @@ export default {
         this.fetchKulaStatus();
         // Poll system stats : cadence selon le mode + pause si onglet caché
         this.statsPoller = makePoller({
-            fetch:    () => this.fetchSystemStats(),
+            fetch:    () => Promise.all([ this.fetchSystemStats(), this.fetchKulaStatus() ]),
             interval: POLL.system,
         });
         this.statsPoller.start();
@@ -327,7 +327,11 @@ export default {
                 const data = await res.json();
                 if (data.ok) this.systemStats = data.data;
                 setLowPower(data.lowPowerMode);
-            } catch { /* silencieux */ }
+            } catch {
+                // Ne jamais conserver un lien Kula périmé si le service est
+                // désactivé, supprimé ou temporairement injoignable.
+                this.kulaUrl = null;
+            }
         },
 
         statClass(percent) {


### PR DESCRIPTION
## Résumé

- conserve le calcul réel de la taille des volumes tout en empêchant un bind mount parent de retraverser ses systèmes de fichiers enfants
- exécute une seule mesure à la fois, limite le conteneur auxiliaire à 0,5 CPU, 128 Mio et 32 processus, puis met les résultats en cache pendant cinq minutes
- attribue un nom déterministe à chaque conteneur BusyBox et force sa suppression après succès, erreur ou expiration
- actualise l’état Kula avec la barre système et retire le lien périmé lorsque Kula est désactivé ou indisponible

## Validation

- `npx tsx --test backend/volume-usage.test.ts`
- `npm run check-ts`
- `npx eslint backend/volume-usage.ts backend/volume-usage.test.ts`
- `npm run build:frontend`
- `git diff --check`
- validation réelle : mesure de `/mnt` terminée en 369 ms avec `du -sbx`, contre plus de six minutes auparavant
