### PR TITLE
Réorganiser la présentation des fonctionnalités dans les README

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -28,11 +28,13 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 | Domaine | Dockge Enhanced ajoute |
 | --- | --- |
 | **Multi-instance** | Noms d'instances, sélection multiple et regroupement coloré par serveur, copie/migration transactionnelle, jobs reprenables et réplication froide automatique sans dépôt à configurer |
+| **Gestion des stacks** | Actions par stack et conteneur, Build + Recreate, planification, notes, Git manuel et protections pour les services partageant le réseau d'un VPN |
 | **Sauvegarde & reprise** | Restic multi-destination, volumes, cohérence par stack, restauration sélective, tests et diffs de snapshots |
+| **Automatisation & audit** | API REST limitée par droits et stacks, webhooks par stack, exemples Home Assistant et historique central avec origine et durée |
+| **Ressources Docker** | Images, volumes, conteneurs hors Dockge et réseaux, actions groupées, auto-prune et protections contre les suppressions risquées |
 | **Images & sécurité** | Surveillance des mises à jour, auto-update avec rollback, scan Trivy et exceptions CVE |
 | **Supervision** | Stats système, stacks et conteneurs, crash loops, healthchecks avec auto-heal, logs enrichis et Kula optionnel |
-| **Gestion Docker** | Images, volumes, conteneurs et réseaux hors Dockge, actions Compose par conteneur, actions groupées et protections contre les suppressions risquées |
-| **Automatisation & intégrations** | API REST et webhooks à droits limités, Home Assistant, Git manuel, PlugNPiN optionnel et assistant de labels |
+| **Intégrations** | PlugNPiN optionnel et assistant de labels par service pour Nginx Proxy Manager, Pi-hole et AdGuard Home |
 | **Notifications & accès** | Discord, Apprise, 2FA, trusted proxy, Turnstile et clients mobiles |
 
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 | Area | Dockge Enhanced adds |
 | --- | --- |
 | **Multi-instance** | Instance names, multi-server selection and color-coded grouping, transactional copy/migration, resumable jobs, and automatic cold replication with no repository setup |
+| **Stack management** | Per-stack and per-container actions, Build + Recreate, scheduling, notes, manual Git, and safeguards for services sharing a VPN network |
 | **Backup & recovery** | Multi-destination Restic, volumes, per-stack consistency, selective restore, snapshot tests and diffs |
+| **Automation & audit** | REST API scoped by permissions and stacks, per-stack webhooks, Home Assistant examples, and centralized history with origin and duration |
+| **Docker resources** | Images, volumes, unmanaged containers and networks, bulk actions, auto-prune, and safeguards for risky deletions |
 | **Images & security** | Update monitoring, auto-update with rollback, Trivy scans, and CVE exceptions |
 | **Monitoring** | System, stack, and container stats, crash loops, healthcheck auto-heal, enhanced logs, and optional Kula integration |
-| **Docker management** | Images, volumes, unmanaged containers and networks, per-container Compose actions, bulk actions, and safeguards for risky deletions |
-| **Automation & integrations** | Scoped REST API and webhooks, Home Assistant, manual Git, optional PlugNPiN and label assistant |
+| **Integrations** | Optional PlugNPiN and per-service label assistant for Nginx Proxy Manager, Pi-hole, and AdGuard Home |
 | **Notifications & access** | Discord, Apprise, 2FA, trusted proxy, Turnstile, and mobile clients |
 
 


### PR DESCRIPTION
## Résumé

- sépare la gestion des stacks, l’automatisation, les ressources Docker et les intégrations ;
- met en avant Build + Recreate, les notes, Git, l’API, les webhooks et l’audit ;
- conserve une structure strictement symétrique entre les README français et anglais.

## Validation

- relecture croisée des deux tableaux ;
- `git diff --check`.