### PR TITLE
Corriger l’authentification des outils HTTP

### DIFF
--- a/frontend/src/components/StackGitPanel.vue
+++ b/frontend/src/components/StackGitPanel.vue
@@ -130,7 +130,7 @@ export default {
             const response = await fetch(`/api/stack-tools/${encodeURIComponent(this.stackName)}/git${path}`, {
                 method,
                 headers: {
-                    "Authorization": `Bearer ${this.$root.getSocket().token}`,
+                    "Authorization": `Bearer ${this.$root.getAuthToken()}`,
                     ...(body === undefined ? {} : { "Content-Type": "application/json" }),
                 },
                 body: body === undefined ? undefined : JSON.stringify(body),

--- a/frontend/src/components/settings/Automation.vue
+++ b/frontend/src/components/settings/Automation.vue
@@ -243,7 +243,7 @@ export default {
             const response = await fetch(`/api/automation${path}`, {
                 method,
                 headers: {
-                    "Authorization": `Bearer ${this.$root.getSocket().token}`,
+                    "Authorization": `Bearer ${this.$root.getAuthToken()}`,
                     ...(body === undefined ? {} : { "Content-Type": "application/json" }),
                 },
                 body: body === undefined ? undefined : JSON.stringify(body),

--- a/frontend/src/components/settings/Integrations.vue
+++ b/frontend/src/components/settings/Integrations.vue
@@ -231,7 +231,7 @@ export default {
     },
     methods: {
         async api(method, path, body) {
-            const token = this.$root.getSocket().token;
+            const token = this.$root.getAuthToken();
             const response = await fetch(`/api/integrations${path}`, {
                 method,
                 headers: {

--- a/frontend/src/mixins/socket.ts
+++ b/frontend/src/mixins/socket.ts
@@ -222,7 +222,9 @@ export default defineComponent({
                 this.loggedIn = true;
                 this.storage().token = "autoLogin";
                 this.socketIO.token = "autoLogin";
-                if (username) this.username = username;
+                if (username) {
+                    this.username = username;
+                }
                 this.allowLoginDialog = false;
                 this.afterLogin();
             });
@@ -299,6 +301,16 @@ export default defineComponent({
          */
         storage() : Storage {
             return (this.remember) ? localStorage : sessionStorage;
+        },
+
+        /**
+         * Return the JWT used by authenticated HTTP APIs.
+         * Socket.IO keeps its own connection object, but the Dockge JWT is
+         * persisted in the storage selected by the "remember me" setting.
+         */
+        getAuthToken() : string {
+            const token = this.storage().token;
+            return token && token !== "autoLogin" ? token : "";
         },
 
         getSocket() : Socket {

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -923,7 +923,7 @@ export default {
     methods: {
         async loadPlugNPiNIntegrationStatus() {
             try {
-                const token = this.$root.getSocket().token;
+                const token = this.$root.getAuthToken();
                 const response = await fetch("/api/integrations/plugnpin/settings", {
                     headers: { "Authorization": `Bearer ${token}` },
                 });


### PR DESCRIPTION
## Résumé

- centralise la récupération du JWT HTTP depuis le stockage actif de Dockge ;
- corrige le panneau Git, Paramètres → Automatisation et Paramètres → Intégrations ;
- corrige aussi la détection PlugNPiN depuis la page Compose ;
- respecte le choix « Se souvenir de moi » entre `localStorage` et `sessionStorage`.

## Cause

Les nouveaux appels utilisaient `getSocket().token`, mais l’objet Socket.IO ne contient pas le JWT Dockge. Les requêtes partaient donc avec `Bearer undefined`, ce qui provoquait « Token invalide ou expiré ».

## Validation

- `npm run check-ts`
- lint ciblé des cinq fichiers modifiés : aucune erreur
- `npm run build:frontend`
- `node --import tsx --test frontend/src/plugnpin-labels.test.ts`
- `git diff --check`
- vérification statique : aucun appel résiduel à `getSocket().token`