### PR TITLE
ci: autoriser les groupes Dependabot sûrs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Activer la fusion squash pour les mises à jour patch et mineures
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.dependency-group == 'minor-and-patch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -67,7 +68,8 @@ jobs:
         if: >-
           steps.pr.outputs.eligible == 'true' &&
           (steps.fallback-metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.fallback-metadata.outputs.update-type == 'version-update:semver-minor')
+           steps.fallback-metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.fallback-metadata.outputs.dependency-group == 'minor-and-patch')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ steps.pr.outputs.url }}


### PR DESCRIPTION
## Objectif

Prendre en charge les mises à jour Docker groupées pour lesquelles Dependabot fournit le groupe `minor-and-patch` sans renseigner `update-type`.

## Sécurité

- seules les PR créées par Dependabot sont concernées ;
- le groupe doit être explicitement `minor-and-patch` ;
- les mises à jour majeures restent exclues par la configuration Dependabot ;
- la fusion reste conditionnée à la réussite de tous les contrôles du dépôt ;
- la fusion utilise le mode squash.

## Validation

- syntaxe vérifiée avec `actionlint` ;
- absence d’erreur de whitespace vérifiée avec `git diff --check`.