### PR TITLE
Ajouter Dozzle aux crédits

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -480,6 +480,7 @@ Les clients tiers commerciaux sont autorisés par la licence, mais ne doivent pa
 - [**Restic**](https://restic.net/) — outil de backup chiffré
 - [**Apprise**](https://github.com/caronc/apprise-api) — passerelle de notifications multi-plateformes
 - [**Kula**](https://github.com/c0m4r/kula) par c0m4r — monitoring système léger (AGPLv3)
+- [**Dozzle**](https://github.com/amir20/dozzle) par Amir Rajan — visualisation en temps réel des logs Docker (licence MIT)
 - [**PlugNPiN**](https://github.com/DeepSpace2/PlugNPiN) par DeepSpace2 — automatisation optionnelle du DNS et de Nginx Proxy Manager (GPLv3)
 
 ---

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Commercial third-party clients are allowed by the license, but must not imply of
 - [**Restic**](https://restic.net/) — encrypted backup tool
 - [**Apprise**](https://github.com/caronc/apprise-api) — multi-platform notification gateway
 - [**Kula**](https://github.com/c0m4r/kula) by c0m4r — lightweight system monitor (AGPLv3)
+- [**Dozzle**](https://github.com/amir20/dozzle) by Amir Rajan — real-time Docker log viewer (MIT licence)
 - [**PlugNPiN**](https://github.com/DeepSpace2/PlugNPiN) by DeepSpace2 — optional DNS and Nginx Proxy Manager automation (GPLv3)
 
 ---


### PR DESCRIPTION
## Résumé

- ajoute Dozzle et son auteur aux crédits du README anglais ;
- ajoute la même attribution dans le README français ;
- précise la licence MIT et le rôle de visualisation des logs Docker.

## Validation

- `git diff --check`
- cohérence des liens et formulations FR/EN
