### PR TITLE
Automatiser les PR Dependabot validées

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,15 +23,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Activer la fusion squash pour les mises à jour patch et mineures
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.dependency-group == 'minor-and-patch'
+      - name: Activer la fusion squash après les contrôles requis
+        # Les mises à jour indirectes n'ont pas toujours de type sémantique.
+        # La protection de main attend les builds et le scan de sécurité avant la fusion.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if ! gh pr merge --auto --squash --delete-branch "$PR_URL"; then
-            echo "::notice::L'auto-merge natif est indisponible; la fusion sera réévaluée à la fin des contrôles."
-          fi
+          gh pr merge --auto --squash --delete-branch "$PR_URL"

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -3,21 +3,6 @@ name: Validation Docker PR
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "Dockerfile"
-      - "Dockerfile.*"
-      - "**/Dockerfile"
-      - "**/Dockerfile.*"
-      - "docker-compose.yml"
-      - "compose.yml"
-      - "package.json"
-      - "package-lock.json"
-      - "pnpm-lock.yaml"
-      - "requirements*.txt"
-      - "**/requirements*.txt"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/docker-pr.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Résumé

- active la fusion automatique pour toutes les PR Dependabot internes, y compris les mises à jour indirectes sans type sémantique ;
- rend visible toute erreur d’activation au lieu de la masquer ;
- la protection de `main` impose désormais le build TypeScript, le build Docker multi-architecture et le scan des nouvelles vulnérabilités HIGH/CRITICAL avant fusion.

## Validation

- `git diff --check`
- analyse YAML locale
- vérification de la protection de branche via l’API GitHub.