### PR TITLE
Épingler les stacks et compléter la coloration des fichiers

### DIFF
--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -164,8 +164,10 @@
                     :isSelectMode="selectMode"
                     :isSelected="isSelected"
                     :scheduled="isStackScheduled(item.name, item.endpoint)"
+                    :pinned="isStackPinned(item)"
                     :select="select"
                     :deselect="deselect"
+                    @toggle-pin="toggleStackPin(item)"
                 />
             </template>
         </div>
@@ -209,6 +211,7 @@ export default {
             stackAgentFilters: this.loadAgentFilters(),
             stackGroupByAgent: this.loadStackGrouping(),
             stackSort: this.loadStackSort(),
+            pinnedStacks: this.loadPinnedStacks(),
             filterState: {
                 status: null,
                 active: null,
@@ -280,6 +283,10 @@ export default {
             });
 
             result.sort((m1, m2) => {
+                const pinnedOrder = Number(this.isStackPinned(m2)) - Number(this.isStackPinned(m1));
+                if (pinnedOrder !== 0) {
+                    return pinnedOrder;
+                }
 
                 if (this.stackSort === "name") {
                     return m1.name.localeCompare(m2.name, undefined, { sensitivity: "base" });
@@ -495,6 +502,27 @@ export default {
         window.removeEventListener("scroll", this.onScroll);
     },
     methods: {
+        stackPinKey(stack) {
+            return JSON.stringify([ stack.endpoint || "", stack.name ]);
+        },
+        loadPinnedStacks() {
+            try {
+                const stored = JSON.parse(localStorage.getItem("pinnedStacks") || "[]");
+                return Array.isArray(stored) ? stored.filter(key => typeof key === "string") : [];
+            } catch {
+                return [];
+            }
+        },
+        isStackPinned(stack) {
+            return this.pinnedStacks.includes(this.stackPinKey(stack));
+        },
+        toggleStackPin(stack) {
+            const key = this.stackPinKey(stack);
+            this.pinnedStacks = this.pinnedStacks.includes(key)
+                ? this.pinnedStacks.filter(candidate => candidate !== key)
+                : [ ...this.pinnedStacks, key ];
+            localStorage.setItem("pinnedStacks", JSON.stringify(this.pinnedStacks));
+        },
         loadStackSort() {
             const stored = localStorage.getItem("stackSort");
             const migrationKey = "stackSortNameDefaultV1";

--- a/frontend/src/components/StackListItem.vue
+++ b/frontend/src/components/StackListItem.vue
@@ -26,6 +26,18 @@
                 <span v-else>{{ endpointDisplay }}</span>
             </div>
         </div>
+        <button
+            class="stack-pin-button"
+            :class="{ 'stack-pin-button--pinned': pinned }"
+            type="button"
+            :title="$t(pinned ? 'stackUnpin' : 'stackPin')"
+            :aria-label="$t(pinned ? 'stackUnpin' : 'stackPin')"
+            :aria-pressed="pinned"
+            @click.stop="$emit('toggle-pin')"
+            @keydown.stop
+        >
+            <font-awesome-icon icon="thumbtack" />
+        </button>
     </div>
 </template>
 
@@ -55,6 +67,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        pinned: {
+            type: Boolean,
+            default: false,
+        },
         agentColors: {
             type: Object,
             default: null,
@@ -80,6 +96,7 @@ export default {
             default: () => {}
         },
     },
+    emits: [ "toggle-pin" ],
     data() {
         return {
             isCollapsed: true,
@@ -209,6 +226,8 @@ export default {
     }
     .title {
         margin-top: -4px;
+        min-width: 0;
+        flex: 1;
 
         > span:first-child {
             color: var(--agent-color, inherit);
@@ -233,6 +252,32 @@ export default {
     .scheduled-indicator {
         color: #3b82f6;
         font-size: .78rem;
+    }
+
+    .stack-pin-button {
+        flex: 0 0 auto;
+        border: 0;
+        padding: 6px;
+        background: transparent;
+        color: $dark-font-color3;
+        opacity: 0;
+        transition: opacity .15s ease, color .15s ease;
+
+        &:focus-visible,
+        &--pinned {
+            opacity: 1;
+            color: #d97706;
+        }
+    }
+
+    &:hover .stack-pin-button {
+        opacity: 1;
+    }
+
+    @media (hover: none) {
+        .stack-pin-button {
+            opacity: .6;
+        }
     }
 }
 

--- a/frontend/src/components/VolumeBrowser.vue
+++ b/frontend/src/components/VolumeBrowser.vue
@@ -153,7 +153,7 @@ export default {
                 extensions.push(yaml());
             } else if ([ "json", "jsonc" ].includes(extension)) {
                 extensions.push(json());
-            } else if (extension === "py") {
+            } else if (extension === "py" || fileName === ".env" || fileName.startsWith(".env.")) {
                 extensions.push(python());
             } else if ([ "sh", "bash", "zsh" ].includes(extension) || [ ".bashrc", ".zshrc", "dockerfile" ].includes(fileName)) {
                 extensions.push(StreamLanguage.define(shell));

--- a/frontend/src/icon.ts
+++ b/frontend/src/icon.ts
@@ -97,6 +97,7 @@ import {
     faDiagramProject,
     faCodeBranch,
     faCloudArrowUp,
+    faThumbtack,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -195,6 +196,7 @@ library.add(
     faDiagramProject,
     faCodeBranch,
     faCloudArrowUp,
+    faThumbtack,
 );
 
 export { FontAwesomeIcon };

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -1021,5 +1021,7 @@
     "stackGit.pushConfirm": "Push the current branch using the host's configured Git credentials?",
     "stackGit.history": "History",
     "stackGit.restore": "Restore files",
-    "stackGit.restoreConfirm": "Restore tracked stack files from commit {hash}? The worktree must be clean and Compose is validated with automatic rollback on failure."
+    "stackGit.restoreConfirm": "Restore tracked stack files from commit {hash}? The worktree must be clean and Compose is validated with automatic rollback on failure.",
+    "stackPin": "Pin this stack to the top of the list",
+    "stackUnpin": "Unpin this stack"
 }

--- a/frontend/src/lang/es.json
+++ b/frontend/src/lang/es.json
@@ -138,5 +138,7 @@
     "New Container Name...": "Nombre del nuevo Container...",
     "Network name...": "Nombre de la red...",
     "Select a network...": "Selecciona una red...",
-    "NoNetworksAvailable": "No hay redes disponibles. Primero debes agregar redes internas o habilitar redes externas en el lado derecho."
+    "NoNetworksAvailable": "No hay redes disponibles. Primero debes agregar redes internas o habilitar redes externas en el lado derecho.",
+    "stackPin": "Fijar esta pila en la parte superior de la lista",
+    "stackUnpin": "Dejar de fijar esta pila"
 }

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -1015,5 +1015,7 @@
     "stackGit.pushConfirm": "Pousser la branche actuelle avec les identifiants Git configurés sur l’hôte ?",
     "stackGit.history": "Historique",
     "stackGit.restore": "Restaurer les fichiers",
-    "stackGit.restoreConfirm": "Restaurer les fichiers suivis de la stack depuis le commit {hash} ? Le répertoire doit être propre et Compose sera validé avec rollback automatique en cas d’échec."
+    "stackGit.restoreConfirm": "Restaurer les fichiers suivis de la stack depuis le commit {hash} ? Le répertoire doit être propre et Compose sera validé avec rollback automatique en cas d’échec.",
+    "stackPin": "Épingler cette stack en haut de la liste",
+    "stackUnpin": "Désépingler cette stack"
 }


### PR DESCRIPTION
## Modifications

- ajoute une punaise sur chaque stack pour la maintenir en tête du panneau latéral ;
- conserve les préférences dans le navigateur et distingue les stacks de même nom selon leur instance ;
- applique la priorité des stacks épinglées avec les tris et regroupements existants ;
- complète la coloration syntaxique de l’éditeur de fichiers pour les fichiers `.env` ;
- ajoute les libellés français, anglais et espagnols.

## Expérience utilisateur

Les stacks utilisées fréquemment restent accessibles en haut de liste. La punaise est visible au survol, au clavier, sur les écrans tactiles et en permanence lorsqu’elle est active.

## Validation

- `git diff --check`
- `npm run check-ts`
- lint ciblé sur les fichiers modifiés
- `npm run build:frontend`
- construction de l’image Docker
- vérification du conteneur sain et du bundle servi
