### PR TITLE
Adapter la colonne des stacks à la hauteur de la page

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -43,7 +43,7 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 <details>
 <summary><strong>Mostrar el catálogo completo de funcionalidades</strong></summary>
 
-**2026-08-11 — Columna de stacks más densa y redimensionable** — El panel de escritorio muestra más stacks en la misma altura y sustituye sus columnas Bootstrap fijas por un separador accesible con ratón y teclado. La anchura de la columna está limitada para conservar ambos paneles, se recuerda por navegador y se ignora en móviles, donde la navegación apilada existente no cambia.
+**2026-08-11 — Columna de stacks más densa y redimensionable** — El panel de escritorio muestra más stacks en la misma altura y sustituye sus columnas Bootstrap fijas por un separador accesible con ratón y teclado. La anchura de la columna está limitada para conservar ambos paneles y se recuerda por navegador, mientras que su altura sigue el contenido real de Compose, los contenedores y el terminal en lugar de detenerse en el viewport. En móviles, la navegación apilada existente no cambia.
 
 **2026-08-09 — Espacio Registros y Compose más denso y redimensionable** — Las páginas de stack reducen sus espacios y sustituyen la división fija por mitades en escritorio por un separador arrastrable y accesible mediante teclado, cuya posición se recuerda en el navegador. Los registros pueden ocupar toda la pantalla, mientras que el panel Compose puede contraerse y restaurarse cuando solo importa la salida de ejecución. Una acción dedicada copia directamente el YAML Compose sin formato, sin números de línea ni artefactos de selección visual. En móviles, los paneles permanecen apilados y adaptados al uso táctil.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,7 +41,7 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 <details>
 <summary><strong>Afficher le catalogue complet des fonctionnalités</strong></summary>
 
-**2026-08-11 — Colonne des stacks plus dense et redimensionnable** — Le tableau de bord sur ordinateur affiche davantage de stacks à hauteur égale et remplace ses colonnes Bootstrap fixes par une poignée accessible à la souris et au clavier. La largeur de la colonne est bornée pour préserver les deux panneaux, mémorisée par navigateur et ignorée sur mobile, où la navigation empilée existante reste inchangée.
+**2026-08-11 — Colonne des stacks plus dense et redimensionnable** — Le tableau de bord sur ordinateur affiche davantage de stacks à hauteur égale et remplace ses colonnes Bootstrap fixes par une poignée accessible à la souris et au clavier. La largeur de la colonne est bornée pour préserver les deux panneaux et mémorisée par navigateur, tandis que sa hauteur suit le contenu réel de Compose, des conteneurs et du terminal au lieu de s’arrêter au viewport. Sur mobile, la navigation empilée existante reste inchangée.
 
 **2026-08-09 — Espace Logs et Compose plus dense et redimensionnable** — Les pages de stack réduisent leurs espacements et remplacent le partage fixe en deux moitiés sur ordinateur par une poignée accessible au clavier, dont la position est mémorisée dans le navigateur. Les logs peuvent occuper tout l’écran, tandis que l’encart Compose peut être réduit puis restauré lorsque seule la sortie d’exécution est utile. Une action dédiée copie directement le YAML Compose brut, sans gouttière de numéros de ligne ni artefact de sélection visuelle. Sur mobile, les encarts restent empilés et adaptés au tactile.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 <details>
 <summary><strong>Show the complete feature catalogue</strong></summary>
 
-**2026-08-11 — Denser, resizable stack sidebar** — The desktop dashboard shows more stacks in the same height and replaces its fixed Bootstrap columns with a draggable, keyboard-accessible divider. The sidebar width is constrained to preserve both panels, remembered per browser and ignored on mobile, where the existing stacked navigation remains unchanged.
+**2026-08-11 — Denser, resizable stack sidebar** — The desktop dashboard shows more stacks in the same height and replaces its fixed Bootstrap columns with a draggable, keyboard-accessible divider. The sidebar width is constrained to preserve both panels and remembered per browser, while its height follows the actual Compose, container and terminal content instead of stopping at the viewport. On mobile, the existing stacked navigation remains unchanged.
 
 **2026-08-09 — Denser, resizable Logs and Compose workspace** — Stack pages use tighter spacing and replace the fixed half-width desktop layout with a keyboard-accessible draggable divider whose position is remembered in the browser. Logs can take the entire screen, while the Compose panel can be collapsed and restored when only runtime output matters. A dedicated action copies the raw Compose YAML directly, without line-number gutters or visual-selection artefacts. Mobile layouts remain stacked and touch-friendly.
 

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="shadow-box mb-3" :style="boxStyle">
+    <div class="shadow-box">
         <div class="list-header">
             <div class="header-top">
                 <!-- TODO -->
@@ -206,7 +206,6 @@ export default {
             selectAll: false,
             disableSelectAllWatcher: false,
             selectedStacks: {},
-            windowTop: 0,
             stackStatusFilter: "all",
             stackAgentFilters: this.loadAgentFilters(),
             stackGroupByAgent: this.loadStackGrouping(),
@@ -220,25 +219,6 @@ export default {
         };
     },
     computed: {
-        /**
-         * Improve the sticky appearance of the list by increasing its
-         * height as user scrolls down.
-         * Not used on mobile.
-         * @returns {object} Style for stack list
-         */
-        boxStyle() {
-            if (window.innerWidth > 550) {
-                return {
-                    height: `calc(100vh - 160px + ${this.windowTop}px)`,
-                };
-            } else {
-                return {
-                    height: "calc(100vh - 160px)",
-                };
-            }
-
-        },
-
         /**
          * Returns a sorted list of stacks based on the applied filters and search text.
          * @returns {Array} The sorted list of stacks.
@@ -495,12 +475,6 @@ export default {
             }
         },
     },
-    mounted() {
-        window.addEventListener("scroll", this.onScroll);
-    },
-    beforeUnmount() {
-        window.removeEventListener("scroll", this.onScroll);
-    },
     methods: {
         stackPinKey(stack) {
             return JSON.stringify([ stack.endpoint || "", stack.name ]);
@@ -644,18 +618,6 @@ export default {
             };
         },
         /**
-         * Handle user scroll
-         * @returns {void}
-         */
-        onScroll() {
-            if (window.top.scrollY <= 133) {
-                this.windowTop = window.top.scrollY;
-            } else {
-                this.windowTop = 133;
-            }
-        },
-
-        /**
          * Clear the search bar
          * @returns {void}
          */
@@ -770,9 +732,7 @@ export default {
 @import "../styles/vars.scss";
 
 .shadow-box {
-    height: calc(100vh - 150px);
-    position: sticky;
-    top: 10px;
+    height: 100%;
     display: flex;
     flex-direction: column;
     min-height: 0;

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -19,7 +19,7 @@
     "releaseNews.item.stackPins": "Frequently used stacks can be pinned to the top of the sidebar, with a preference remembered per browser.",
     "releaseNews.item.composeWorkspace": "The denser Logs and Compose workspace has a remembered draggable divider, fullscreen logs and a collapsible Compose panel.",
     "releaseNews.item.rawComposeCopy": "A dedicated action copies the raw Compose YAML without line numbers or visual-selection artefacts.",
-    "releaseNews.item.stackSidebar": "The denser stack sidebar can be resized with a mouse or keyboard, and its width is remembered per browser.",
+    "releaseNews.item.stackSidebar": "The denser stack sidebar can be resized with a mouse or keyboard, remembers its width per browser and follows the full page height.",
     "releaseNews.close": "Close",
     "releaseNews.gotIt": "Got it",
     "Create your admin account": "Create your admin account",

--- a/frontend/src/lang/es.json
+++ b/frontend/src/lang/es.json
@@ -5,7 +5,7 @@
     "releaseNews.item.stackPins": "Los stacks de uso frecuente pueden fijarse en la parte superior del panel lateral, con una preferencia guardada por navegador.",
     "releaseNews.item.composeWorkspace": "El espacio Registros y Compose más denso incluye un separador redimensionable recordado, registros a pantalla completa y un panel Compose contraíble.",
     "releaseNews.item.rawComposeCopy": "Una acción dedicada copia el YAML Compose sin formato, sin números de línea ni artefactos de selección visual.",
-    "releaseNews.item.stackSidebar": "La columna de stacks más densa se puede redimensionar con el ratón o el teclado, y su anchura se recuerda por navegador.",
+    "releaseNews.item.stackSidebar": "La columna de stacks más densa se puede redimensionar con el ratón o el teclado, recuerda su anchura por navegador y sigue toda la altura de la página.",
     "logLineWrap": "Ajuste de línea",
     "logLineWrapToggle": "Activar o desactivar el ajuste automático de línea",
     "logLineWrapOn": "Líneas ajustadas",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -19,7 +19,7 @@
     "releaseNews.item.stackPins": "Les stacks utilisées fréquemment peuvent être épinglées en tête du panneau latéral, avec une préférence mémorisée par navigateur.",
     "releaseNews.item.composeWorkspace": "L’espace Logs et Compose plus dense dispose d’une séparation redimensionnable mémorisée, de logs plein écran et d’un encart Compose réductible.",
     "releaseNews.item.rawComposeCopy": "Une action dédiée copie le YAML Compose brut sans numéros de ligne ni artefacts de sélection visuelle.",
-    "releaseNews.item.stackSidebar": "La colonne des stacks plus dense se redimensionne à la souris ou au clavier, et sa largeur est mémorisée par navigateur.",
+    "releaseNews.item.stackSidebar": "La colonne des stacks plus dense se redimensionne à la souris ou au clavier, mémorise sa largeur par navigateur et suit toute la hauteur de la page.",
     "releaseNews.close": "Fermer",
     "releaseNews.gotIt": "J'ai compris",
     "Create your admin account": "Créez votre compte administrateur",

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -112,13 +112,18 @@ export default {
 
 .dashboard-layout {
     display: grid;
-    align-items: start;
+    align-items: stretch;
     width: 100%;
 }
 
 .stack-sidebar,
 .dashboard-content {
     min-width: 0;
+}
+
+.stack-sidebar {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
 }
 
 .dashboard-resize-handle {


### PR DESCRIPTION
## Modifications

- retire la hauteur de liste calculée à partir du viewport et l’écouteur de défilement associé ;
- étire la colonne des stacks sur la hauteur réelle du contenu principal ;
- aligne le séparateur vertical sur cette même hauteur dynamique ;
- conserve le défilement interne de la liste et le comportement mobile ;
- précise ce comportement dans le popup Nouveautés et les README français, anglais et espagnol.

## Validation

- `git diff --check`
- validation JSON des traductions FR/EN/ES
- `npm run check-ts`
- lint ciblé sans erreur
- `npm run build:frontend`
