### PR TITLE
Regrouper et fusionner automatiquement les mises à jour

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,9 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      npm-validated-batch:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -22,10 +21,9 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      docker-validated-batch:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -35,7 +33,6 @@ updates:
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      actions-validated-batch:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,20 +24,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Activer la fusion squash après les contrôles requis
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        # Les mises à jour indirectes n'ont pas toujours de type sémantique.
-        # Les versions majeures restent ouvertes : un build vert ne prouve pas à lui seul
-        # l'absence de régression fonctionnelle. Les patchs et mineures restent automatiques.
+        # Chaque lot, y compris majeur, doit passer les builds natifs, les scans,
+        # le contrôle TypeScript, le build frontend et le smoke test avant fusion.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr merge --auto --squash --delete-branch "$PR_URL"
-
-      - name: Signaler une mise à jour majeure à valider
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          gh pr comment "$PR_URL" --body "Mise à jour majeure détectée : la fusion automatique reste désactivée jusqu'à une validation fonctionnelle explicite."


### PR DESCRIPTION
## Résumé

- regroupe les mises à jour en un lot npm, un lot Docker et un lot GitHub Actions
- active l’auto-merge pour tous les lots, y compris les versions majeures
- conserve tous les contrôles bloquants : TypeScript, frontend, builds natifs, Trivy, CodeQL et smoke tests

## Effet attendu

- remplace la file actuelle de PR unitaires qui se rendent mutuellement obsolètes
- une incompatibilité majeure reste visible dans son lot et peut être corrigée sans bloquer les deux autres écosystèmes

## Validation

- syntaxe YAML validée
- `git diff --check`