### PR TITLE
Écarter TypeScript 7 tant que le lint est incompatible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
       npm-validated-batch:
         patterns:
           - "*"
+    # TypeScript 7 ne peut pas encore être installé avec la dernière version
+    # publiée de TypeScript-ESLint (contrainte actuelle : TypeScript < 6.1).
+    # Les versions mineures et correctives restent suivies automatiquement.
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Résumé

- empêche uniquement le saut TypeScript 7 actuellement impossible à installer
- conserve le suivi automatique des versions mineures et correctives de TypeScript
- laisse le reste du lot npm être calculé et validé automatiquement

## Vérification

- la dernière chaîne TypeScript-ESLint publiée exige TypeScript `< 6.1`
- le lot #184 tentait TypeScript 7 et échouait dès `npm ci`
- syntaxe YAML validée