### PR TITLE
Isoler les migrations npm incompatibles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,23 @@ updates:
       - dependency-name: "typescript"
         update-types:
           - "version-update:semver-major"
+      # Ces majeures changent leurs API publiques et exigent une migration
+      # applicative dédiée. Leurs patchs et mineures restent automatisés.
+      - dependency-name: "express"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/express"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "promisify-child-process"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "croner"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "jwt-decode"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Résumé

- isole les versions majeures Express, Croner, jwt-decode et promisify-child-process dont les API ont changé
- conserve leur suivi automatique pour les patchs et versions mineures
- permet au lot npm compatible de poursuivre ses validations et son auto-merge

## Validation

- incompatibilités confirmées par la compilation TypeScript du lot #186
- syntaxe YAML validée
- `git diff --check`