### PR TITLE
Limiter les requêtes sur toutes les routes API

### DIFF
--- a/backend/dockge-server.ts
+++ b/backend/dockge-server.ts
@@ -28,6 +28,7 @@ import packageJSON from "../package.json";
 import { log } from "./log";
 import * as socketIO from "socket.io";
 import express, { Express } from "express";
+import { rateLimit } from "express-rate-limit";
 import { parse } from "ts-command-line-args";
 import https from "https";
 import http from "http";
@@ -215,6 +216,18 @@ export class DockgeServer {
 
         // Create express
         this.app = express();
+
+        // Toutes les routes HTTP sensibles sont placées derrière une limite
+        // commune. Le plafond reste volontairement généreux pour les écrans de
+        // supervision, tout en empêchant l'abus soutenu des opérations Docker,
+        // fichiers, sauvegardes et authentification par jeton.
+        this.app.use("/api", rateLimit({
+            windowMs: 60 * 1000,
+            limit: 600,
+            standardHeaders: "draft-8",
+            legacyHeaders: false,
+            message: { ok: false, message: "Trop de requêtes, réessayez dans quelques instants." },
+        }));
 
         // Create HTTP server
         if (this.config.sslKey && this.config.sslCert) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "dayjs": "~1.11.21",
                 "dotenv": "~17.4.2",
                 "express": "~4.22.2",
+                "express-rate-limit": "^8.6.2",
                 "express-static-gzip": "~3.0.1",
                 "http-graceful-shutdown": "~4.0.0",
                 "js-yaml": "^5.2.3",
@@ -64,9 +65,9 @@
                 "@typescript-eslint/eslint-plugin": "~8.66.0",
                 "@typescript-eslint/parser": "~8.66.0",
                 "@vitejs/plugin-vue": "~6.0.8",
-                "@xterm/addon-fit": "*",
+                "@xterm/addon-fit": "beta",
                 "@xterm/addon-search": "^0.16.0",
-                "@xterm/xterm": "*",
+                "@xterm/xterm": "beta",
                 "bootstrap": "5.3.8",
                 "bootstrap-vue-next": "~0.45.10",
                 "codemirror": "^6.0.1",
@@ -5602,6 +5603,25 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
         "node_modules/express-static-gzip": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-3.0.1.tgz",
@@ -6683,7 +6703,6 @@
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
             "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 12"
             }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "dayjs": "~1.11.21",
         "dotenv": "~17.4.2",
         "express": "~4.22.2",
+        "express-rate-limit": "^8.6.2",
         "express-static-gzip": "~3.0.1",
         "http-graceful-shutdown": "~4.0.0",
         "js-yaml": "^5.2.3",


### PR DESCRIPTION
## Résumé

- applique une limite commune à toutes les routes HTTP `/api`
- conserve un plafond généreux adapté aux écrans de supervision
- renvoie une réponse structurée lorsque la limite est atteinte
- couvre notamment les opérations Docker, fichiers, sauvegardes et jetons API

## Validation

- `npm ci --ignore-scripts`
- `npm audit --audit-level=high`
- `npm run check-ts`
- `npx tsx --test backend/auth.test.ts`
- `npm run build:frontend`
- `git diff --check`