### PR TITLE
Valider les chemins et URL reçus

### DIFF
--- a/backend/integrations/plugnpin-manager.ts
+++ b/backend/integrations/plugnpin-manager.ts
@@ -108,7 +108,11 @@ function quoteYaml(value: string): string {
 }
 
 function normalizeUrl(value: unknown): string {
-    return String(value ?? "").trim().replace(/\/+$/, "");
+    let normalized = String(value ?? "").trim();
+    while (normalized.endsWith("/")) {
+        normalized = normalized.slice(0, -1);
+    }
+    return normalized;
 }
 
 export function normalizePlugNPiNSettings(input: Partial<PlugNPiNSettings>): PlugNPiNSettings {

--- a/backend/registry-auth.test.ts
+++ b/backend/registry-auth.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeRegistryHost } from "./registry-auth";
+
+test("normalizes registry URLs without accepting paths as hosts", () => {
+    assert.equal(normalizeRegistryHost("https://REGISTRY.example.test/team/"), "registry.example.test");
+    assert.equal(normalizeRegistryHost("http://registry.example.test///"), "registry.example.test");
+    assert.equal(normalizeRegistryHost("registry.example.test/team"), "registry.example.test");
+});
+
+test("normalizes Docker Hub aliases", () => {
+    assert.equal(normalizeRegistryHost("docker.io"), "registry-1.docker.io");
+    assert.equal(normalizeRegistryHost("index.docker.io/v1/"), "registry-1.docker.io");
+});

--- a/backend/registry-auth.ts
+++ b/backend/registry-auth.ts
@@ -31,7 +31,13 @@ export function normalizeRegistryHost(registry: string): string {
         const parsed = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
         return normalizeDockerHubAlias(parsed.host.toLowerCase());
     } catch {
-        const host = trimmed.replace(/^https?:\/\//i, "").replace(/\/+$/, "").toLowerCase();
+        const lower = trimmed.toLowerCase();
+        const withoutScheme = lower.startsWith("https://")
+            ? lower.slice(8)
+            : lower.startsWith("http://") ? lower.slice(7) : lower;
+        const host = withoutScheme.slice(0, withoutScheme.search(/[/?#]/) < 0
+            ? withoutScheme.length
+            : withoutScheme.search(/[/?#]/));
         return normalizeDockerHubAlias(host);
     }
 }

--- a/backend/routers/watcher-router.ts
+++ b/backend/routers/watcher-router.ts
@@ -451,7 +451,7 @@ export class WatcherRouter extends Router {
 
         router.get("/backup/snapshots/:id/browse", async (req: Request, res: Response) => {
             try {
-                const dirPath = (req.query.path as string) ?? "";
+                const dirPath = typeof req.query.path === "string" ? req.query.path : "";
                 if (!dirPath.startsWith("/") || dirPath.includes("..") || dirPath.length > 1000) {
                     res.status(400).json({ ok: false, message: "Chemin invalide" });
                     return;


### PR DESCRIPTION
## Résumé

- refuse les paramètres de chemin HTTP ambigus au lieu de les convertir de force
- normalise les hôtes de registre sans expression régulière dépendante de l’entrée
- retire les suffixes des URL PlugNPiN en temps linéaire
- ajoute des tests de normalisation des registres privés et Docker Hub

## Validation

- `npm run check-ts`
- `npx tsx --test backend/registry-auth.test.ts backend/integrations/plugnpin-manager.test.ts`
- `git diff --check`