### PR TITLE
Sécuriser les empreintes de secrets

### DIFF
--- a/backend/models/user.ts
+++ b/backend/models/user.ts
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
 import { R } from "redbean-node";
 import { BeanModel } from "redbean-node/dist/bean-model";
-import { generatePasswordHash, shake256, SHAKE256_LENGTH } from "../password-hash";
+import { generatePasswordHash, passwordVersionFingerprint } from "../password-hash";
 
 export class User extends BeanModel {
     /**
@@ -37,7 +37,7 @@ export class User extends BeanModel {
     static createJWT(user : User, jwtSecret : string) {
         return jwt.sign({
             username: user.username,
-            h: shake256(user.password, SHAKE256_LENGTH),
+            h: passwordVersionFingerprint(user.password, jwtSecret),
         }, jwtSecret);
     }
 

--- a/backend/password-hash.test.ts
+++ b/backend/password-hash.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { passwordVersionFingerprint } from "./password-hash";
+
+test("password version fingerprints are stable and keyed", () => {
+    const digest = "$2b$10$stored-bcrypt-digest";
+    const first = passwordVersionFingerprint(digest, "jwt-secret-a");
+
+    assert.equal(first, passwordVersionFingerprint(digest, "jwt-secret-a"));
+    assert.notEqual(first, passwordVersionFingerprint(digest, "jwt-secret-b"));
+    assert.notEqual(first, passwordVersionFingerprint(`${digest}-changed`, "jwt-secret-a"));
+    assert.match(first, /^[a-f0-9]{32}$/);
+});

--- a/backend/password-hash.ts
+++ b/backend/password-hash.ts
@@ -30,18 +30,16 @@ export function needRehashPassword(hash : string) : boolean {
     return false;
 }
 
-export const SHAKE256_LENGTH = 16;
-
 /**
- * @param {string} data The data to be hashed
- * @param {number} len Output length of the hash
- * @returns {string} The hashed data in hex format
+ * Create a keyed fingerprint of the stored bcrypt digest. It is embedded in
+ * JWTs only to invalidate them after a password change.
  */
-export function shake256(data : string, len : number) {
-    if (!data) {
+export function passwordVersionFingerprint(passwordHash : string, jwtSecret : string) {
+    if (!passwordHash) {
         return "";
     }
-    return crypto.createHash("shake256", { outputLength: len })
-        .update(data)
-        .digest("hex");
+    return crypto.createHmac("sha256", jwtSecret)
+        .update(passwordHash)
+        .digest("hex")
+        .slice(0, 32);
 }

--- a/backend/socket-handlers/main-socket-handler.ts
+++ b/backend/socket-handlers/main-socket-handler.ts
@@ -5,7 +5,7 @@ import { DockgeServer } from "../dockge-server";
 import { log } from "../log";
 import { R } from "redbean-node";
 import { loginRateLimiter, twoFaRateLimiter } from "../rate-limiter";
-import { generatePasswordHash, needRehashPassword, shake256, SHAKE256_LENGTH, verifyPassword } from "../password-hash";
+import { generatePasswordHash, needRehashPassword, passwordVersionFingerprint, verifyPassword } from "../password-hash";
 import { User } from "../models/user";
 import {
     callbackError,
@@ -136,7 +136,7 @@ export class MainSocketHandler extends SocketHandler {
 
                 if (user) {
                     // Check if the password changed
-                    if (decoded.h !== shake256(user.password, SHAKE256_LENGTH)) {
+                    if (decoded.h !== passwordVersionFingerprint(user.password, server.jwtSecret)) {
                         throw new Error("The token is invalid due to password change or old token");
                     }
 

--- a/backend/transfers/stack-transfer-restic.ts
+++ b/backend/transfers/stack-transfer-restic.ts
@@ -60,7 +60,7 @@ function repositoryLocation(destination: BackupDestination): string {
 
 function repositoryId(destination: BackupDestination): string {
     return createHash("sha256")
-        .update(`${repositoryLocation(destination)}\0${destination.resticPassword}`)
+        .update(repositoryLocation(destination))
         .digest("hex")
         .slice(0, 24);
 }


### PR DESCRIPTION
## Résumé

- remplace l’empreinte non clé du digest bcrypt par un HMAC lié au secret JWT
- conserve l’invalidation immédiate des sessions après changement de mot de passe
- retire le mot de passe Restic du calcul de l’identifiant local du dépôt
- ajoute un test de stabilité, séparation des clés et changement de digest

## Validation

- `npm run check-ts`
- `npx tsx --test backend/password-hash.test.ts backend/auth.test.ts`
- `git diff --check`