### PR TITLE
Supprimer le shell des services Dozzle et Kula

### DIFF
--- a/backend/watchers/dozzle-manager.ts
+++ b/backend/watchers/dozzle-manager.ts
@@ -1,9 +1,14 @@
-import { exec } from "child_process";
-import { promisify } from "util";
 import * as fs from "fs/promises";
 import * as path from "path";
+import childProcessAsync from "promisify-child-process";
 
-const execAsync = promisify(exec);
+async function docker(args: string[]): Promise<string> {
+    const result = await childProcessAsync.spawn("docker", args, { encoding: "utf8" });
+    if ((result.code ?? 0) !== 0) {
+        throw new Error(result.stderr?.toString() || `docker ${args[0]} failed`);
+    }
+    return result.stdout?.toString() ?? "";
+}
 const DATA_DIR = process.env.DOCKGE_DATA_DIR ?? "/opt/dockge/data";
 const STACKS_DIR = process.env.DOCKGE_STACKS_DIR ?? "/opt/stacks";
 const SETTINGS_PATH = path.join(DATA_DIR, "dozzle-settings.json");
@@ -99,15 +104,15 @@ export class DozzleManager {
         try {
             await this.stop();
             await this.writeComposeFile();
-            await execAsync([
-                "docker run -d",
-                `--name ${DOZZLE_CONTAINER_NAME}`,
-                `-p ${this.settings.port}:8080`,
-                "-v /var/run/docker.sock:/var/run/docker.sock:ro",
-                "-v dozzle_dockge_data:/data",
-                "--restart unless-stopped",
+            await docker([
+                "run", "-d",
+                "--name", DOZZLE_CONTAINER_NAME,
+                "-p", `${this.settings.port}:8080`,
+                "-v", "/var/run/docker.sock:/var/run/docker.sock:ro",
+                "-v", "dozzle_dockge_data:/data",
+                "--restart", "unless-stopped",
                 DOZZLE_IMAGE,
-            ].join(" "));
+            ]);
         } finally {
             this._starting = false;
         }
@@ -115,14 +120,14 @@ export class DozzleManager {
 
     async stop(): Promise<void> {
         try {
-            await execAsync(`docker stop ${DOZZLE_CONTAINER_NAME}`);
-            await execAsync(`docker rm ${DOZZLE_CONTAINER_NAME}`);
+            await docker([ "stop", DOZZLE_CONTAINER_NAME ]);
+            await docker([ "rm", DOZZLE_CONTAINER_NAME ]);
         } catch { /* absent: normal */ }
     }
 
     async getStatus(): Promise<DozzleStatus> {
         try {
-            const { stdout } = await execAsync(`docker inspect --format "{{.State.Running}}" ${DOZZLE_CONTAINER_NAME}`);
+            const stdout = await docker([ "inspect", "--format", "{{.State.Running}}", DOZZLE_CONTAINER_NAME ]);
             return stdout.trim() === "true" ? "running" : "stopped";
         } catch {
             return "stopped";

--- a/backend/watchers/kula-manager.ts
+++ b/backend/watchers/kula-manager.ts
@@ -13,12 +13,17 @@
  * Fichier : backend/watchers/kula-manager.ts
  */
 
-import { exec } from "child_process";
-import { promisify } from "util";
 import * as fs from "fs/promises";
 import * as path from "path";
+import childProcessAsync from "promisify-child-process";
 
-const execAsync = promisify(exec);
+async function docker(args: string[]): Promise<string> {
+    const result = await childProcessAsync.spawn("docker", args, { encoding: "utf8" });
+    if ((result.code ?? 0) !== 0) {
+        throw new Error(result.stderr?.toString() || `docker ${args[0]} failed`);
+    }
+    return result.stdout?.toString() ?? "";
+}
 
 const DATA_DIR      = process.env.DOCKGE_DATA_DIR  ?? "/opt/dockge/data";
 const STACKS_DIR    = process.env.DOCKGE_STACKS_DIR ?? "/opt/stacks";
@@ -151,23 +156,21 @@ export class KulaManager {
         await this._writeComposeFile();
 
         const port = this.settings.port ?? 27960;
-        const networkArgs = this.settings.networkMode === "host"
-            ? "--network host"
-            : `-p ${port}:27960`;
-
-        const cmd = [
-            "docker run -d",
-            `--name ${KULA_CONTAINER_NAME}`,
-            "--pid host",
-            networkArgs,
-            "-v kula_dockge_data:/app/data",
-            "--restart unless-stopped",
+        const args = [
+            "run", "-d",
+            "--name", KULA_CONTAINER_NAME,
+            "--pid", "host",
+            ...(this.settings.networkMode === "host"
+                ? [ "--network", "host" ]
+                : [ "-p", `${port}:27960` ]),
+            "-v", "kula_dockge_data:/app/data",
+            "--restart", "unless-stopped",
             KULA_IMAGE,
-        ].join(" ");
+        ];
 
-        console.log(`[KulaManager] Démarrage : ${cmd}`);
+        console.log(`[KulaManager] Démarrage du conteneur sur le port ${port}`);
         try {
-            await execAsync(cmd);
+            await docker(args);
             console.log(`[KulaManager] Container démarré (port ${port})`);
         } catch (e) {
             console.error(`[KulaManager] Échec docker run :`, e);
@@ -177,8 +180,8 @@ export class KulaManager {
 
     async stop(): Promise<void> {
         try {
-            await execAsync(`docker stop ${KULA_CONTAINER_NAME}`);
-            await execAsync(`docker rm ${KULA_CONTAINER_NAME}`);
+            await docker([ "stop", KULA_CONTAINER_NAME ]);
+            await docker([ "rm", KULA_CONTAINER_NAME ]);
             console.log("[KulaManager] Container arrêté");
         } catch {
             // Container n'existait pas — normal
@@ -187,9 +190,7 @@ export class KulaManager {
 
     async getStatus(): Promise<KulaStatus> {
         try {
-            const { stdout } = await execAsync(
-                `docker inspect --format "{{.State.Running}}" ${KULA_CONTAINER_NAME}`,
-            );
+            const stdout = await docker([ "inspect", "--format", "{{.State.Running}}", KULA_CONTAINER_NAME ]);
             return stdout.trim() === "true" ? "running" : "stopped";
         } catch {
             return "stopped";


### PR DESCRIPTION
## Résumé

- remplace toutes les commandes shell Dozzle et Kula par des appels directs au binaire Docker
- passe chaque option comme argument distinct, y compris les ports configurés
- conserve les opérations de démarrage, arrêt, suppression et lecture d’état
- évite aussi de journaliser une commande reconstruite avec une valeur configurable

## Validation

- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`