### PR TITLE
Valider les chemins des stacks

### DIFF
--- a/backend/stack-path.test.ts
+++ b/backend/stack-path.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { resolveStackPath } from "./stack";
+
+test("résout les noms de stacks historiques sans modifier leur chemin", () => {
+    const root = path.resolve("/tmp/dockge-stacks");
+    for (const name of [ "demo", "demo-stack", "demo_stack", "demo.stack", "Demo1" ]) {
+        assert.equal(resolveStackPath(root, name), path.join(root, name));
+    }
+});
+
+test("rejette les traversées et noms interprétés comme chemins", () => {
+    for (const name of [ "../secret", "stack/child", "stack\\child", ".", "..", "", "/absolute" ]) {
+        assert.throws(() => resolveStackPath("/tmp/dockge-stacks", name), /Invalid stack/);
+    }
+});

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -62,6 +62,18 @@ interface StackMetadata {
 // (découverte automatique, sans `-f` explicite).
 const COMPOSE_OVERRIDE_FILE = "compose.override.yaml";
 
+export function resolveStackPath(stacksDir: string, stackName: string): string {
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(stackName)) {
+        throw new ValidationError("Invalid stack name");
+    }
+    const root = path.resolve(stacksDir);
+    const resolved = path.resolve(root, stackName);
+    if (path.dirname(resolved) !== root) {
+        throw new ValidationError("Invalid stack path");
+    }
+    return resolved;
+}
+
 export class Stack {
 
     name: string;
@@ -85,6 +97,7 @@ export class Stack {
         this._composeOverrideYAML = composeOverrideYAML;
 
         if (!skipFSOperations) {
+            resolveStackPath(this.server.stacksDir, this.name);
             // Check if compose file name is different from compose.yaml
             for (const filename of acceptedComposeFileNames) {
                 if (fs.existsSync(path.join(this.path, filename))) {
@@ -516,7 +529,9 @@ export class Stack {
     }
 
     static async getStack(server: DockgeServer, stackName: string, skipFSOperations = false) : Promise<Stack> {
-        let dir = path.join(server.stacksDir, stackName);
+        let dir = skipFSOperations
+            ? path.resolve(server.stacksDir, stackName)
+            : resolveStackPath(server.stacksDir, stackName);
 
         if (!skipFSOperations) {
             if (!await fileExists(dir) || !(await fsAsync.stat(dir)).isDirectory()) {


### PR DESCRIPTION
## Résumé

- centralise la résolution des dossiers de stacks dans une validation dédiée
- conserve les noms historiques avec lettres, chiffres, points, tirets et underscores
- rejette les chemins absolus, traversées et séparateurs avant tout accès au système de fichiers
- ajoute des tests ciblés sur les noms compatibles et les entrées malveillantes

## Validation locale

- `npx tsx --test backend/stack-path.test.ts` (2 tests réussis)
- `npm run check-ts`
- `npm run build:frontend`
- `git diff --check`
- conteneur de branche démarré en état `healthy`
- test navigateur Chromium dans un conteneur isolé : accueil rendu, 9 stacks détectées, ouverture d’une stack et aucune erreur frontend