### PR TITLE
Sécuriser la mesure des volumes sauvegardés

### DIFF
--- a/backend/watchers/backup-manager.test.ts
+++ b/backend/watchers/backup-manager.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { BackupRunLock, normalizeStackBackupPolicy } from "./backup-manager";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BackupRunLock, normalizeStackBackupPolicy, readDiskUsage } from "./backup-manager";
 
 test("defaults unknown stack policies to hot mode", () => {
     assert.deepEqual(normalizeStackBackupPolicy(undefined), { mode: "hot" });
@@ -46,4 +49,18 @@ test("allows concurrent backups when overlap protection is disabled", () => {
     assert.equal(lock.isActive(), true);
     lock.release();
     assert.equal(lock.isActive(), false);
+});
+
+test("mesure un chemin sans interpréter ses caractères comme une commande", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "dockge-du-"));
+    const marker = path.join(root, "commande-executee");
+    const volume = path.join(root, `volume;touch ${path.basename(marker)}`);
+    try {
+        await fs.mkdir(volume);
+        await fs.writeFile(path.join(volume, "data.bin"), Buffer.alloc(4096));
+        assert.match(await readDiskUsage(volume), /^\S+/);
+        await assert.rejects(fs.access(marker));
+    } finally {
+        await fs.rm(root, { recursive: true, force: true });
+    }
 });

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import * as cron from "node-cron";
-import { exec, spawn } from "child_process";
+import { exec, execFile, spawn } from "child_process";
 import { promisify } from "util";
 import * as readline from "readline";
 import * as fs from "fs/promises";
@@ -17,6 +17,7 @@ import { Settings } from "../settings";
 import { ValidationError } from "../util-server";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const STACKS_DIR         = process.env.DOCKGE_STACKS_DIR ?? "/opt/stacks";
 const DATA_DIR           = process.env.DOCKGE_DATA_DIR   ?? "/opt/dockge/data";
@@ -112,6 +113,11 @@ const EXCLUDED_VOL_DESTINATIONS = new Set([
     "/etc/resolv.conf",
 ]);
 const EXCLUDED_VOL_PREFIXES = ["/proc", "/sys", "/dev", "/run", "/tmp"];
+
+export async function readDiskUsage(dir: string, timeout = 15_000): Promise<string> {
+    const { stdout } = await execFileAsync("du", [ "-sh", "--", dir ], { timeout });
+    return stdout.split("\t")[0].trim() || "?";
+}
 
 export interface BackupSettings {
     enabled: boolean;
@@ -1262,8 +1268,7 @@ export class BackupManager {
     async getDirSizes(selectedVolumes: string[] = []): Promise<{ appData: string; volumes: Record<string, string> }> {
         const du = async (dir: string): Promise<string> => {
             try {
-                const { stdout } = await execAsync(`du -sh ${shellQuote(dir)} 2>/dev/null`, { timeout: 15000 });
-                return stdout.split("\t")[0].trim() || "?";
+                return await readDiskUsage(dir);
             } catch {
                 return "?";
             }
@@ -1329,8 +1334,7 @@ export class BackupManager {
         await Promise.all(dirs.map(async dir => {
             const p = path.join(volPath, dir);
             try {
-                const { stdout } = await execAsync(`du -sh ${shellQuote(p)} 2>/dev/null`, { timeout: 60000 });
-                results[dir] = stdout.split("\t")[0].trim() || "?";
+                results[dir] = await readDiskUsage(p, 60_000);
             } catch { results[dir] = "?"; }
         }));
         return results;


### PR DESCRIPTION
## Résumé

- exécute `du` sans shell
- transmet les chemins comme arguments opaques
- ajoute un test contre l’injection de commande

## Tests

- tests backup : 6/6
- TypeScript
- audit HIGH/CRITICAL
- image Docker et appel API réels