### PR TITLE
Mettre à jour la dépendance once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,13 +2430,13 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "license": "MIT",
             "optional": true,
             "engines": {
-                "node": ">= 6"
+                "node": ">= 10"
             }
         },
         "node_modules/@types/bcryptjs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "form-data": "^4.0.4",
         "lodash": "^4.18.1",
         "tar": "^7.5.21",
+        "@tootallnate/once": "^2.0.1",
         "minimatch@^9.0.0": "^9.0.7",
         "redbean-node": {
             "glob": "^10.5.0"


### PR DESCRIPTION
## Résumé

- force `@tootallnate/once` vers sa version corrigée

## Tests

- audit npm
- TypeScript et tests
- image et démarrage SQLite