### PR TITLE
Valider l’hôte Apprise

### DIFF
--- a/backend/notification/apprise.test.ts
+++ b/backend/notification/apprise.test.ts
@@ -4,6 +4,7 @@ import { buildAppriseEndpoint } from "./apprise";
 
 test("construit un endpoint Apprise HTTP explicite", () => {
     assert.equal(buildAppriseEndpoint("http://apprise:8000"), "http://apprise:8000/notify/");
+    assert.equal(buildAppriseEndpoint("http://192.168.0.20:8000"), "http://192.168.0.20:8000/notify/");
     assert.equal(buildAppriseEndpoint("https://notify.example.test/base/"), "https://notify.example.test/base/notify/");
 });
 
@@ -11,4 +12,6 @@ test("rejette les variantes d’URL Apprise ambiguës", () => {
     assert.throws(() => buildAppriseEndpoint("file:///etc/passwd"), /invalide/);
     assert.throws(() => buildAppriseEndpoint("https://user:secret@example.test"), /invalide/);
     assert.throws(() => buildAppriseEndpoint("https://example.test?next=http://127.0.0.1"), /invalide/);
+    assert.equal(buildAppriseEndpoint("https://example.test/%2e%2e/admin"), "https://example.test/admin/notify/");
+    assert.throws(() => buildAppriseEndpoint("https://-bad.example/path"), /invalide/);
 });

--- a/backend/notification/apprise.ts
+++ b/backend/notification/apprise.ts
@@ -27,8 +27,19 @@ export function buildAppriseEndpoint(serverUrl: string): string {
     if (![ "http:", "https:" ].includes(parsed.protocol) || parsed.username || parsed.password || parsed.search || parsed.hash) {
         throw new Error("URL du serveur Apprise invalide");
     }
-    parsed.pathname = `${parsed.pathname.replace(/\/+$/, "")}/notify/`;
-    return parsed.toString();
+    const host = parsed.host.toLowerCase();
+    const dnsOrIpv4 = /^(?:localhost|[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?)(?::[0-9]{1,5})?$/;
+    const ipv6 = /^\[[0-9a-f:]+\](?::[0-9]{1,5})?$/;
+    if ((!dnsOrIpv4.test(host) && !ipv6.test(host)) || host.includes("..")) {
+        throw new Error("URL du serveur Apprise invalide");
+    }
+    const safeProtocol = parsed.protocol === "https:" ? "https:" : "http:";
+    const basePath = parsed.pathname.split("/").filter(Boolean).map(segment => {
+        const decoded = decodeURIComponent(segment);
+        if (decoded === "." || decoded === ".." || decoded.includes("/")) throw new Error("URL du serveur Apprise invalide");
+        return encodeURIComponent(decoded);
+    });
+    return `${safeProtocol}//${host}/${[ ...basePath, "notify" ].join("/")}/`;
 }
 
 export class AppriseNotifier {


### PR DESCRIPTION
## Résumé

- reconstruit l’endpoint depuis des composants validés
- conserve les hôtes locaux et les IP privées

## Tests

- tests ciblés
- TypeScript