### PR TITLE
Sécuriser le test d’existence des fichiers

### DIFF
--- a/backend/util-server.test.ts
+++ b/backend/util-server.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileExists } from "./util-server";
+
+test("vérifie un chemin sans interprétation par un shell", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dockge-file-exists-"));
+    const marker = path.join(tempDir, "marker");
+    const hostilePath = path.join(tempDir, "file;touch marker");
+
+    try {
+        await fs.writeFile(hostilePath, "test");
+
+        assert.equal(await fileExists(hostilePath), true);
+        assert.equal(await fileExists(path.join(tempDir, "absent")), false);
+        assert.equal(await fileExists(marker), false);
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});

--- a/backend/util-server.ts
+++ b/backend/util-server.ts
@@ -5,7 +5,7 @@ import { log } from "./log";
 import { ERROR_TYPE_VALIDATION } from "../common/util-common";
 import { R } from "redbean-node";
 import { verifyPassword } from "./password-hash";
-import fs from "fs";
+import { execFile } from "child_process";
 import { AgentManager } from "./agent-manager";
 
 export interface JWTDecoded {
@@ -99,8 +99,10 @@ export async function doubleCheckPassword(socket : DockgeSocket, currentPassword
     return user;
 }
 
-export function fileExists(file : string) {
-    return fs.promises.access(file, fs.constants.F_OK)
-        .then(() => true)
-        .catch(() => false);
+export function fileExists(file : string) : Promise<boolean> {
+    return new Promise((resolve) => {
+        execFile("test", [ "-e", file ], { timeout: 5000 }, (error) => {
+            resolve(error === null);
+        });
+    });
 }


### PR DESCRIPTION
## Résumé

- vérifie l’existence sans interpréter le chemin
- transmet le chemin comme argument séparé

## Tests

- tests ciblés
- TypeScript et build
- image et démarrage isolé