### PR TITLE
Ignorer temporairement les CVE Go de Restic

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -18,6 +18,35 @@ vulnerabilities:
     expired_at: 2026-09-13
     statement: Corrigé upstream après la dernière release Restic disponible.
 
+  - id: CVE-2026-33818
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go encoding/asn1); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-39821
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go net/http / x/net/idna); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-56853
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go net/http HTTP/2); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-56858
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go html/template); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-56859
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go encoding/xml); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-56860
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go net/url); aucune release Go corrigée stable n'est encore disponible.
+  - id: CVE-2026-56862
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go crypto/tls); aucune release Go corrigée stable n'est encore disponible.
+
 misconfigurations:
   - id: AVD-DS-0002
     paths: ["Dockerfile"]


### PR DESCRIPTION
Le workflow de publication est actuellement bloqué par 7 vulnérabilités HIGH détectées dans /usr/local/bin/restic.

Restic 0.19.1 est toujours la version utilisée dans l'image et ces vulnérabilités proviennent de la stdlib Go avec laquelle son binaire officiel a été compilé.

Cette PR :
- ne change aucun code applicatif ;
- ne modifie pas le Dockerfile ;
- ajoute uniquement les 7 CVE Restic/Go actuellement bloquantes à .trivyignore.yaml ;
- limite chaque exception au chemin usr/local/bin/restic ;
- fait expirer les exceptions le 13 septembre 2026 afin qu'elles soient réévaluées rapidement.

Toutes les autres vulnérabilités HIGH/CRITICAL continuent de faire échouer Trivy.