### PR TITLE
Fix Restic SFTP SSH option injection

### DIFF
--- a/backend/watchers/backup-manager.test.ts
+++ b/backend/watchers/backup-manager.test.ts
@@ -7,6 +7,7 @@ import {
     BackupRunLock,
     assertExistingPathWithinRoots,
     assertPathWithinRoots,
+    assertSafeSftpConfig,
     buildComposeCommandArgs,
     buildResticCommandArgs,
     normalizeStackBackupPolicy,
@@ -104,4 +105,38 @@ test("conserve les valeurs Restic et Compose dans des arguments séparés", () =
     ]), [
         "compose", "-f", "compose.yaml", "exec", "-T", "service;false", "sh", "-c", "echo sauvegarde",
     ]);
+});
+
+test("rejette les champs SFTP capables d'injecter des options SSH", () => {
+    const base = {
+        host: "backup.example.com",
+        port: 22,
+        user: "dockge",
+        path: "/backups/dockge",
+        authMode: "key" as const,
+        keyPath: "/run/secrets/id_ed25519",
+    };
+
+    assert.deepEqual(assertSafeSftpConfig(base), base);
+
+    assert.throws(
+        () => assertSafeSftpConfig({ ...base, host: "-oProxyCommand=touch /tmp/pwned" }),
+        /Hôte SFTP invalide/,
+    );
+    assert.throws(
+        () => assertSafeSftpConfig({ ...base, host: "backup.example.com -oProxyCommand=id" }),
+        /Hôte SFTP invalide/,
+    );
+    assert.throws(
+        () => assertSafeSftpConfig({ ...base, user: "dockge -oProxyCommand=id" }),
+        /Utilisateur SFTP invalide/,
+    );
+    assert.throws(
+        () => assertSafeSftpConfig({ ...base, keyPath: "/run/secrets/key -oProxyCommand=id" }),
+        /Chemin de clé SSH invalide/,
+    );
+    assert.throws(
+        () => assertSafeSftpConfig({ ...base, keyPath: "relative/id_ed25519" }),
+        /Chemin de clé SSH invalide/,
+    );
 });

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -313,7 +313,7 @@ export function assertSafeSftpConfig(config: SftpConfig): SftpConfig {
         host.length < 1 ||
         host.length > 255 ||
         host.startsWith("-") ||
-        !/^[a-zA-Z0-9._:\[\]-]+$/.test(host)
+        /[\s\x00-\x1f\x7f]/.test(host)
     ) {
         throw new ValidationError("Hôte SFTP invalide");
     }
@@ -321,7 +321,7 @@ export function assertSafeSftpConfig(config: SftpConfig): SftpConfig {
     if (
         user.length < 1 ||
         user.length > 128 ||
-        !/^[a-zA-Z0-9._-]+$/.test(user)
+        /[\s\x00-\x1f\x7f]/.test(user)
     ) {
         throw new ValidationError("Utilisateur SFTP invalide");
     }
@@ -339,7 +339,7 @@ export function assertSafeSftpConfig(config: SftpConfig): SftpConfig {
         if (
             !path.isAbsolute(keyPath) ||
             keyPath.length > 2000 ||
-            /[\s\x00-\x1f\x7f,"'`$;&|<>\\]/.test(keyPath)
+            /[\s\x00-\x1f\x7f]/.test(keyPath)
         ) {
             throw new ValidationError("Chemin de clé SSH invalide");
         }

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -298,6 +298,63 @@ function sanitizeRetention(value: unknown): number {
     return Math.max(0, Math.floor(n));
 }
 
+/**
+ * Restic transmet certaines options SFTP à ssh sous forme de chaînes ensuite
+ * découpées en argv. Les champs utilisateur qui entrent dans ces chaînes ne
+ * doivent donc jamais pouvoir créer un nouvel argument SSH.
+ */
+export function assertSafeSftpConfig(config: SftpConfig): SftpConfig {
+    const host = String(config.host ?? "");
+    const user = String(config.user ?? "");
+    const remotePath = String(config.path ?? "");
+    const keyPath = config.keyPath == null ? undefined : String(config.keyPath);
+
+    if (
+        host.length < 1 ||
+        host.length > 255 ||
+        host.startsWith("-") ||
+        !/^[a-zA-Z0-9._:\[\]-]+$/.test(host)
+    ) {
+        throw new ValidationError("Hôte SFTP invalide");
+    }
+
+    if (
+        user.length < 1 ||
+        user.length > 128 ||
+        !/^[a-zA-Z0-9._-]+$/.test(user)
+    ) {
+        throw new ValidationError("Utilisateur SFTP invalide");
+    }
+
+    if (
+        remotePath.length < 1 ||
+        remotePath.length > 2000 ||
+        !remotePath.startsWith("/") ||
+        /[\x00-\x1f\x7f]/.test(remotePath)
+    ) {
+        throw new ValidationError("Chemin SFTP invalide");
+    }
+
+    if (config.authMode === "key" && keyPath) {
+        if (
+            !path.isAbsolute(keyPath) ||
+            keyPath.length > 2000 ||
+            /[\s\x00-\x1f\x7f,"'`$;&|<>\\]/.test(keyPath)
+        ) {
+            throw new ValidationError("Chemin de clé SSH invalide");
+        }
+    }
+
+    return {
+        ...config,
+        host,
+        user,
+        path: remotePath,
+        keyPath,
+        port: sanitizePort(config.port),
+    };
+}
+
 function assertSafeResticId(id: string): string {
     if (!/^[a-zA-Z0-9_-]{1,128}$/.test(id)) {
         throw new Error("Identifiant de snapshot invalide");
@@ -388,8 +445,8 @@ function buildResticEnv(dest: BackupDestination): Record<string, string> {
  */
 function buildSftpOptions(dest: BackupDestination, tmpFile?: string): string[] {
     if (dest.type !== "sftp" || !dest.sftp) return [];
-    const s = dest.sftp;
-    const port = sanitizePort(s.port);
+    const s = assertSafeSftpConfig(dest.sftp);
+    const port = s.port;
 
     if (s.authMode === "password" && tmpFile) {
         // Restic parse la valeur de -o sftp.command= avec le parseur CSV de Go :
@@ -466,7 +523,7 @@ function buildRepoUrl(dest: BackupDestination): string {
             return dest.local!.path;
 
         case "sftp": {
-            const s = dest.sftp!;
+            const s = assertSafeSftpConfig(dest.sftp!);
             // Le port est passé via sftp.args/-o sftp.command, pas dans l'URL
             return `sftp:${s.user}@${s.host}:${s.path}`;
         }


### PR DESCRIPTION
## Summary

Prevents user-controlled Restic SFTP destination fields from injecting additional SSH arguments.

## Changes

- validates SFTP host and user before they reach Restic/SSH
- rejects SFTP hosts beginning with `-`
- validates key paths used in `sftp.args` and rejects whitespace/control or shell-sensitive characters
- validates the remote SFTP path and normalizes the port
- applies validation both when building the Restic repository URL and SSH options
- adds regression tests for `ProxyCommand`-style option injection

Fixes the issue reported in private security advisory `GHSA-gr5v-r6c5-f4q2`.

No dependency changes.