### PR TITLE
Conserver la barre verticale des logs en lignes complètes

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -43,6 +43,8 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 <details>
 <summary><strong>Mostrar el catálogo completo de funcionalidades</strong></summary>
 
+**2026-08-18 — Barra de desplazamiento vertical con líneas completas** — Desactivar el ajuste de línea mantiene las entradas largas en una sola línea con desplazamiento horizontal, mientras la vista xterm conserva el ancho visible del panel para que su barra de desplazamiento vertical siga accesible a la derecha.
+
 **2026-08-17 — Registros de stack fiables después de las acciones Docker** — El panel Registros vuelve a conectar automáticamente su flujo en tiempo real después de iniciar, detener, reiniciar, actualizar o recrear una stack. Se conservan el servicio, el periodo de historial y el modo de timestamps seleccionados, y las operaciones de salida/reconexión del terminal se secuencian para impedir que un callback asíncrono antiguo vuelva a enlazar el flujo equivocado.
 
 **2026-08-13 — Protección opcional contra copias Restic simultáneas** — Los ajustes de copia de seguridad incluyen ahora una protección activada por defecto que impide iniciar una copia manual, programada o al guardar un Compose mientras ya se ejecuta otra copia Restic. Los intentos manuales muestran inmediatamente una ventana en la WebUI; los intentos automáticos se registran y se notifican en la pestaña Copias de seguridad si está abierta. Desactivar la opción restablece los inicios paralelos para las instalaciones que los necesiten expresamente.

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,6 +41,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 <details>
 <summary><strong>Afficher le catalogue complet des fonctionnalités</strong></summary>
 
+**2026-08-18 — Barre de défilement verticale avec les lignes complètes** — Désactiver le retour à la ligne conserve les longues entrées sur une seule ligne avec défilement horizontal, tout en maintenant la viewport xterm à la largeur visible du panneau afin que sa barre de défilement verticale reste accessible à droite.
+
 **2026-08-17 — Logs de stack fiables après les actions Docker** — Le panneau Logs reconnecte désormais automatiquement son flux en temps réel après les opérations de démarrage, arrêt, redémarrage, mise à jour et recréation d’une stack. Le service, la période d’historique et le mode timestamps sélectionnés sont conservés, et les opérations de sortie/reconnexion du terminal sont séquencées afin qu’un ancien callback asynchrone ne puisse plus rattacher le mauvais flux.
 
 **2026-08-13 — Protection optionnelle contre le chevauchement des backups Restic** — Les réglages de sauvegarde proposent désormais un garde-fou activé par défaut qui empêche un backup manuel, planifié ou déclenché par l’enregistrement d’un Compose de démarrer pendant qu’un autre backup Restic tourne. Une tentative manuelle affiche immédiatement une popup dans la WebUI ; une tentative automatique est journalisée et signalée dans l’onglet Sauvegarde s’il est ouvert. Désactiver l’option rétablit les lancements parallèles pour les installations qui en ont explicitement besoin.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 <details>
 <summary><strong>Show the complete feature catalogue</strong></summary>
 
+**2026-08-18 — Vertical log scrollbar with full lines** — Disabling line wrapping keeps long log entries on a single line with horizontal scrolling, while the xterm viewport remains pinned to the visible panel width so its vertical scrollbar stays accessible on the right.
+
 **2026-08-17 — Reliable live stack logs after Docker actions** — The Logs panel now automatically reconnects its live stream after stack start, stop, restart, update and recreate operations. The selected service, history range and timestamp mode are preserved, and terminal leave/join operations are sequenced so an older asynchronous callback cannot rebind the wrong stream.
 
 **2026-08-13 — Optional Restic backup overlap protection** — Backup settings now include an enabled-by-default guard that prevents manual, scheduled, and compose-save backups from starting while another Restic backup is active. Manual attempts display an immediate WebUI modal; automatic attempts are logged and surfaced to an open Backup tab. Disabling the option restores parallel starts for installations that explicitly require them.

--- a/frontend/src/components/Terminal.vue
+++ b/frontend/src/components/Terminal.vue
@@ -349,10 +349,14 @@ export default {
             const dimensions = this.terminalFitAddOn.proposeDimensions();
             const columns = Math.min(2000, Math.max(dimensions?.cols ?? this.cols, this.longestOutputLine + 1));
             const rows = dimensions?.rows ?? this.rows;
-            if (xtermElement) {
-                xtermElement.style.width = `${columns}ch`;
-            }
             this.terminal.resize(columns, rows);
+
+            if (xtermElement) {
+                // Keep the xterm viewport at the visible terminal width. The rendered
+                // screen can still overflow horizontally, but the vertical scrollbar
+                // remains reachable at the right edge of the Logs panel.
+                xtermElement.style.width = "100%";
+            }
         },
 
         terminalWriteProxy() {

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -21,6 +21,7 @@
     "releaseNews.item.rawComposeCopy": "A dedicated action copies the raw Compose YAML without line numbers or visual-selection artefacts.",
     "releaseNews.item.stackSidebar": "The denser stack sidebar can be resized with a mouse or keyboard, remembers its width and fills the visible height or follows longer page content.",
     "releaseNews.item.liveStackLogsRefresh": "Stack logs automatically reconnect after start, stop, restart, update and recreate actions, while service, time range and timestamp selections are preserved.",
+    "releaseNews.item.logNoWrapScrollbar": "With full lines enabled, horizontal scrolling remains available without pushing the vertical scrollbar outside the visible Logs panel.",
     "releaseNews.close": "Close",
     "releaseNews.gotIt": "Got it",
     "Create your admin account": "Create your admin account",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -21,6 +21,7 @@
     "releaseNews.item.rawComposeCopy": "Une action dédiée copie le YAML Compose brut sans numéros de ligne ni artefacts de sélection visuelle.",
     "releaseNews.item.stackSidebar": "La colonne des stacks plus dense se redimensionne à la souris ou au clavier, mémorise sa largeur et remplit la hauteur visible ou suit le contenu plus long de la page.",
     "releaseNews.item.liveStackLogsRefresh": "Les logs de stack se reconnectent automatiquement après les actions de démarrage, arrêt, redémarrage, mise à jour et recréation, tout en conservant le service, la période et les timestamps sélectionnés.",
+    "releaseNews.item.logNoWrapScrollbar": "En mode lignes complètes, le défilement horizontal reste disponible sans repousser la barre de défilement verticale hors de la zone visible.",
     "releaseNews.close": "Fermer",
     "releaseNews.gotIt": "J'ai compris",
     "Create your admin account": "Créez votre compte administrateur",

--- a/frontend/src/release-news.js
+++ b/frontend/src/release-news.js
@@ -37,6 +37,12 @@ export const RELEASE_NEWS = [
             "releaseNews.item.liveStackLogsRefresh",
         ],
     },
+    {
+        id: "2026-08-18-log-nowrap-scrollbar",
+        items: [
+            "releaseNews.item.logNoWrapScrollbar",
+        ],
+    },
 ];
 
 export function getReleaseNewsSince(lastSeenId) {


### PR DESCRIPTION
## Modifications

- conserve les logs sur une seule ligne lorsque le retour à la ligne est désactivé ;
- garde la viewport xterm à la largeur visible du panneau afin que la barre de défilement verticale reste accessible à droite ;
- conserve le défilement horizontal pour les lignes longues ;
- ajoute la nouveauté au popup « Nouveautés » ;
- met à jour les README français, anglais et espagnol avec l’entrée du 18/08/2026.

## Validation

- `git diff --check`
- validation JSON des traductions FR/EN/ES

Aucune dépendance ajoutée et aucune installation locale requise.
