### PR TITLE
Ajouter le tri des stacks par dates

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -43,6 +43,8 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 <details>
 <summary><strong>Mostrar el catálogo completo de funcionalidades</strong></summary>
 
+**2026-08-19 — Ordenar stacks por fecha de creación y última actualización** — El selector de stacks permite ordenar primero las más recientes por fecha de creación o por la última actualización registrada por Dockge. Las stacks nuevas guardan un `createdAt` exacto e inmutable; las existentes usan la fecha de creación del sistema de archivos cuando está disponible, marcada internamente como estimada. Las stacks fijadas mantienen la prioridad.
+
 **2026-08-18 — Pausa y reanudación del seguimiento de logs en vivo** — La barra de herramientas de Registros puede pausar el seguimiento automático sin desconectar el flujo en vivo: las nuevas líneas siguen entrando en el historial de xterm mientras la posición de lectura permanece fija. Reanudar vuelve inmediatamente a los últimos logs y reactiva el desplazamiento automático.
 
 **2026-08-18 — Barra de desplazamiento vertical con líneas completas** — Desactivar el ajuste de línea mantiene las entradas largas en una sola línea con desplazamiento horizontal, mientras la vista xterm conserva el ancho visible del panel para que su barra de desplazamiento vertical siga accesible a la derecha.

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,6 +41,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 <details>
 <summary><strong>Afficher le catalogue complet des fonctionnalités</strong></summary>
 
+**2026-08-19 — Tri des stacks par date de création et dernière mise à jour** — Le sélecteur de stacks peut maintenant trier les stacks les plus récentes en premier selon leur date de création ou leur dernière mise à jour Dockge. Les nouvelles stacks enregistrent un `createdAt` exact et immuable ; les stacks existantes utilisent le birthtime du filesystem lorsqu'il est disponible, identifié en interne comme estimation. Les stacks épinglées restent prioritaires.
+
 **2026-08-18 — Pause et reprise du suivi des logs live** — La barre d'outils des Logs peut suspendre le défilement automatique sans couper le flux live : les nouvelles lignes continuent d'entrer dans le scrollback xterm tandis que la position de lecture reste figée. Reprendre revient immédiatement aux derniers logs et réactive le suivi automatique.
 
 **2026-08-18 — Barre de défilement verticale avec les lignes complètes** — Désactiver le retour à la ligne conserve les longues entrées sur une seule ligne avec défilement horizontal, tout en maintenant la viewport xterm à la largeur visible du panneau afin que sa barre de défilement verticale reste accessible à droite.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 <details>
 <summary><strong>Show the complete feature catalogue</strong></summary>
 
+**2026-08-19 — Sort stacks by creation date and last update** — The stack selector now supports newest-first sorting by creation date and Dockge's last-update timestamp. New stacks store an immutable exact `createdAt`; existing stacks fall back to filesystem birth time when available, marked internally as estimated. Pinned stacks keep priority.
+
 **2026-08-18 — Pause and resume live log following** — The Logs toolbar can pause automatic following without disconnecting the live stream: new lines continue entering xterm's scrollback while the current reading position stays fixed. Resume jumps straight back to the latest output and restores automatic scrolling.
 
 **2026-08-18 — Vertical log scrollbar with full lines** — Disabling line wrapping keeps long log entries on a single line with horizontal scrolling, while the xterm viewport remains pinned to the visible panel width so its vertical scrollbar stays accessible on the right.

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -52,6 +52,8 @@ interface StackContainerVolumeUsage {
 }
 
 interface StackMetadata {
+    createdAt: string | null;
+    createdAtEstimated: boolean;
     lastUpdated: string | null;
     lastStartedAt: string | null;
     note: string;
@@ -139,6 +141,15 @@ export class Stack {
     }
 
     toSimpleJSON(endpoint : string) : object {
+        const metadata = this.readMetaSync();
+        let createdAt = metadata.createdAt;
+        let createdAtEstimated = metadata.createdAtEstimated;
+
+        if (!createdAt && this.isManagedByDockge) {
+            createdAt = this.estimateCreatedAt();
+            createdAtEstimated = createdAt !== null;
+        }
+
         return {
             name: this.name,
             status: this._status,
@@ -146,6 +157,9 @@ export class Stack {
             isManagedByDockge: this.isManagedByDockge,
             composeFileName: this._composeFileName,
             buildServices: this.getBuildServices(),
+            createdAt,
+            createdAtEstimated,
+            lastUpdated: metadata.lastUpdated,
             endpoint,
         };
     }
@@ -294,6 +308,13 @@ export class Stack {
             await fsAsync.writeFile(envPath, this.composeENV);
         }
 
+        if (isAdd) {
+            await this.writeMeta({
+                createdAt: new Date().toISOString(),
+                createdAtEstimated: false,
+            });
+        }
+
         // Write/overwrite/remove the compose.override.yaml
         // Docker Compose le fusionne automatiquement avec le fichier principal.
         const overridePath = path.join(dir, COMPOSE_OVERRIDE_FILE);
@@ -306,20 +327,66 @@ export class Stack {
         }
     }
 
+    private emptyMeta(): StackMetadata {
+        return {
+            createdAt: null,
+            createdAtEstimated: false,
+            lastUpdated: null,
+            lastStartedAt: null,
+            note: "",
+        };
+    }
+
+    private normalizeMeta(parsed: Partial<StackMetadata>): StackMetadata {
+        return {
+            createdAt: typeof parsed.createdAt === "string" ? parsed.createdAt : null,
+            createdAtEstimated: parsed.createdAtEstimated === true,
+            lastUpdated: typeof parsed.lastUpdated === "string" ? parsed.lastUpdated : null,
+            lastStartedAt: typeof parsed.lastStartedAt === "string" ? parsed.lastStartedAt : null,
+            note: typeof parsed.note === "string" ? parsed.note : "",
+        };
+    }
+
+    private readMetaSync(): StackMetadata {
+        try {
+            const raw = fs.readFileSync(path.join(this.path, ".dockge-meta.json"), "utf8");
+            return this.normalizeMeta(JSON.parse(raw) as Partial<StackMetadata>);
+        } catch {
+            return this.emptyMeta();
+        }
+    }
+
+    /**
+     * Best-effort creation date for stacks created before createdAt existed.
+     * Prefer the stack directory birthtime, then the compose file birthtime.
+     */
+    private estimateCreatedAt(): string | null {
+        const candidates = [
+            this.path,
+            path.join(this.path, this._composeFileName),
+        ];
+
+        for (const candidate of candidates) {
+            try {
+                const stat = fs.statSync(candidate);
+                if (Number.isFinite(stat.birthtimeMs) && stat.birthtimeMs > 0) {
+                    return stat.birthtime.toISOString();
+                }
+            } catch {
+                // Try next candidate.
+            }
+        }
+
+        return null;
+    }
+
     /** Lit le fichier .dockge-meta.json du stack */
     private async readMeta(): Promise<StackMetadata> {
         try {
             const raw = await fsAsync.readFile(path.join(this.path, ".dockge-meta.json"), "utf8");
-            const parsed = JSON.parse(raw) as Partial<StackMetadata>;
-            return {
-                lastUpdated: parsed.lastUpdated ?? null,
-                lastStartedAt: parsed.lastStartedAt ?? null,
-                note: typeof parsed.note === "string" ? parsed.note : "",
-            };
+            return this.normalizeMeta(JSON.parse(raw) as Partial<StackMetadata>);
         } catch {
-            return { lastUpdated: null,
-                lastStartedAt: null,
-                note: "" };
+            return this.emptyMeta();
         }
     }
 

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -105,6 +105,8 @@
                         <option value="name">{{ $t("stackSortName") }}</option>
                         <option value="status">{{ $t("stackSortStatus") }}</option>
                         <option value="agent">{{ $t("stackSortAgent") }}</option>
+                        <option value="created">{{ $t("stackSortCreated") }}</option>
+                        <option value="updated">{{ $t("stackSortUpdated") }}</option>
                     </select>
                     <div class="stack-search-field">
                         <a v-if="searchText == ''" class="search-icon">
@@ -285,6 +287,26 @@ export default {
                         return endpointOrder;
                     }
                     return m1.name.localeCompare(m2.name);
+                }
+
+                if (this.stackSort === "created" || this.stackSort === "updated") {
+                    const field = this.stackSort === "created" ? "createdAt" : "lastUpdated";
+                    const date1 = m1[field] ? Date.parse(m1[field]) : Number.NaN;
+                    const date2 = m2[field] ? Date.parse(m2[field]) : Number.NaN;
+                    const valid1 = Number.isFinite(date1);
+                    const valid2 = Number.isFinite(date2);
+
+                    if (valid1 && !valid2) {
+                        return -1;
+                    }
+                    if (!valid1 && valid2) {
+                        return 1;
+                    }
+                    if (valid1 && valid2 && date1 !== date2) {
+                        return date2 - date1;
+                    }
+
+                    return m1.name.localeCompare(m2.name, undefined, { sensitivity: "base" });
                 }
 
                 // sort by managed by dockge

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -1052,5 +1052,8 @@
     "stackGit.restore": "Restore files",
     "stackGit.restoreConfirm": "Restore tracked stack files from commit {hash}? The worktree must be clean and Compose is validated with automatic rollback on failure.",
     "stackPin": "Pin this stack to the top of the list",
-    "stackUnpin": "Unpin this stack"
+    "stackUnpin": "Unpin this stack",
+    "stackSortCreated": "Creation date",
+    "stackSortUpdated": "Last update",
+    "releaseNews.item.stackDateSorting": "The stack list can now be sorted by creation date or last update. Existing stacks use filesystem creation time when available, while new stacks store an exact Dockge creation timestamp."
 }

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -1042,5 +1042,8 @@
     "stackPin": "Épingler cette stack en haut de la liste",
     "stackUnpin": "Désépingler cette stack",
     "disableAuth": "désactiver l'authentification",
-    "scenarios": "dans lesquels vous avez l'intention d'implémenter une authentification tierce"
+    "scenarios": "dans lesquels vous avez l'intention d'implémenter une authentification tierce",
+    "stackSortCreated": "Date de création",
+    "stackSortUpdated": "Dernière mise à jour",
+    "releaseNews.item.stackDateSorting": "La liste des stacks peut maintenant être triée par date de création ou dernière mise à jour. Les anciennes stacks utilisent leur date de création filesystem lorsqu'elle est disponible, tandis que les nouvelles enregistrent une date de création Dockge exacte."
 }

--- a/frontend/src/release-news.js
+++ b/frontend/src/release-news.js
@@ -49,6 +49,12 @@ export const RELEASE_NEWS = [
             "releaseNews.item.logFollowToggle",
         ],
     },
+    {
+        id: "2026-08-19-stack-date-sorting",
+        items: [
+            "releaseNews.item.stackDateSorting",
+        ],
+    },
 ];
 
 export function getReleaseNewsSince(lastSeenId) {


### PR DESCRIPTION
## Modifications

- ajoute **Date de création** et **Dernière mise à jour** au tri de la liste des stacks ;
- trie ces deux critères du plus récent au plus ancien, avec les dates inconnues en fin de liste ;
- conserve la priorité actuelle des stacks épinglées ;
- enregistre un `createdAt` exact et immuable lors de la création des nouvelles stacks ;
- pour les stacks existantes, utilise le `birthtime` du dossier de stack puis du fichier Compose comme estimation lorsque le filesystem le fournit ;
- n'utilise volontairement ni `mtime` ni `ctime`, afin d'éviter de présenter une modification/restauration comme une création ;
- expose `createdAt`, son caractère estimé et `lastUpdated` dans les données légères utilisées par la liste, y compris via les agents distants ;
- ajoute la nouveauté au popup « Nouveautés » ;
- met à jour les README français, anglais et espagnol.

## Comportement attendu

### Date de création
- nouvelles stacks : date Dockge exacte ;
- stacks existantes : meilleure estimation disponible via le filesystem ;
- si aucune date exploitable n'est disponible : la stack apparaît après celles dont la date est connue.

### Dernière mise à jour
- utilise le `lastUpdated` déjà enregistré par Dockge-Enhanced ;
- les stacks sans historique `lastUpdated` apparaissent après celles dont la date est connue.

## Validation

- `git diff --check`
- validation JSON des traductions FR/EN

Aucune dépendance ajoutée et aucune installation locale requise.
