### PR TITLE
Fiabiliser le déplacement des stacks

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -43,6 +43,8 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 <details>
 <summary><strong>Mostrar el catálogo completo de funcionalidades</strong></summary>
 
+**2026-08-20 — Movimientos de stacks más seguros y errores de despliegue útiles** — El asistente de transferencia ahora detecta conflictos de `container_name` explícitos durante la validación del destino y muestra el error real de Docker Compose, limitado y sin secuencias ANSI, en lugar de remitir a un terminal invisible. Se conservan el streaming de los terminales existentes y el rollback transaccional. Al mover una stack, la transferencia de datos de los volúmenes se selecciona automáticamente cuando hay un transporte directo o compartido compatible; el modo solo configuración sigue disponible y se indica claramente.
+
 **2026-08-19 — Ordenar stacks por fecha de creación y última actualización** — El selector de stacks permite ordenar primero las más recientes por fecha de creación o por la última actualización registrada por Dockge. Las stacks nuevas guardan un `createdAt` exacto e inmutable; las existentes usan la fecha de creación del sistema de archivos cuando está disponible, marcada internamente como estimada. Las stacks fijadas mantienen la prioridad.
 
 **2026-08-18 — Pausa y reanudación del seguimiento de logs en vivo** — La barra de herramientas de Registros puede pausar el seguimiento automático sin desconectar el flujo en vivo: las nuevas líneas siguen entrando en el historial de xterm mientras la posición de lectura permanece fija. Reanudar vuelve inmediatamente a los últimos logs y reactiva el desplazamiento automático.

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,6 +41,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 <details>
 <summary><strong>Afficher le catalogue complet des fonctionnalités</strong></summary>
 
+**2026-08-20 — Déplacements de stacks plus sûrs et erreurs de déploiement utiles** — L’assistant de transfert détecte désormais les conflits de `container_name` explicites pendant la validation de la cible et affiche l’erreur Docker Compose réelle, bornée et débarrassée des séquences ANSI, au lieu de renvoyer vers un terminal invisible. Le streaming des terminaux existants et le rollback transactionnel sont conservés. Pour un déplacement, le transfert des données des volumes est sélectionné automatiquement dès qu’un transport direct ou partagé compatible est disponible ; le mode configuration seule reste disponible et clairement signalé.
+
 **2026-08-19 — Tri des stacks par date de création et dernière mise à jour** — Le sélecteur de stacks peut maintenant trier les stacks les plus récentes en premier selon leur date de création ou leur dernière mise à jour Dockge. Les nouvelles stacks enregistrent un `createdAt` exact et immuable ; les stacks existantes utilisent le birthtime du filesystem lorsqu'il est disponible, identifié en interne comme estimation. Les stacks épinglées restent prioritaires.
 
 **2026-08-18 — Pause et reprise du suivi des logs live** — La barre d'outils des Logs peut suspendre le défilement automatique sans couper le flux live : les nouvelles lignes continuent d'entrer dans le scrollback xterm tandis que la position de lecture reste figée. Reprendre revient immédiatement aux derniers logs et réactive le suivi automatique.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 <details>
 <summary><strong>Show the complete feature catalogue</strong></summary>
 
+**2026-08-20 — Safer stack moves with useful deployment errors** — The transfer wizard now detects explicit `container_name` conflicts during target preflight and displays Docker Compose's real bounded, ANSI-free deployment error instead of referring to an invisible terminal. Existing terminal streaming and transactional rollback behavior are preserved. For a move, volume-data transfer is selected automatically whenever a compatible direct or shared transport is available; configuration-only mode remains available and clearly identified.
+
 **2026-08-19 — Sort stacks by creation date and last update** — The stack selector now supports newest-first sorting by creation date and Dockge's last-update timestamp. New stacks store an immutable exact `createdAt`; existing stacks fall back to filesystem birth time when available, marked internally as estimated. Pinned stacks keep priority.
 
 **2026-08-18 — Pause and resume live log following** — The Logs toolbar can pause automatic following without disconnecting the live stream: new lines continue entering xterm's scrollback while the current reading position stays fixed. Resume jumps straight back to the latest output and restores automatic scrolling.

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -412,9 +412,22 @@ export class Stack {
 
     async deploy(socket : DockgeSocket) : Promise<number> {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("up", "-d", "--remove-orphans"), this.path);
+        const outputChunks : string[] = [];
+        let outputLength = 0;
+        const maxOutputLength = 16_384;
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("up", "-d", "--remove-orphans"), this.path, (data) => {
+            outputChunks.push(data);
+            outputLength += data.length;
+            while (outputLength > maxOutputLength && outputChunks.length > 1) {
+                outputLength -= outputChunks.shift()?.length || 0;
+            }
+        });
         if (exitCode !== 0) {
-            throw new Error("Failed to deploy, please check the terminal output for more information.");
+            const output = outputChunks.join("")
+                .replace(/[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*)?\u0007)|(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g, "")
+                .replace(/\r/g, "")
+                .trim();
+            throw new Error(output || "Docker Compose failed to deploy the stack.");
         }
         const now = new Date().toISOString();
         await this.writeMeta({ lastUpdated: now, lastStartedAt: now });

--- a/backend/terminal.test.ts
+++ b/backend/terminal.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Terminal } from "./terminal";
+import { DockgeServer } from "./dockge-server";
+
+test("captures progress output without changing the terminal exit contract", async () => {
+    let output = "";
+    const exitCode = await Terminal.exec({} as DockgeServer, undefined, `terminal-capture-${Date.now()}`, process.execPath, [ "-e", "process.stderr.write('\\u001b[31mport is already allocated\\u001b[0m\\n');" ], process.cwd(), data => {
+        output += data;
+    });
+
+    assert.equal(exitCode, 0);
+    assert.match(output, /port is already allocated/);
+});

--- a/backend/terminal.ts
+++ b/backend/terminal.ts
@@ -226,7 +226,7 @@ export class Terminal {
         return terminal;
     }
 
-    public static exec(server : DockgeServer, socket : DockgeSocket | undefined, terminalName : string, file : string, args : string | string[], cwd : string) : Promise<number> {
+    public static exec(server : DockgeServer, socket : DockgeSocket | undefined, terminalName : string, file : string, args : string | string[], cwd : string, onOutput? : (data : string) => void) : Promise<number> {
         return new Promise((resolve, reject) => {
             // check if terminal exists
             if (Terminal.terminalMap.has(terminalName)) {
@@ -236,6 +236,12 @@ export class Terminal {
 
             let terminal = new Terminal(server, terminalName, file, args, cwd, process.env);
             terminal.rows = PROGRESS_TERMINAL_ROWS;
+            if (onOutput) {
+                terminal.outputTransform = (data) => {
+                    onOutput(data);
+                    return data;
+                };
+            }
 
             if (socket) {
                 terminal.join(socket);

--- a/backend/transfers/stack-transfer.integration.test.ts
+++ b/backend/transfers/stack-transfer.integration.test.ts
@@ -131,6 +131,27 @@ test("blocks deployment when a Compose device is missing on the target", { skip:
     }
 });
 
+test("blocks deployment when an explicit container name belongs to another project", { skip: !dockerAvailable,
+    timeout: 30_000 }, async () => {
+    const root = await fsAsync.mkdtemp(path.join(os.tmpdir(), "dockge-transfer-container-name-"));
+    const targetName = `transfer-name-${Date.now()}`;
+    const containerName = `dockge-transfer-occupied-${Date.now()}`;
+    const server = { stacksDir: root } as DockgeServer;
+    try {
+        await execFileAsync("docker", [ "create", "--name", containerName, "docker:29.6.1-cli", "sleep", "300" ]);
+        const transferRequest = request(targetName);
+        transferRequest.composeYAML = transferRequest.composeYAML.replace("    image: docker:29.6.1-cli\n", `    image: docker:29.6.1-cli\n    container_name: ${containerName}\n`);
+        const preflight = await preflightStackTransfer(server, transferRequest);
+        const issue = preflight.issues.find(item => item.code === "container-name-conflict");
+        assert.equal(issue?.severity, "error");
+        assert.equal(issue?.params?.name, containerName);
+    } finally {
+        await execFileAsync("docker", [ "rm", "-f", containerName ]).catch(() => {});
+        await fsAsync.rm(root, { recursive: true,
+            force: true });
+    }
+});
+
 test("rolls configuration and containers back when target verification fails", { skip: !dockerAvailable,
     timeout: 90_000 }, async () => {
     const root = await fsAsync.mkdtemp(path.join(os.tmpdir(), "dockge-transfer-rollback-"));
@@ -160,6 +181,34 @@ test("rolls configuration and containers back when target verification fails", {
         assert.equal(fs.existsSync(path.join(root, targetName)), false);
         const ids = String((await execFileAsync("docker", [ "ps", "-aq", "--filter", `label=com.docker.compose.project=${targetName}` ])).stdout).trim();
         assert.equal(ids, "");
+    } finally {
+        await fsAsync.rm(root, { recursive: true,
+            force: true });
+        mock.restoreAll();
+    }
+});
+
+test("surfaces Docker Compose output and rolls back when target deployment fails", { skip: !dockerAvailable,
+    timeout: 30_000 }, async () => {
+    const root = await fsAsync.mkdtemp(path.join(os.tmpdir(), "dockge-transfer-deploy-error-"));
+    const targetName = `transfer-deploy-error-${Date.now()}`;
+    const memory = new Map<string, unknown>();
+    mock.method(Settings, "get", async (key: string) => memory.get(key));
+    mock.method(Settings, "set", async (key: string, value: unknown) => {
+        memory.set(key, value);
+    });
+    mock.method(Terminal, "exec", async (_server: DockgeServer, _socket: DockgeSocket | undefined, _name: string, _file: string, _args: string | string[], _cwd: string, onOutput?: (data: string) => void) => {
+        onOutput?.("\u001b[31mError response from daemon: port is already allocated\u001b[0m\r\n");
+        return 1;
+    });
+    const server = { stacksDir: root } as DockgeServer;
+    const socket = { endpoint: "",
+        id: "integration",
+        connected: true,
+        emitAgent() {} } as unknown as DockgeSocket;
+    try {
+        await assert.rejects(importStackTransfer(server, socket, request(targetName)), /port is already allocated/);
+        assert.equal(fs.existsSync(path.join(root, targetName)), false);
     } finally {
         await fsAsync.rm(root, { recursive: true,
             force: true });

--- a/backend/transfers/stack-transfer.ts
+++ b/backend/transfers/stack-transfer.ts
@@ -668,6 +668,31 @@ export async function preflightStackTransfer(server: DockgeServer, request: Stac
     }
 
     const targetMounts = resolvedMounts(config);
+    for (const [ service, rawService ] of Object.entries(asRecord(config.services))) {
+        const containerName = asRecord(rawService).container_name;
+        if (typeof containerName !== "string" || !containerName.trim()) {
+            continue;
+        }
+        try {
+            const inspected = JSON.parse(await runDocker([ "container", "inspect", containerName.trim() ])) as unknown[];
+            const labels = asRecord(asRecord(asRecord(inspected[0]).Config).Labels);
+            const ownerProject = typeof labels["com.docker.compose.project"] === "string" ? String(labels["com.docker.compose.project"]) : "";
+            const ownerService = typeof labels["com.docker.compose.service"] === "string" ? String(labels["com.docker.compose.service"]) : "";
+            const ownerWorkingDir = typeof labels["com.docker.compose.project.working_dir"] === "string" ? path.resolve(String(labels["com.docker.compose.project.working_dir"])) : "";
+            const targetWorkingDir = path.resolve(server.stacksDir, request.targetName);
+            if (ownerProject !== request.targetName || ownerService !== service || ownerWorkingDir !== targetWorkingDir) {
+                issues.push({ severity: "error",
+                    scope: "deploy",
+                    code: "container-name-conflict",
+                    message: `${service}: container name ${containerName} is already used${ownerProject ? ` by Compose project ${ownerProject}` : ""}`,
+                    params: { service,
+                        name: containerName,
+                        project: ownerProject || "unknown" } });
+            }
+        } catch {
+            // An exact inspect failure means that this explicit name is available.
+        }
+    }
     const occupied = await inspectOccupiedPorts().catch(() => new Set<string>());
     for (const port of publishedPorts(config)) {
         if (occupied.has(`${port.published}/${port.protocol}`)) {

--- a/frontend/src/components/StackTransferModal.vue
+++ b/frontend/src/components/StackTransferModal.vue
@@ -271,7 +271,7 @@
                     <div v-if="operation === 'move'">{{ $t("stackTransfer.sourceKept") }}</div>
                 </div>
 
-                <div v-if="operationError" class="alert alert-danger">{{ operationError }}</div>
+                <div v-if="operationError" class="alert alert-danger transfer-operation-error">{{ operationError }}</div>
                 <div v-if="transferring && transferPhase" class="alert alert-primary">
                     <span class="spinner-border spinner-border-sm me-2" />{{ $t(`stackTransfer.phase.${transferPhase}`) }}
                     <div v-if="currentJob" class="progress mt-2" role="progressbar" :aria-valuenow="currentJob.progress" aria-valuemin="0" aria-valuemax="100">
@@ -509,6 +509,9 @@ export default {
                 this.sourceRunningServices = analysis.data.runningServices || [];
                 this.analysisWarnings = analysis.data.warnings || [];
                 await this.loadDataCapabilities();
+                if (operation === "move" && this.availableRepositories.length > 0) {
+                    this.includeData = true;
+                }
                 await this.loadRules();
                 this.applyRules();
                 if (operation === "replicate") {
@@ -1088,6 +1091,7 @@ export default {
 .transfer-issue-success { background: rgba(25, 135, 84, .14); color: #75d5a5; }
 .transfer-issue-warning { background: rgba(255, 193, 7, .14); color: #ffd76a; }
 .transfer-issue-error { background: rgba(220, 53, 69, .14); color: #ff8793; }
+.transfer-operation-error { white-space: pre-wrap; overflow-wrap: anywhere; }
 .transfer-override-preview { max-height: 260px; overflow: auto; border-radius: .4rem; padding: .75rem; background: rgba(0, 0, 0, .25); font-size: .8rem; }
 .target-compose-editor { min-height: 8rem; resize: vertical; font-family: var(--bs-font-monospace); font-size: .82rem; line-height: 1.45; }
 </style>

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -304,6 +304,7 @@
     "stackTransfer.issue.compose-valid": "The Compose configuration is valid on the target.",
     "stackTransfer.issue.compose-invalid": "Invalid Compose configuration: {error}",
     "stackTransfer.issue.port-conflict": "{service}: port {published}/{protocol} is already in use on the target.",
+    "stackTransfer.issue.container-name-conflict": "{service}: container name {name} is already used on the target by Compose project {project}.",
     "stackTransfer.issue.bind-found": "Target path {path} is available.",
     "stackTransfer.issue.bind-create": "Target path {path} does not exist yet; it will be created automatically during deployment.",
     "stackTransfer.issue.bind-missing": "Target path {path} does not exist yet; it will be created automatically during deployment.",
@@ -1055,5 +1056,7 @@
     "stackUnpin": "Unpin this stack",
     "stackSortCreated": "Creation date",
     "stackSortUpdated": "Last update",
-    "releaseNews.item.stackDateSorting": "The stack list can now be sorted by creation date or last update. Existing stacks use filesystem creation time when available, while new stacks store an exact Dockge creation timestamp."
+    "releaseNews.item.stackDateSorting": "The stack list can now be sorted by creation date or last update. Existing stacks use filesystem creation time when available, while new stacks store an exact Dockge creation timestamp.",
+    "releaseNews.item.stackTransferErrors": "Stack moves now display the real Docker error and detect explicit container names already in use on the target before deployment.",
+    "releaseNews.item.stackTransferData": "Stack moves automatically select data transfer when a compatible transport is available; configuration-only moves remain clearly identified."
 }

--- a/frontend/src/lang/es.json
+++ b/frontend/src/lang/es.json
@@ -4,6 +4,8 @@
     "watcher.backup.concurrentPopupTitle": "Copia ya en curso",
     "watcher.backup.concurrentPopupBody": "Ya se está ejecutando una copia Restic. El nuevo inicio se bloqueó inmediatamente para proteger la CPU y el almacenamiento.",
     "releaseNews.intro": "Estas son las funciones añadidas desde tu anterior actualización de Dockge-Enhanced.",
+    "releaseNews.item.stackTransferErrors": "Al mover una stack ahora se muestra el error real de Docker y se detectan antes del despliegue los nombres de contenedor explícitos ya utilizados en el destino.",
+    "releaseNews.item.stackTransferData": "Al mover una stack, la transferencia de datos se selecciona automáticamente cuando hay un transporte compatible; los movimientos solo de configuración siguen indicándose claramente.",
     "releaseNews.item.updateRange": "La ventana emergente agrupa solo las funciones publicadas desde tu actualización anterior, sin importar cuántas versiones se hayan omitido.",
     "releaseNews.item.logWrap": "Un botón en los registros permite alternar el ajuste de línea o mantener cada entrada completa en una sola línea con desplazamiento horizontal.",
     "releaseNews.item.stackPins": "Los stacks de uso frecuente pueden fijarse en la parte superior del panel lateral, con una preferencia guardada por navegador.",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -296,6 +296,7 @@
     "stackTransfer.issue.compose-valid": "La configuration Compose est valide sur la cible.",
     "stackTransfer.issue.compose-invalid": "Configuration Compose invalide : {error}",
     "stackTransfer.issue.port-conflict": "{service} : le port {published}/{protocol} est déjà utilisé sur la cible.",
+    "stackTransfer.issue.container-name-conflict": "{service} : le nom de conteneur {name} est déjà utilisé sur la cible par le projet Compose {project}.",
     "stackTransfer.issue.bind-found": "Le chemin cible {path} est disponible.",
     "stackTransfer.issue.bind-create": "Le chemin cible {path} n’existe pas encore ; il sera créé automatiquement lors du déploiement.",
     "stackTransfer.issue.bind-missing": "Le chemin cible {path} n’existe pas encore ; il sera créé automatiquement lors du déploiement.",
@@ -1045,5 +1046,7 @@
     "scenarios": "dans lesquels vous avez l'intention d'implémenter une authentification tierce",
     "stackSortCreated": "Date de création",
     "stackSortUpdated": "Dernière mise à jour",
-    "releaseNews.item.stackDateSorting": "La liste des stacks peut maintenant être triée par date de création ou dernière mise à jour. Les anciennes stacks utilisent leur date de création filesystem lorsqu'elle est disponible, tandis que les nouvelles enregistrent une date de création Dockge exacte."
+    "releaseNews.item.stackDateSorting": "La liste des stacks peut maintenant être triée par date de création ou dernière mise à jour. Les anciennes stacks utilisent leur date de création filesystem lorsqu'elle est disponible, tandis que les nouvelles enregistrent une date de création Dockge exacte.",
+    "releaseNews.item.stackTransferErrors": "Le déplacement d’une stack affiche maintenant l’erreur Docker réelle et détecte avant le déploiement les noms de conteneurs explicites déjà utilisés sur la cible.",
+    "releaseNews.item.stackTransferData": "Lors d’un déplacement, le transfert des données est sélectionné automatiquement lorsqu’un transport compatible est disponible ; la copie de configuration seule reste clairement signalée."
 }

--- a/frontend/src/release-news.js
+++ b/frontend/src/release-news.js
@@ -55,6 +55,13 @@ export const RELEASE_NEWS = [
             "releaseNews.item.stackDateSorting",
         ],
     },
+    {
+        id: "2026-08-20-stack-transfer-errors-data",
+        items: [
+            "releaseNews.item.stackTransferErrors",
+            "releaseNews.item.stackTransferData",
+        ],
+    },
 ];
 
 export function getReleaseNewsSince(lastSeenId) {


### PR DESCRIPTION
## Résumé
- affiche l’erreur Docker Compose réelle dans l’assistant de transfert
- bloque les conflits de `container_name` dès la validation de la cible
- présélectionne les données lors d’un déplacement quand un transport est disponible
- actualise la popup de nouveautés et les README

## Validation
- TypeScript et lint ciblé
- tests PTY et 6 scénarios Docker de transfert/rollback
- build frontend et build Docker
- `git diff --check`