### PR TITLE
Fiabiliser la vérification des archives HTTP directes

### DIFF
--- a/backend/transfers/http-direct-transport.ts
+++ b/backend/transfers/http-direct-transport.ts
@@ -218,7 +218,6 @@ export async function resumeDirectHttpArchive(repositoryId: string, snapshotId: 
 }
 
 export async function restoreDirectHttpArchive(repositoryId: string, snapshotId: string, output: Writable): Promise<void> {
-    await verifyDirectHttpArchive(repositoryId, snapshotId);
     const file = await download(repositoryId, snapshotId);
     await new Promise<void>((resolve, reject) => {
         const input = createReadStream(file);

--- a/backend/transfers/stack-image-transfer.integration.test.ts
+++ b/backend/transfers/stack-image-transfer.integration.test.ts
@@ -30,7 +30,7 @@ test("copies a tagged local Docker image over verified direct HTTP", { skip: !do
     app.use("/api/transfer/http", rateLimit({ windowMs: 60_000,
         limit: 100 }));
     app.get("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
-    app.head("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
+    app.head("/api/transfer/http/:id", (_request, response) => response.sendStatus(405));
     const server = createServer(app);
     await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
     const address = server.address();


### PR DESCRIPTION
## Résumé

- évite le précontrôle `HEAD` redondant avant l’import
- conserve l’authentification, la reprise, la taille attendue et le SHA-256 sur le téléchargement
- couvre les serveurs qui refusent les requêtes `HEAD`

## Validation

- TypeScript et lint ciblé
- 19 tests unitaires
- 14 scénarios Docker de transfert et rollback
- transfert réel d’image avec `HEAD` refusé
- builds frontend et Docker
- `git diff --check`