### PR TITLE
Vérifier les archives HTTP par téléchargement

### DIFF
--- a/backend/transfers/http-direct-transport.test.ts
+++ b/backend/transfers/http-direct-transport.test.ts
@@ -22,7 +22,7 @@ test("transfers an archive over authenticated HTTP with Range and SHA-256 verifi
     configureHttpDirectTransport(root);
     const app = express();
     app.get("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
-    app.head("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
+    app.head("/api/transfer/http/:id", (_request, response) => response.sendStatus(405));
     const server = createServer(app);
     await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
     try {
@@ -32,7 +32,7 @@ test("transfers an archive over authenticated HTTP with Range and SHA-256 verifi
         const payload = Buffer.from("direct-http-transfer-".repeat(4096));
         const snapshotId = await uploadDirectHttpArchive(repositoryId, Readable.from(payload));
         await verifyDirectHttpArchive(repositoryId, snapshotId);
-        assert.deepEqual(await resumeDirectHttpArchive(repositoryId, snapshotId), { offset: 0,
+        assert.deepEqual(await resumeDirectHttpArchive(repositoryId, snapshotId), { offset: payload.length,
             size: payload.length });
 
         const descriptor = JSON.parse(Buffer.from(snapshotId.slice("http-snapshot:".length), "base64url").toString("utf8")) as { id: string; token: string };

--- a/backend/transfers/http-direct-transport.ts
+++ b/backend/transfers/http-direct-transport.ts
@@ -200,13 +200,7 @@ async function download(repositoryId: string, snapshotId: string): Promise<strin
 }
 
 export async function verifyDirectHttpArchive(repositoryId: string, snapshotId: string): Promise<void> {
-    const config = repository(repositoryId);
-    const descriptor = snapshot(snapshotId);
-    const response = await fetch(`${config.baseUrl}/api/transfer/http/${descriptor.id}`, { method: "HEAD",
-        headers: await requestHeaders(descriptor) });
-    if (!response.ok || Number(response.headers.get("content-length")) !== descriptor.size || response.headers.get("x-content-sha256") !== descriptor.sha256) {
-        throw new Error("Direct HTTP archive verification failed");
-    }
+    await download(repositoryId, snapshotId);
 }
 
 export async function resumeDirectHttpArchive(repositoryId: string, snapshotId: string): Promise<{ offset: number; size: number }> {


### PR DESCRIPTION
## Résumé

- remplace le précontrôle `HEAD` par le téléchargement authentifié de l’archive
- vérifie la taille et le SHA-256 avant la restauration
- réutilise l’archive vérifiée lors de l’extraction
- couvre explicitement un serveur refusant `HEAD`

## Validation

- TypeScript et lint ciblé
- 17 tests ciblés
- 14 scénarios Docker de transfert, migration et rollback
- builds frontend et Docker
- `git diff --check`