### PR TITLE
Régénérer les snapshots HTTP expirés

### DIFF
--- a/backend/transfers/http-direct-transport.ts
+++ b/backend/transfers/http-direct-transport.ts
@@ -126,6 +126,14 @@ export function isDirectHttpRepository(value: string): boolean {
     return value.startsWith(REPOSITORY_PREFIX);
 }
 
+export function isDirectHttpSnapshotReusable(value: string, minimumValidityMs = 60_000): boolean {
+    try {
+        return new Date(snapshot(value).expiresAt).getTime() > Date.now() + minimumValidityMs;
+    } catch {
+        return false;
+    }
+}
+
 export function directHttpUsesTls(value: string): boolean {
     return repository(value).baseUrl.startsWith("https://");
 }

--- a/backend/transfers/stack-data-transfer.integration.test.ts
+++ b/backend/transfers/stack-data-transfer.integration.test.ts
@@ -111,7 +111,7 @@ async function down(root: string, name: string): Promise<void> {
     } catch { /* best effort */ }
 }
 
-async function createContext(root: string, repository: string): Promise<{ server: DockgeServer; socket: DockgeSocket; repositoryId: string }> {
+async function createContext(root: string, repository: string): Promise<{ server: DockgeServer; socket: DockgeSocket; repositoryId: string; memory: Map<string, unknown> }> {
     const memory = new Map<string, unknown>();
     mock.method(Settings, "get", async (key: string) => memory.get(key));
     mock.method(Settings, "set", async (key: string, value: unknown) => {
@@ -143,7 +143,8 @@ async function createContext(root: string, repository: string): Promise<{ server
         emitAgent() {} } as unknown as DockgeSocket;
     return { server,
         socket,
-        repositoryId: getStackTransferRepositories()[0].id };
+        repositoryId: getStackTransferRepositories()[0].id,
+        memory };
 }
 
 test("copies bind and named-volume data through a shared Restic repository", { skip: !integrationAvailable,
@@ -201,7 +202,7 @@ test("copies bind and named-volume data through resumable direct HTTP", { skip: 
     configureHttpDirectTransport(path.join(root, ".data"));
     const app = express();
     app.get("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
-    app.head("/api/transfer/http/:id", (request, response) => void serveDirectHttpArchive(request, response));
+    app.head("/api/transfer/http/:id", (_request, response) => response.sendStatus(405));
     const httpServer = createServer(app);
     await new Promise<void>(resolve => httpServer.listen(0, "127.0.0.1", resolve));
     try {
@@ -210,12 +211,19 @@ test("copies bind and named-volume data through resumable direct HTTP", { skip: 
         assert.ok(address && typeof address === "object");
         const repositoryId = directHttpRepositoryId(`http://127.0.0.1:${address.port}`);
         await writeSource(root, sourceName);
-        const snapshot = await createStackTransferDataSnapshot(context.server, { transferId,
+        const request = { transferId,
             stackName: sourceName,
             repositoryId,
             mappings: mappings(),
-            policy: { mode: "hot" },
-            phase: "copy" });
+            policy: { mode: "hot" as const },
+            phase: "copy" as const };
+        const expired = await createStackTransferDataSnapshot(context.server, request);
+        const jobs = context.memory.get("stackTransferDataSourceJobs") as Array<{ snapshotIds: string[] }>;
+        const descriptor = JSON.parse(Buffer.from(expired.snapshotId.slice("http-snapshot:".length), "base64url").toString("utf8")) as Record<string, unknown>;
+        descriptor.expiresAt = new Date(Date.now() - 1_000).toISOString();
+        jobs[0].snapshotIds = [ `http-snapshot:${Buffer.from(JSON.stringify(descriptor)).toString("base64url")}` ];
+        const snapshot = await createStackTransferDataSnapshot(context.server, request);
+        assert.notEqual(snapshot.snapshotId, expired.snapshotId);
         await stageStackTransferDataTarget(context.server, context.socket, { transferId,
             repositoryId,
             snapshotId: snapshot.snapshotId,

--- a/backend/transfers/stack-data-transfer.ts
+++ b/backend/transfers/stack-data-transfer.ts
@@ -25,6 +25,7 @@ import {
 } from "./stack-transfer";
 import { StackTransferRepository } from "./stack-transfer-restic";
 import { stackTransferTransport } from "./stack-transfer-transport";
+import { isDirectHttpRepository, isDirectHttpSnapshotReusable } from "./http-direct-transport";
 
 const execFileAsync = promisify(execFile);
 const SOURCE_JOBS_SETTING = "stackTransferDataSourceJobs";
@@ -360,9 +361,12 @@ export async function createStackTransferDataSnapshot(server: DockgeServer, requ
     const existing = (await readSourceJobs()).find(item => item.id === assertTransferId(request.transferId));
     if (existing?.status === "snapshotted" && existing.phase === request.phase && existing.snapshotIds.length) {
         const snapshotId = existing.snapshotIds.at(-1)!;
-        return { snapshotId,
-            archivePath: archivePath(existing.id, request.phase),
-            bytesTransferred: existing.snapshotBytes?.[snapshotId] || 0 };
+        if (!isDirectHttpRepository(existing.repositoryId) || isDirectHttpSnapshotReusable(snapshotId)) {
+            return { snapshotId,
+                archivePath: archivePath(existing.id, request.phase),
+                bytesTransferred: existing.snapshotBytes?.[snapshotId] || 0 };
+        }
+        await stackTransferTransport.cleanup(existing.repositoryId, existing.snapshotIds).catch(() => {});
     }
     const now = new Date().toISOString();
     const job: SourceDataJob = {


### PR DESCRIPTION
## Résumé

- détecte les snapshots HTTP temporaires expirés ou proches de l’expiration
- régénère automatiquement l’archive et son jeton lors d’une nouvelle tentative
- conserve la reprise normale tant que le snapshot reste valide
- couvre le cas réel d’un identifiant de transfert réutilisé après expiration

## Validation

- TypeScript et lint ciblé
- tests unitaires ciblés
- 14 scénarios Docker de transfert, migration et rollback
- test de régénération puis restauration des volumes
- builds frontend et Docker
- `git diff --check`