### PR TITLE
Rafraîchir le snapshot lors d’une reprise

### DIFF
--- a/frontend/src/components/StackTransferModal.vue
+++ b/frontend/src/components/StackTransferModal.vue
@@ -1053,7 +1053,7 @@ export default {
             persist();
             try {
                 this.transferPhase = this.operation === "move" ? "initialSnapshot" : "snapshot";
-                const snapshot = state.snapshot || await this.emitAgentLong(this.endpoint, "createStackTransferDataSnapshot", {
+                const snapshot = await this.emitAgentLong(this.endpoint, "createStackTransferDataSnapshot", {
                     transferId,
                     stackName: this.stack.name,
                     repositoryId: this.repositoryId,


### PR DESCRIPTION
## Résumé

- redemande systématiquement le snapshot à l’instance source lors d’une reprise
- permet à la source de réutiliser un snapshot valide ou d’en régénérer un expiré
- empêche le navigateur de renvoyer indéfiniment un ancien jeton conservé dans `localStorage`

## Validation

- TypeScript, lint et build frontend
- build Docker
- transfert HTTP direct réel de 59 146 240 octets
- restauration PostgreSQL et Redis avec services sains
- reprise réelle à partir d’une tâche contenant un jeton expiré
- `git diff --check`