### PR TITLE
Préserver le défilement pendant l’édition Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ ENV NODE_ENV=production
 
 # Docker CLI + Compose plugin (nécessaires pour gérer les stacks)
 # Trivy n'est pas installé ici — le scanner utilise aquasec/trivy:latest via Docker
-RUN apk add --no-cache docker-cli docker-cli-compose git openssh-client sshpass rsync
+RUN apk upgrade --no-cache libcrypto3 libssl3 \
+    && apk add --no-cache docker-cli docker-cli-compose git openssh-client sshpass rsync
 
 # npm et Corepack ne sont pas nécessaires à l’exécution. Les retirer élimine
 # aussi leur propre arbre de dépendances de l’image exposée.

--- a/backend/watchers/dozzle-manager.test.ts
+++ b/backend/watchers/dozzle-manager.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { buildDozzleCompose, isLegacyManagedDozzle, isManagedComposeContainer } from "./dozzle-manager";
 
 interface DozzleComposeModel {

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -487,6 +487,8 @@
                             tab="true"
                             :disabled="!isEditMode"
                             :hasFocus="editorFocus"
+                            :scroll-into-view="false"
+                            preserve-scroll-position
                             @change="yamlCodeChange"
                         />
                     </div>
@@ -517,6 +519,8 @@
                                 tab="true"
                                 :disabled="!isEditMode"
                                 :hasFocus="editorFocus"
+                                :scroll-into-view="false"
+                                preserve-scroll-position
                             />
                         </div>
                     </div>
@@ -543,6 +547,8 @@
                                 tab="true"
                                 :disabled="!isEditMode"
                                 :hasFocus="editorFocus"
+                                :scroll-into-view="false"
+                                preserve-scroll-position
                                 @change="yamlCodeChange"
                             />
                         </div>


### PR DESCRIPTION
Corrige #255.

## Résumé
- conserve la position de défilement des éditeurs Compose, override et `.env` lors des mises à jour programmatiques
- évite le défilement forcé de la page pendant l’édition visuelle
- adapte le test Dozzle à l’interface ESM actuelle de `js-yaml`
- applique le correctif OpenSSL disponible dans l’image Alpine de production

## Validation
- TypeScript et build frontend
- build Docker
- scan Trivy local : aucune vulnérabilité HIGH/CRITICAL
- tests d’intégration complets : seul l’échec de métadonnées déjà présent sur `main` subsiste
- test Dozzle ciblé : 3/3