### PR TITLE
Rétablir la console dans l’image Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV NODE_ENV=production
 # Docker CLI + Compose plugin (nécessaires pour gérer les stacks)
 # Trivy n'est pas installé ici — le scanner utilise aquasec/trivy:latest via Docker
 RUN apk upgrade --no-cache libcrypto3 libssl3 \
-    && apk add --no-cache docker-cli docker-cli-compose git openssh-client sshpass rsync
+    && apk add --no-cache bash docker-cli docker-cli-compose git openssh-client sshpass rsync
 
 # npm et Corepack ne sont pas nécessaires à l’exécution. Les retirer élimine
 # aussi leur propre arbre de dépendances de l’image exposée.

--- a/backend/terminal.test.ts
+++ b/backend/terminal.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { Terminal } from "./terminal";
+import { mainTerminalShell, Terminal } from "./terminal";
 import { DockgeServer } from "./dockge-server";
 
 test("captures progress output without changing the terminal exit contract", async () => {
@@ -11,4 +11,17 @@ test("captures progress output without changing the terminal exit contract", asy
 
     assert.equal(exitCode, 0);
     assert.match(output, /port is already allocated/);
+});
+
+test("uses bash on Unix when it is available", () => {
+    assert.equal(mainTerminalShell("linux", (command) => command === "bash"), "bash");
+});
+
+test("falls back to sh on Unix when bash is unavailable", () => {
+    assert.equal(mainTerminalShell("linux", () => false), "sh");
+});
+
+test("prefers PowerShell 7 and keeps the Windows PowerShell fallback", () => {
+    assert.equal(mainTerminalShell("win32", (command) => command === "pwsh.exe"), "pwsh.exe");
+    assert.equal(mainTerminalShell("win32", () => false), "powershell.exe");
 });

--- a/backend/terminal.ts
+++ b/backend/terminal.ts
@@ -274,27 +274,24 @@ export class InteractiveTerminal extends Terminal {
     }
 }
 
+export function mainTerminalShell(platform: NodeJS.Platform, commandExists = commandExistsSync): string {
+    if (platform === "win32") {
+        return commandExists("pwsh.exe") ? "pwsh.exe" : "powershell.exe";
+    }
+    return commandExists("bash") ? "bash" : "sh";
+}
+
 /**
  * User interactive terminal that use bash or powershell with limited commands such as docker, ls, cd, dir
  */
 export class MainTerminal extends InteractiveTerminal {
     constructor(server : DockgeServer, name : string) {
-        let shell;
-
         // Throw an error if console is not enabled
         if (!server.config.enableConsole) {
             throw new Error("Console is not enabled.");
         }
 
-        if (os.platform() === "win32") {
-            if (commandExistsSync("pwsh.exe")) {
-                shell = "pwsh.exe";
-            } else {
-                shell = "powershell.exe";
-            }
-        } else {
-            shell = "bash";
-        }
+        const shell = mainTerminalShell(os.platform());
         super(server, name, shell, [], server.stacksDir);
     }
 


### PR DESCRIPTION
Corrige #258.

## Résumé
- installe Bash dans l’image de production Alpine
- utilise  comme repli lorsque Bash est absent
- conserve les choix PowerShell sous Windows
