### PR TITLE
Ajouter des prérequis de démarrage par stack

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -30,7 +30,7 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 | Área | Lo que agrega Dockge Enhanced |
 | --- | --- |
 | **Multiinstancia** | Federación automática en malla completa al agregar o quitar un agente, gestión desde cada instancia vinculada, selección y agrupación multiservidor, copia/migración transaccional, trabajos reanudables y replicación en frío automática |
-| **Gestión de stacks** | Stacks fijados, columna de stacks más densa y redimensionable, espacio Registros/Compose redimensionable, copia fiable del YAML sin formato, acciones y programación por stack y por contenedor, Construir + Recrear, notas y herramientas Git opcionales, y protecciones para servicios que comparten una red VPN |
+| **Gestión de stacks** | Stacks fijados, columna de stacks más densa y redimensionable, espacio Registros/Compose redimensionable, copia fiable del YAML sin formato, acciones y programación por stack y por contenedor, requisitos de inicio del host opcionales, Construir + Recrear, notas y herramientas Git opcionales, y protecciones para servicios que comparten una red VPN |
 | **Copias de seguridad y recuperación** | Restic con múltiples destinos, volúmenes, consistencia por stack, restauración selectiva, pruebas de instantáneas y diferencias (diffs) |
 | **Automatización y auditoría** | API REST acotada por permisos y stacks, webhooks por stack, ejemplos para Home Assistant e historial centralizado con origen y duración |
 | **Recursos de Docker** | Imágenes, volúmenes, contenedores no gestionados y redes, acciones masivas, limpieza automática y protecciones para eliminaciones de riesgo |
@@ -42,6 +42,8 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 
 <details>
 <summary><strong>Mostrar el catálogo completo de funcionalidades</strong></summary>
+
+**2026-08-27 — Requisitos de inicio del host por stack** — Las stacks gestionadas pueden comprobar opcionalmente puntos de montaje del host y servicios `systemd` antes de iniciar, reiniciar o recrear contenedores. El mismo guardia protege los inicios programados de stacks y servicios, mientras que Detener, Down y Eliminar siguen disponibles. Las comprobaciones usan helpers Docker efímeros aislados de la red contra el host, se pueden probar desde la página de la stack y no cambian el comportamiento existente hasta activarlas.
 
 **2026-08-22 — Credenciales de federación resistentes y recuperación** — Las instancias Enhanced ahora intercambian JWT de federación dedicados, vinculados al ID de un usuario activo en lugar del nombre de usuario WebUI y el hash de contraseña modificables. Renombrar una cuenta, cambiar su contraseña o aplicar un rehash automático ya no deja sin conexión las instancias vinculadas. La primera sesión autenticada después de actualizar renueva automáticamente una malla que aún funciona. Si un enlace ya estaba roto, una acción con una llave junto a la instancia sin conexión acepta una sola vez sus credenciales WebUI actuales, las sustituye por el token dedicado y vuelve a intentar la sincronización completa sin eliminar la instancia, los stacks ni los datos.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -28,7 +28,7 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 | Domaine | Dockge Enhanced ajoute |
 | --- | --- |
 | **Multi-instance** | Fédération automatique en maillage complet à l'ajout ou au retrait d'un agent, gestion depuis chaque instance liée, sélection et regroupement multi-serveurs, copie/migration transactionnelle, jobs reprenables et réplication froide automatique |
-| **Gestion des stacks** | Stacks épinglées, colonne des stacks plus dense et redimensionnable, espace Logs/Compose redimensionnable, copie fiable du YAML brut, actions et planification par stack et conteneur, Build + Recreate, notes et outils Git facultatifs, et protections pour les services partageant le réseau d'un VPN |
+| **Gestion des stacks** | Stacks épinglées, colonne des stacks plus dense et redimensionnable, espace Logs/Compose redimensionnable, copie fiable du YAML brut, actions et planification par stack et conteneur, prérequis de démarrage hôte facultatifs, Build + Recreate, notes et outils Git facultatifs, et protections pour les services partageant le réseau d'un VPN |
 | **Sauvegarde & reprise** | Restic multi-destination, volumes, cohérence par stack, restauration sélective, tests et diffs de snapshots |
 | **Automatisation & audit** | API REST limitée par droits et stacks, webhooks par stack, exemples Home Assistant et historique central avec origine et durée |
 | **Ressources Docker** | Images, volumes, conteneurs hors Dockge et réseaux, actions groupées, auto-prune et protections contre les suppressions risquées |
@@ -40,6 +40,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 
 <details>
 <summary><strong>Afficher le catalogue complet des fonctionnalités</strong></summary>
+
+**2026-08-27 — Prérequis hôte par stack au démarrage** — Les stacks gérées peuvent vérifier facultativement des points de montage hôte et services `systemd` avant tout démarrage, redémarrage ou recréation. Le même garde protège les démarrages planifiés des stacks et services, tandis que Stop, Down et Delete restent disponibles. Les vérifications passent par des helpers Docker éphémères isolés du réseau, interrogent l’hôte, se testent depuis la page de la stack et ne changent aucun comportement tant qu’elles ne sont pas activées.
 
 **2026-08-22 — Identifiants de fédération résilients et récupération** — Les instances Enhanced échangent désormais des JWT de fédération dédiés, liés à l’ID d’un utilisateur actif plutôt qu’à l’identifiant WebUI et au hash de mot de passe modifiables. Renommer un compte, changer son mot de passe ou le rehasher automatiquement ne met plus les instances liées hors ligne. La première session authentifiée après la mise à jour renouvelle automatiquement un maillage encore fonctionnel. Si une liaison était déjà cassée, une action avec une clé à côté de l’instance hors ligne accepte une seule fois ses identifiants WebUI actuels, les remplace par le jeton dédié et retente la synchronisation complète sans supprimer l’instance, les stacks ni les données.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 | Area | Dockge Enhanced adds |
 | --- | --- |
 | **Multi-instance** | Automatic full-mesh federation when an agent is added or removed, management from every linked instance, multi-server selection and grouping, transactional copy/migration, resumable jobs, and automatic cold replication |
-| **Stack management** | Pinned stacks, denser resizable stack sidebar, resizable Logs/Compose workspace, reliable raw YAML copy, per-stack and per-container actions and scheduling, Build + Recreate, optional notes and Git tools, and safeguards for services sharing a VPN network |
+| **Stack management** | Pinned stacks, denser resizable stack sidebar, resizable Logs/Compose workspace, reliable raw YAML copy, per-stack and per-container actions and scheduling, optional host start prerequisites, Build + Recreate, optional notes and Git tools, and safeguards for services sharing a VPN network |
 | **Backup & recovery** | Multi-destination Restic, volumes, per-stack consistency, selective restore, snapshot tests and diffs |
 | **Automation & audit** | REST API scoped by permissions and stacks, per-stack webhooks, Home Assistant examples, and centralized history with origin and duration |
 | **Docker resources** | Images, volumes, unmanaged containers and networks, bulk actions, auto-prune, and safeguards for risky deletions |
@@ -40,6 +40,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 
 <details>
 <summary><strong>Show the complete feature catalogue</strong></summary>
+
+**2026-08-27 — Per-stack host start prerequisites** — Managed stacks can optionally verify host mount points and `systemd` services before they start, restart or recreate containers. The same guard protects scheduled stack and service starts, while Stop, Down and Delete remain available. Checks run through short-lived, network-isolated Docker helpers against the host, can be tested from the stack page, and keep existing behavior unchanged until enabled.
 
 **2026-08-22 — Resilient federation credentials and recovery** — Enhanced instances now exchange dedicated federation JWTs tied to an active user ID rather than to the mutable WebUI username and password hash. Renaming an account, changing its password or transparently rehashing it no longer takes linked instances offline. The first authenticated session after upgrading rotates an operational mesh automatically. If a link was already broken, a key action beside the offline instance accepts its current WebUI credentials once, replaces them with the dedicated token and retries full-mesh synchronization without removing the instance, stacks or data.
 

--- a/backend/agent-socket-handlers/docker-socket-handler.ts
+++ b/backend/agent-socket-handlers/docker-socket-handler.ts
@@ -361,6 +361,39 @@ export class DockerSocketHandler extends AgentSocketHandler {
             }
         });
 
+        agentSocket.on("getStackStartGuardStatus", async (stackName : unknown, startGuard : unknown, callback) => {
+            if (typeof startGuard === "function") {
+                callback = startGuard;
+                startGuard = undefined;
+            }
+            try {
+                checkLogin(socket);
+                if (typeof stackName !== "string") {
+                    throw new ValidationError("Stack name must be a string");
+                }
+                const stack = await Stack.getStack(server, stackName);
+                callbackResult(await stack.getStartGuardStatus(startGuard), callback);
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
+        agentSocket.on("saveStackStartGuard", async (stackName : unknown, startGuard : unknown, callback) => {
+            try {
+                checkLogin(socket);
+                if (typeof stackName !== "string") {
+                    throw new ValidationError("Stack name must be a string");
+                }
+                const stack = await Stack.getStack(server, stackName);
+                const savedStartGuard = await stack.saveStartGuard(startGuard);
+                await this.auditStack(socket, "stack.start_guard.save", stackName, "success", null, { conditions: savedStartGuard.conditions.length });
+                server.sendStackList();
+                callbackResult({ ok: true, startGuard: savedStartGuard }, callback);
+            } catch (e) {
+                callbackError(e, callback);
+            }
+        });
+
         // down stack
         agentSocket.on("downStack", async (stackName : unknown, callback) => {
             try {

--- a/backend/operations-toolkit.test.ts
+++ b/backend/operations-toolkit.test.ts
@@ -60,9 +60,12 @@ test("stack notes preserve existing metadata and enforce their size limit", asyn
         assert.deepEqual(
             JSON.parse(await fs.readFile(path.join(stackDir, ".dockge-meta.json"), "utf8")),
             {
+                createdAt: null,
+                createdAtEstimated: false,
                 lastUpdated: "2026-07-26T00:00:00.000Z",
                 lastStartedAt: "2026-07-26T01:00:00.000Z",
                 note: "runbook: internal wiki",
+                startGuard: { enabled: false, conditions: [] },
             },
         );
         await assert.rejects(stack.saveNote("x".repeat(10_001)), /10000/);

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -51,12 +51,48 @@ interface StackContainerVolumeUsage {
     mounts: StackVolumeMountUsage[];
 }
 
+export type StartGuardConditionType = "mount" | "systemd";
+
+export interface StartGuardCondition {
+    type: StartGuardConditionType;
+    target: string;
+}
+
+export interface StartGuard {
+    enabled: boolean;
+    conditions: StartGuardCondition[];
+}
+
+export interface StartGuardConditionStatus extends StartGuardCondition {
+    ok: boolean;
+    message: string;
+}
+
+export interface StartGuardStatus {
+    ok: boolean;
+    enabled: boolean;
+    ready: boolean;
+    conditions: StartGuardConditionStatus[];
+}
+
 interface StackMetadata {
     createdAt: string | null;
     createdAtEstimated: boolean;
     lastUpdated: string | null;
     lastStartedAt: string | null;
     note: string;
+    startGuard: StartGuard;
+}
+
+const HOST_HELPER_IMAGE = process.env.DOCKGE_VOLUME_HELPER_IMAGE || "busybox:stable";
+const HOST_HELPER_TIMEOUT = 15_000;
+
+export function isHostMountPoint(mountInfo: string, target: string): boolean {
+    return mountInfo.split("\n").some((line) => {
+        const separator = line.indexOf(" - ");
+        const fields = (separator >= 0 ? line.slice(0, separator) : line).split(" ");
+        return fields[4] === `/host${target}`;
+    });
 }
 
 // Nom du fichier d'override compose. Docker Compose le fusionne automatiquement
@@ -136,6 +172,7 @@ export class Stack {
             composeENV: this.composeENV,
             composeOverrideYAML: this.composeOverrideYAML,
             note: metadata.note,
+            startGuard: metadata.startGuard,
             primaryHostname,
         };
     }
@@ -334,6 +371,7 @@ export class Stack {
             lastUpdated: null,
             lastStartedAt: null,
             note: "",
+            startGuard: { enabled: false, conditions: [] },
         };
     }
 
@@ -344,7 +382,53 @@ export class Stack {
             lastUpdated: typeof parsed.lastUpdated === "string" ? parsed.lastUpdated : null,
             lastStartedAt: typeof parsed.lastStartedAt === "string" ? parsed.lastStartedAt : null,
             note: typeof parsed.note === "string" ? parsed.note : "",
+            startGuard: Stack.normalizeStartGuard(parsed.startGuard),
         };
+    }
+
+    static normalizeStartGuard(value: unknown, strict = false): StartGuard {
+        if (!value || typeof value !== "object") {
+            return { enabled: false, conditions: [] };
+        }
+        const guard = value as { enabled?: unknown; conditions?: unknown };
+        if (!Array.isArray(guard.conditions)) {
+            return { enabled: guard.enabled === true, conditions: [] };
+        }
+        if (guard.conditions.length > 20) {
+            if (!strict) {
+                return { enabled: false, conditions: [] };
+            }
+            throw new ValidationError("A start guard supports at most 20 conditions");
+        }
+        let conditions: StartGuardCondition[];
+        try {
+            conditions = guard.conditions.map((condition) => Stack.normalizeStartGuardCondition(condition));
+        } catch (error) {
+            if (!strict) {
+                return { enabled: false, conditions: [] };
+            }
+            throw error;
+        }
+        return { enabled: guard.enabled === true, conditions };
+    }
+
+    private static normalizeStartGuardCondition(value: unknown): StartGuardCondition {
+        if (!value || typeof value !== "object") {
+            throw new ValidationError("Invalid start guard condition");
+        }
+        const condition = value as { type?: unknown; target?: unknown };
+        if ((condition.type !== "mount" && condition.type !== "systemd") || typeof condition.target !== "string") {
+            throw new ValidationError("Invalid start guard condition");
+        }
+        const target = condition.target.trim();
+        if (condition.type === "mount") {
+            if (!/^\/(?:[A-Za-z0-9._@+-]+\/)*[A-Za-z0-9._@+-]+$/.test(target)) {
+                throw new ValidationError("Mount prerequisite must be an absolute host path");
+            }
+        } else if (!/^[A-Za-z0-9][A-Za-z0-9@_.-]*\.service$/.test(target)) {
+            throw new ValidationError("Systemd prerequisite must be a .service unit name");
+        }
+        return { type: condition.type, target };
     }
 
     private readMetaSync(): StackMetadata {
@@ -410,7 +494,57 @@ export class Stack {
         return normalized;
     }
 
+    async saveStartGuard(startGuard: unknown): Promise<StartGuard> {
+        const normalized = Stack.normalizeStartGuard(startGuard, true);
+        await this.writeMeta({ startGuard: normalized });
+        return normalized;
+    }
+
+    async getStartGuardStatus(startGuardInput?: unknown): Promise<StartGuardStatus> {
+        const startGuard = startGuardInput === undefined
+            ? (await this.readMeta()).startGuard
+            : Stack.normalizeStartGuard(startGuardInput, true);
+        if (!startGuard.enabled || startGuard.conditions.length === 0) {
+            return { ok: true, enabled: startGuard.enabled, ready: true, conditions: [] };
+        }
+        const conditions = await Promise.all(startGuard.conditions.map((condition) => this.checkStartGuardCondition(condition)));
+        return { ok: conditions.every((condition) => condition.ok), enabled: true, ready: conditions.every((condition) => condition.ok), conditions };
+    }
+
+    private async assertStartGuard(): Promise<void> {
+        const status = await this.getStartGuardStatus();
+        if (!status.ready) {
+            const failed = status.conditions.find((condition) => !condition.ok);
+            throw new Error(`Start prerequisite failed: ${failed?.type === "mount" ? "host mount" : "systemd service"} ${failed?.target ?? "unknown"} — ${failed?.message ?? "not ready"}`);
+        }
+    }
+
+    private async checkStartGuardCondition(condition: StartGuardCondition): Promise<StartGuardConditionStatus> {
+        try {
+            if (condition.type === "mount") {
+                const result = await childProcessAsync.spawn("docker", [
+                    "run", "--rm", "--network", "none",
+                    "--mount", "type=bind,src=/,dst=/host,readonly",
+                    HOST_HELPER_IMAGE, "cat", "/proc/self/mountinfo",
+                ], { encoding: "utf-8", timeout: HOST_HELPER_TIMEOUT });
+                const mounted = isHostMountPoint(result.stdout?.toString() ?? "", condition.target);
+                return { ...condition, ok: mounted, message: mounted ? "Mounted" : "Host path is not a mount point" };
+            }
+
+            await childProcessAsync.spawn("docker", [
+                "run", "--rm", "--network", "none", "--privileged", "--pid", "host",
+                "--mount", "type=bind,src=/,dst=/host,readonly",
+                HOST_HELPER_IMAGE, "chroot", "/host", "/usr/bin/systemctl", "is-active", "--quiet", condition.target,
+            ], { encoding: "utf-8", timeout: HOST_HELPER_TIMEOUT });
+            return { ...condition, ok: true, message: "Service is active" };
+        } catch (error) {
+            const output = error instanceof Error ? error.message : "Host prerequisite check failed";
+            return { ...condition, ok: false, message: condition.type === "mount" ? "Host path is not a mount point" : `Service is inactive or unavailable (${output})` };
+        }
+    }
+
     async deploy(socket : DockgeSocket) : Promise<number> {
+        await this.assertStartGuard();
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         const outputChunks : string[] = [];
         let outputLength = 0;
@@ -656,6 +790,7 @@ export class Stack {
     }
 
     async start(socket: DockgeSocket) {
+        await this.assertStartGuard();
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("up", "-d", "--remove-orphans"), this.path);
         if (exitCode !== 0) {
@@ -675,6 +810,7 @@ export class Stack {
     }
 
     async startScheduled(): Promise<number> {
+        await this.assertStartGuard();
         const res = await childProcessAsync.spawn("docker", this.getComposeOptions("up", "-d", "--remove-orphans"), {
             cwd: this.path,
             encoding: "utf-8",
@@ -701,6 +837,9 @@ export class Stack {
     }
 
     async serviceScheduled(serviceName: string, action: "start" | "stop"): Promise<number> {
+        if (action === "start") {
+            await this.assertStartGuard();
+        }
         const targets = await this.getServiceActionTargets(serviceName);
         const args = action === "start"
             ? this.getComposeOptions("up", "-d", serviceName)
@@ -721,6 +860,7 @@ export class Stack {
     }
 
     async restart(socket: DockgeSocket) : Promise<number> {
+        await this.assertStartGuard();
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("restart"), this.path);
         if (exitCode !== 0) {
@@ -734,6 +874,7 @@ export class Stack {
         if (!serviceName) {
             throw new ValidationError("Service name is required");
         }
+        await this.assertStartGuard();
         const res = await childProcessAsync.spawn("docker", this.getComposeOptions("restart", serviceName), {
             cwd: this.path,
             encoding: "utf-8",
@@ -784,6 +925,9 @@ export class Stack {
     }
 
     async serviceAction(socket: DockgeSocket, serviceName: string, action: "start" | "stop" | "restart" | "update" | "recreate" | "pull-recreate"): Promise<string[]> {
+        if (action !== "stop") {
+            await this.assertStartGuard();
+        }
         const targets = await this.getServiceActionTargets(serviceName);
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         const exec = async (command: string, ...args: string[]) => {
@@ -831,6 +975,7 @@ export class Stack {
     }
 
     async recreate(socket: DockgeSocket) : Promise<number> {
+        await this.assertStartGuard();
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         const exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("up", "-d", "--force-recreate", "--remove-orphans"), this.path);
         if (exitCode !== 0) {
@@ -841,6 +986,7 @@ export class Stack {
     }
 
     async recreateInBackground() : Promise<number> {
+        await this.assertStartGuard();
         const res = await childProcessAsync.spawn("docker", this.getComposeOptions("up", "-d", "--force-recreate", "--remove-orphans"), {
             cwd: this.path,
             encoding: "utf-8",
@@ -864,6 +1010,13 @@ export class Stack {
 
     async update(socket: DockgeSocket) {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
+        const startGuard = (await this.readMeta()).startGuard;
+        if (startGuard.enabled && startGuard.conditions.length > 0) {
+            await this.updateStatus();
+            if (this.status === RUNNING) {
+                await this.assertStartGuard();
+            }
+        }
         let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("pull"), this.path);
         if (exitCode !== 0) {
             throw new Error("Failed to pull, please check the terminal output for more information.");
@@ -873,7 +1026,6 @@ export class Stack {
         await this.writeMeta({ lastUpdated: new Date().toISOString() });
 
         // If the stack is not running, we don't need to restart it
-        await this.updateStatus();
         log.debug("update", "Status: " + this.status);
         if (this.status !== RUNNING) {
             return exitCode;
@@ -889,6 +1041,7 @@ export class Stack {
     }
 
     async pullAndRecreate(socket: DockgeSocket) : Promise<number> {
+        await this.assertStartGuard();
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", this.getComposeOptions("pull"), this.path);
         if (exitCode !== 0) {
@@ -911,6 +1064,7 @@ export class Stack {
         if (buildServices.length === 0) {
             throw new ValidationError("This stack has no service with a build configuration");
         }
+        await this.assertStartGuard();
 
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
         let exitCode = await Terminal.exec(

--- a/backend/start-guard.test.ts
+++ b/backend/start-guard.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isHostMountPoint, Stack } from "./stack";
+
+test("keeps legacy stacks unguarded", () => {
+    assert.deepEqual(Stack.normalizeStartGuard(undefined), { enabled: false, conditions: [] });
+    assert.deepEqual(Stack.normalizeStartGuard({ enabled: true, conditions: [] }), { enabled: true, conditions: [] });
+});
+
+test("validates only safe host mount and systemd prerequisites", () => {
+    assert.deepEqual(Stack.normalizeStartGuard({
+        enabled: true,
+        conditions: [
+            { type: "mount", target: " /mnt/torrent " },
+            { type: "systemd", target: "rclone-synology.service" },
+        ],
+    }), {
+        enabled: true,
+        conditions: [
+            { type: "mount", target: "/mnt/torrent" },
+            { type: "systemd", target: "rclone-synology.service" },
+        ],
+    });
+    assert.throws(() => Stack.normalizeStartGuard({ enabled: true, conditions: [ { type: "mount", target: "relative" } ] }, true));
+    assert.throws(() => Stack.normalizeStartGuard({ enabled: true, conditions: [ { type: "systemd", target: "bad.service;id" } ] }, true));
+    assert.deepEqual(Stack.normalizeStartGuard({ enabled: true, conditions: [ { type: "mount", target: "relative" } ] }), { enabled: false, conditions: [] });
+});
+
+test("recognizes a host mount point without trusting a directory", () => {
+    const mountInfo = "36 25 0:32 / /host/mnt/torrent rw,relatime - ext4 /dev/sda1 rw\n37 25 0:33 / /host/mnt/media rw,relatime - ext4 /dev/sdb1 rw";
+    assert.equal(isHostMountPoint(mountInfo, "/mnt/torrent"), true);
+    assert.equal(isHostMountPoint(mountInfo, "/mnt/torrent/missing"), false);
+});

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -1076,5 +1076,17 @@
     "releaseNews.item.stackTransferErrors": "Stack moves now display the real Docker error and detect explicit container names already in use on the target before deployment.",
     "releaseNews.item.stackTransferData": "Stack moves automatically select data transfer when a compatible transport is available; configuration-only moves remain clearly identified.",
     "releaseNews.item.stackTransferRegistryAccess": "Preflight now tests private-image access and offers to transfer only the required registry credentials with end-to-end encryption.",
-    "releaseNews.item.stackTransferImages": "Stack transfers can copy Docker images from the source instance when the registry is unavailable, rate-limited, or the image comes from a local build."
+    "releaseNews.item.stackTransferImages": "Stack transfers can copy Docker images from the source instance when the registry is unavailable, rate-limited, or the image comes from a local build.",
+    "startGuard.action": "Start prerequisites",
+    "startGuard.heading": "Start prerequisites",
+    "startGuard.enabled": "Check prerequisites before starting this stack",
+    "startGuard.type": "Type",
+    "startGuard.target": "Target",
+    "startGuard.mount": "Host mount",
+    "startGuard.systemd": "systemd service",
+    "startGuard.empty": "No prerequisite configured. Existing start behavior is unchanged.",
+    "startGuard.add": "Add condition",
+    "startGuard.remove": "Remove condition",
+    "startGuard.test": "Test now",
+    "releaseNews.item.startGuard": "Each managed stack can now require host mounts or systemd services before it starts, restarts or recreates containers. The check also protects scheduled starts and can be tested from the stack page."
 }

--- a/frontend/src/lang/es.json
+++ b/frontend/src/lang/es.json
@@ -177,5 +177,17 @@
     "copyRawCompose": "Copiar el YAML Compose sin formato",
     "rawComposeCopied": "YAML Compose copiado sin formato",
     "disableAuth": "desactivar la autenticación",
-    "scenarios": "donde pretendes implementar autenticación de terceros"
+    "scenarios": "donde pretendes implementar autenticación de terceros",
+    "startGuard.action": "Requisitos de inicio",
+    "startGuard.heading": "Requisitos de inicio",
+    "startGuard.enabled": "Comprobar los requisitos antes de iniciar esta pila",
+    "startGuard.type": "Tipo",
+    "startGuard.target": "Destino",
+    "startGuard.mount": "Montaje del host",
+    "startGuard.systemd": "Servicio systemd",
+    "startGuard.empty": "No hay requisitos configurados. El comportamiento de inicio actual no cambia.",
+    "startGuard.add": "Añadir condición",
+    "startGuard.remove": "Eliminar condición",
+    "startGuard.test": "Probar ahora",
+    "releaseNews.item.startGuard": "Cada pila gestionada puede exigir montajes del host o servicios systemd antes de iniciar, reiniciar o recrear contenedores. La comprobación también protege los inicios programados y se puede probar desde la página de la pila."
 }

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -1066,5 +1066,17 @@
     "releaseNews.item.stackTransferErrors": "Le déplacement d’une stack affiche maintenant l’erreur Docker réelle et détecte avant le déploiement les noms de conteneurs explicites déjà utilisés sur la cible.",
     "releaseNews.item.stackTransferData": "Lors d’un déplacement, le transfert des données est sélectionné automatiquement lorsqu’un transport compatible est disponible ; la copie de configuration seule reste clairement signalée.",
     "releaseNews.item.stackTransferRegistryAccess": "Le preflight teste maintenant l’accès aux images privées et propose de transférer uniquement les identifiants de registry nécessaires, chiffrés de bout en bout.",
-    "releaseNews.item.stackTransferImages": "Le déplacement de stacks peut copier les images Docker depuis l’instance source lorsque le registry est indisponible, limité ou que l’image vient d’un build local."
+    "releaseNews.item.stackTransferImages": "Le déplacement de stacks peut copier les images Docker depuis l’instance source lorsque le registry est indisponible, limité ou que l’image vient d’un build local.",
+    "startGuard.action": "Prérequis de démarrage",
+    "startGuard.heading": "Prérequis de démarrage",
+    "startGuard.enabled": "Vérifier les prérequis avant de démarrer cette stack",
+    "startGuard.type": "Type",
+    "startGuard.target": "Cible",
+    "startGuard.mount": "Montage hôte",
+    "startGuard.systemd": "Service systemd",
+    "startGuard.empty": "Aucun prérequis configuré. Le comportement de démarrage existant est inchangé.",
+    "startGuard.add": "Ajouter une condition",
+    "startGuard.remove": "Supprimer la condition",
+    "startGuard.test": "Tester maintenant",
+    "releaseNews.item.startGuard": "Chaque stack gérée peut maintenant exiger la présence de montages hôte ou de services systemd avant le démarrage, redémarrage ou la recréation des conteneurs. Le contrôle protège aussi les démarrages planifiés et se teste depuis la page de la stack."
 }

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -138,6 +138,10 @@
                         <font-awesome-icon icon="note-sticky" />
                         <span class="stack-action-label">{{ $t("showStackNote") }}</span>
                     </button>
+                    <button v-if="!isEditMode && !isAdd && stack.isManagedByDockge" type="button" class="btn stack-action" :class="showStartGuard ? 'btn-primary' : 'btn-normal'" :title="$t('startGuard.action')" :aria-label="$t('startGuard.action')" @click="showStartGuard = !showStartGuard">
+                        <font-awesome-icon icon="shield-alt" />
+                        <span class="stack-action-label">{{ $t("startGuard.action") }}</span>
+                    </button>
                     <button v-if="!endpoint" type="button" class="btn stack-action" :class="showStackGit ? 'btn-primary' : 'btn-normal'" :title="$t('showStackGit')" :aria-label="$t('showStackGit')" @click="showStackGit = !showStackGit">
                         <font-awesome-icon icon="code-branch" />
                         <span class="stack-action-label">{{ $t("showStackGit") }}</span>
@@ -184,6 +188,31 @@
                             <font-awesome-icon :icon="noteSaving ? 'spinner' : 'save'" :spin="noteSaving" class="me-1" />{{ $t("Save") }}
                         </button>
                     </div>
+                </div>
+            </div>
+
+            <div v-if="showStartGuard && !isAdd && stack.isManagedByDockge" class="shadow-box start-guard-panel mb-3">
+                <div class="settings-subheading mb-2"><font-awesome-icon icon="shield-alt" class="me-2" />{{ $t("startGuard.heading") }}</div>
+                <label class="form-check form-switch mb-3">
+                    <input v-model="startGuard.enabled" class="form-check-input" type="checkbox">
+                    <span class="form-check-label">{{ $t("startGuard.enabled") }}</span>
+                </label>
+                <div v-for="(condition, index) in startGuard.conditions" :key="index" class="start-guard-condition mb-2">
+                    <select v-model="condition.type" class="form-select form-select-sm" :aria-label="$t('startGuard.type')">
+                        <option value="mount">{{ $t("startGuard.mount") }}</option>
+                        <option value="systemd">{{ $t("startGuard.systemd") }}</option>
+                    </select>
+                    <input v-model="condition.target" class="form-control form-control-sm" :placeholder="condition.type === 'mount' ? '/mnt/torrent' : 'rclone-synology.service'" :aria-label="$t('startGuard.target')">
+                    <button type="button" class="btn btn-sm btn-outline-danger" :title="$t('startGuard.remove')" :aria-label="$t('startGuard.remove')" @click="removeStartGuardCondition(index)"><font-awesome-icon icon="trash" /></button>
+                    <span v-if="startGuardStatus?.conditions?.[index]" class="small start-guard-status" :class="startGuardStatus.conditions[index].ok ? 'text-success' : 'text-danger'">
+                        {{ startGuardStatus.conditions[index].ok ? '✓' : '✗' }} {{ startGuardStatus.conditions[index].message }}
+                    </span>
+                </div>
+                <div v-if="startGuard.conditions.length === 0" class="text-muted small mb-2">{{ $t("startGuard.empty") }}</div>
+                <div class="d-flex flex-wrap gap-2 mt-3">
+                    <button type="button" class="btn btn-sm btn-normal" :disabled="startGuard.conditions.length >= 20" @click="addStartGuardCondition"><font-awesome-icon icon="plus" class="me-1" />{{ $t("startGuard.add") }}</button>
+                    <button type="button" class="btn btn-sm btn-normal" :disabled="startGuardTesting" @click="testStartGuard"><font-awesome-icon :icon="startGuardTesting ? 'spinner' : 'check'" :spin="startGuardTesting" class="me-1" />{{ $t("startGuard.test") }}</button>
+                    <button type="button" class="btn btn-sm btn-primary" :disabled="startGuardSaving" @click="saveStartGuard"><font-awesome-icon :icon="startGuardSaving ? 'spinner' : 'save'" :spin="startGuardSaving" class="me-1" />{{ $t("Save") }}</button>
                 </div>
             </div>
 
@@ -795,6 +824,11 @@ export default {
             plugNPiNEnabled: false,
             noteSaving: false,
             noteExpanded: false,
+            showStartGuard: false,
+            startGuard: { enabled: false, conditions: [] },
+            startGuardStatus: null,
+            startGuardSaving: false,
+            startGuardTesting: false,
             composePaneWidth: Math.min(75, Math.max(25, Number(localStorage.getItem("composePaneWidth")) || 50)),
             composeCollapsed: localStorage.getItem("composeCollapsed") === "1",
             logsFullscreen: false,
@@ -1502,6 +1536,14 @@ export default {
             this.$root.emitAgent(this.endpoint, "getStack", this.stack.name, (res) => {
                 if (res.ok) {
                     this.stack = res.stack;
+                    this.startGuard = {
+                        enabled: res.stack.startGuard?.enabled === true,
+                        conditions: (res.stack.startGuard?.conditions || []).map((condition) => ({
+                            type: condition.type === "systemd" ? "systemd" : "mount",
+                            target: condition.target || "",
+                        })),
+                    };
+                    this.startGuardStatus = null;
                     this.yamlCodeChange();
                     this.processing = false;
                     this.bindTerminal();
@@ -1681,6 +1723,42 @@ export default {
                 if (res.ok) {
                     this.stack.note = res.note;
                 }
+            });
+        },
+
+        addStartGuardCondition() {
+            if (this.startGuard.conditions.length < 20) {
+                this.startGuard.conditions.push({ type: "mount", target: "" });
+            }
+        },
+
+        removeStartGuardCondition(index) {
+            this.startGuard.conditions.splice(index, 1);
+            this.startGuardStatus = null;
+        },
+
+        saveStartGuard() {
+            this.startGuardSaving = true;
+            this.$root.emitAgent(this.endpoint, "saveStackStartGuard", this.stack.name, this.startGuard, (res) => {
+                this.startGuardSaving = false;
+                this.$root.toastRes(res);
+                if (res.ok) {
+                    this.startGuard = res.startGuard;
+                    this.stack.startGuard = res.startGuard;
+                    this.startGuardStatus = null;
+                }
+            });
+        },
+
+        testStartGuard() {
+            this.startGuardTesting = true;
+            this.$root.emitAgent(this.endpoint, "getStackStartGuardStatus", this.stack.name, this.startGuard, (res) => {
+                this.startGuardTesting = false;
+                if (!res.ok) {
+                    this.$root.toastRes(res);
+                    return;
+                }
+                this.startGuardStatus = res;
             });
         },
 
@@ -1958,6 +2036,37 @@ export default {
 .stack-note-input::placeholder {
     color: #9ca3af;
     opacity: 1;
+}
+
+.start-guard-panel {
+    padding: 16px;
+}
+
+.start-guard-condition {
+    display: grid;
+    grid-template-columns: minmax(9rem, .8fr) minmax(0, 1.4fr) auto;
+    gap: .5rem;
+    align-items: center;
+}
+
+.start-guard-status {
+    grid-column: 1 / -1;
+}
+
+@media (max-width: 650px) {
+    .start-guard-condition {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .start-guard-condition .form-select,
+    .start-guard-condition .form-control {
+        grid-column: 1 / 2;
+    }
+
+    .start-guard-condition .btn {
+        grid-column: 2;
+        grid-row: 1 / 3;
+    }
 }
 
 /* Terminal de progression (deploy/restart/update) : plus haut pour afficher

--- a/frontend/src/release-news.js
+++ b/frontend/src/release-news.js
@@ -80,6 +80,12 @@ export const RELEASE_NEWS = [
             "releaseNews.item.federationTokens",
         ],
     },
+    {
+        id: "2026-08-27-stack-start-guard",
+        items: [
+            "releaseNews.item.startGuard",
+        ],
+    },
 ];
 
 export function getReleaseNewsSince(lastSeenId) {


### PR DESCRIPTION
## Résumé

- ajoute des prérequis facultatifs par stack dans le fichier de métadonnées Dockge : montage hôte et service systemd ;
- bloque les démarrages, redémarrages, recréations et leurs variantes planifiées ou par service lorsque la cible n’est pas prête ;
- laisse strictement inchangées les actions Stop, Down et Delete ;
- teste les prérequis depuis la page Compose, sans lancer la stack ;
- documente la fonctionnalité dans les README FR/EN/ES et la popup Nouveautés.

Les contrôles hôte utilisent uniquement des conteneurs helpers temporaires, isolés du réseau. Les chemins et unités sont validés et aucun argument utilisateur n’est interprété par un shell.

## Validation

- tests ciblés du garde de démarrage ;
- suite backend complète : 108 réussis, 6 ignorés ;
- TypeScript, build frontend et contrôle de diff ;
- vérification réelle des helpers de montage et systemd ;
- build Docker local.