### PR TITLE
Corriger la sélection de toutes les instances

### DIFF
--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -328,7 +328,8 @@ export default {
         },
 
         allAgentsSelected() {
-            return this.stackAgentFilters.length === 0;
+            return this.stackAgentFilters.length === 0
+                || this.stackAgentFilters.length === this.agentOptions.length;
         },
 
         agentFilterLabel() {
@@ -483,7 +484,10 @@ export default {
             return legacy && legacy !== "__all__" ? [ legacy ] : [];
         },
         selectAllAgents() {
-            this.stackAgentFilters = [];
+            // Store every endpoint explicitly so Vue updates each native
+            // checkbox, including one that was unchecked before this click.
+            // An empty array remains supported as the legacy "all" value.
+            this.stackAgentFilters = this.agentOptions.map(agent => agent.endpoint);
         },
         isAgentSelected(endpoint) {
             return this.allAgentsSelected || this.stackAgentFilters.includes(endpoint);


### PR DESCRIPTION
## Résumé

- enregistre explicitement tous les endpoints lors du clic sur « Tous les serveurs » ;
- force la synchronisation visuelle de chaque case à cocher ;
- conserve la compatibilité avec l’ancien état vide signifiant que toutes les instances sont sélectionnées.