### PR TITLE
Docs: warn self-update users about manual recovery

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -23,6 +23,18 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 
 ---
 
+⚠️ **Importante — corrección de la actualización automática de Dockge-Enhanced**
+
+Un error introducido en el mecanismo de actualización automática de Dockge-Enhanced podía impedir que el sidecar completara correctamente la actualización, aunque la interfaz indicara que estaba en curso.
+
+El problema ya está corregido. **Si habías activado la actualización automática de Dockge-Enhanced antes de esta corrección, es necesaria una última actualización manual** en cada instancia de Dockge-Enhanced para obtener la versión corregida:
+
+`docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`
+
+Una vez instalada esta versión, la actualización automática funcionará con normalidad.
+
+**Mis disculpas a los usuarios afectados.** Esta función está precisamente pensada para evitar intervenciones manuales, por lo que se trata de un fallo especialmente inoportuno. Gracias a quienes usan y prueban Dockge-Enhanced y ayudan a detectar rápidamente este tipo de problemas.
+
 ## Funcionalidades
 
 ### Lo que distingue a Dockge Enhanced

--- a/README.fr.md
+++ b/README.fr.md
@@ -21,6 +21,18 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 
 ---
 
+⚠️ **Important — correction de l’auto-mise à jour de Dockge-Enhanced**
+
+Une erreur introduite dans le mécanisme d’auto-mise à jour de Dockge-Enhanced pouvait empêcher le sidecar de terminer correctement la mise à jour alors même que l’interface indiquait qu’elle était en cours.
+
+Le problème est désormais corrigé. **Si vous aviez activé l’auto-mise à jour de Dockge-Enhanced avant ce correctif, une mise à jour manuelle est nécessaire une dernière fois** pour chaque instance Dockge-Enhanced afin de récupérer la version corrigée :
+
+`docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`
+
+Une fois cette version installée, l’auto-mise à jour fonctionnera normalement.
+
+**Toutes mes excuses aux utilisateurs concernés.** Cette fonctionnalité étant justement destinée à éviter les interventions manuelles, c’est évidemment un bug particulièrement mal placé. Merci à ceux qui utilisent et testent Dockge-Enhanced et qui permettent de repérer rapidement ce genre de problème.
+
 ## Fonctionnalités
 
 ### Ce qui distingue Dockge Enhanced

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 
 ---
 
+⚠️ **Important — Dockge-Enhanced self-update fix**
+
+An error introduced in the Dockge-Enhanced self-update mechanism could prevent the sidecar from completing the update even though the interface reported that an update was in progress.
+
+The issue is now fixed. **If you enabled Dockge-Enhanced self-updates before this fix, one final manual update is required** on each Dockge-Enhanced instance to retrieve the corrected version:
+
+`docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`
+
+Once this version is installed, self-updates will work normally.
+
+**My apologies to the affected users.** This feature is specifically meant to avoid manual intervention, so this was obviously a particularly unfortunate bug. Thank you to everyone using and testing Dockge-Enhanced and helping identify this kind of issue quickly.
+
 ## Features
 
 ### What sets Dockge Enhanced apart


### PR DESCRIPTION
Ajoute un avertissement visible avant la section Features/Fonctionnalités/Funcionalidades dans les README FR, EN et ES afin d'informer les utilisateurs concernés par le bug de l'auto-mise à jour de Dockge-Enhanced et de leur indiquer la mise à jour manuelle unique à effectuer.