### PR TITLE
Docs: clarify affected self-update versions

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -27,6 +27,8 @@ Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/
 
 Un error introducido en el mecanismo de actualización automática de Dockge-Enhanced podía impedir que el sidecar completara correctamente la actualización, aunque la interfaz indicara que estaba en curso.
 
+**Este problema afecta a las instancias de Dockge-Enhanced actualizadas entre la noche del 31 de agosto de 2026 y la mañana del 1 de septiembre de 2026.**
+
 El problema ya está corregido. **Si habías activado la actualización automática de Dockge-Enhanced antes de esta corrección, es necesaria una última actualización manual** en cada instancia de Dockge-Enhanced para obtener la versión corregida:
 
 `docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`

--- a/README.fr.md
+++ b/README.fr.md
@@ -25,6 +25,8 @@ Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la su
 
 Une erreur introduite dans le mécanisme d’auto-mise à jour de Dockge-Enhanced pouvait empêcher le sidecar de terminer correctement la mise à jour alors même que l’interface indiquait qu’elle était en cours.
 
+**Ce problème concerne les instances Dockge-Enhanced mises à jour entre le 31 août 2026 au soir et le 1er septembre 2026 au matin.**
+
 Le problème est désormais corrigé. **Si vous aviez activé l’auto-mise à jour de Dockge-Enhanced avant ce correctif, une mise à jour manuelle est nécessaire une dernière fois** pour chaque instance Dockge-Enhanced afin de récupérer la version corrigée :
 
 `docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image mo
 
 An error introduced in the Dockge-Enhanced self-update mechanism could prevent the sidecar from completing the update even though the interface reported that an update was in progress.
 
+**This issue affects Dockge-Enhanced instances updated between the evening of August 31, 2026 and the morning of September 1, 2026.**
+
 The issue is now fixed. **If you enabled Dockge-Enhanced self-updates before this fix, one final manual update is required** on each Dockge-Enhanced instance to retrieve the corrected version:
 
 `docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`


### PR DESCRIPTION
Précise dans les README FR, EN et ES que le bug d'auto-mise à jour concerne les instances mises à jour entre le 31 août 2026 au soir et le 1er septembre 2026 au matin.