### PR TITLE
Fix dark mode secondary text readability

### DIFF
--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -8,6 +8,19 @@ body {
     color: var(--text-color);
 }
 
+// Bootstrap utility text uses its own palette. In dark mode, never let
+// muted/secondary helper text become dimmer than Dockge-Enhanced's
+// --text-muted reference. Brighter semantic colors are left untouched.
+.dark {
+    .text-muted,
+    .text-secondary,
+    .text-body-secondary,
+    .text-body-tertiary,
+    .form-text {
+        color: var(--text-muted) !important;
+    }
+}
+
 #app {
     font-family: var(--font-sans);
 }
@@ -73,7 +86,7 @@ optgroup {
 
 .dark {
     optgroup {
-        color: #535864;
+        color: var(--text-muted);
         option {
             color: $dark-font-color;
         }
@@ -408,7 +421,7 @@ optgroup {
 
 .form-floating > label {
     .dark & {
-        color: $dark-font-color3 !important;
+        color: var(--text-muted) !important;
     }
 }
 

--- a/frontend/src/styles/tokens.scss
+++ b/frontend/src/styles/tokens.scss
@@ -97,6 +97,15 @@
     --text-color: #b1b8c0;
     --text-muted: #9ca3af;
 
+    // Keep Bootstrap's secondary/muted text at least as readable as our
+    // own muted token in dark mode. This fixes helpers, loading labels,
+    // agent endpoints/IPs and other Bootstrap utility text without
+    // flattening brighter semantic/brand colors.
+    --bs-body-color: var(--text-color);
+    --bs-secondary-color: var(--text-muted);
+    --bs-secondary-rgb: 156, 163, 175;
+    --bs-tertiary-color: var(--text-muted);
+
     --shadow-card: 0 15px 70px rgba(0, 0, 0, 0.5);
     --shadow-popover: 0 6px 24px rgba(0, 0, 0, 0.35);
 }


### PR DESCRIPTION
Aligne en mode nuit les textes muted/secondary Bootstrap sur le token --text-muted de Dockge-Enhanced, sans modifier les couleurs déjà plus claires ou sémantiques.
Corrige aussi les optgroup et labels flottants trop sombres.