### PR TITLE
Corriger le rollback après échec de recréation Compose

### DIFF
--- a/extra/self-update-sidecar/index.js
+++ b/extra/self-update-sidecar/index.js
@@ -151,13 +151,21 @@ async function run(deps = {}) {
         } catch (error) { updateError = error; }
         writeStatus("rolling-back", `Update failed; restoring the previous image: ${updateError instanceof Error ? updateError.message : String(updateError)}`, true, plan);
         try {
-            const current = inspect(plan.targetContainerName, deps);
-            if (plan.compose) override = composeUpdate(plan, plan.previousImageId, deps);
-            else await snapshotCreate(recovery, current.Id, plan.previousImageId, deps);
+            // A Compose update can remove the old container before the replacement
+            // is created.  Do not inspect the replacement before restoring: it may
+            // not exist, which would otherwise skip the only recovery path.
+            if (plan.compose) {
+                override = composeUpdate(plan, plan.previousImageId, deps);
+            } else {
+                const current = inspect(plan.targetContainerName, deps);
+                await snapshotCreate(recovery, current.Id, plan.previousImageId, deps);
+            }
             if (waitReady(plan.targetContainerName, deps)) { writeStatus("rolled-back", `Update failed and the previous container was restored: ${updateError instanceof Error ? updateError.message : String(updateError)}`, true, plan); return "rolled-back"; }
             throw new Error("Previous container did not become ready");
         } catch (rollbackError) {
-            writeStatus("rollback-failed", `Update failed and rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`, true, plan);
+            const updateMessage = updateError instanceof Error ? updateError.message : String(updateError);
+            const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+            writeStatus("rollback-failed", `Update failed (${updateMessage}) and rollback failed: ${rollbackMessage}`, true, plan);
             return "rollback-failed";
         }
     } catch (error) { writeStatus("failed", error instanceof Error ? error.message : String(error), false, plan); return "failed"; }

--- a/extra/self-update-sidecar/index.test.js
+++ b/extra/self-update-sidecar/index.test.js
@@ -107,3 +107,25 @@ test("failed readiness rolls back and persists a deduplicatable terminal result"
     assert.equal(fs.existsSync(`${planPath}.claimed`), false);
     assert.equal(fs.existsSync(path.join(root, `${plan.id}.override.yaml`)), false);
 });
+
+test("a Compose creation failure restores the previous image without inspecting a missing replacement", async () => {
+    process.env.SELF_UPDATE_ALLOW_TEST_IMAGES = "dockge-enhanced:test-v2";
+    const work = path.join(root, "missing-replacement"); fs.mkdirSync(work, { recursive: true });
+    const composeFile = path.join(work, "compose.yaml"); fs.writeFileSync(composeFile, "services:\n  dockge:\n    image: dockge-enhanced:test-v1\n");
+    process.env.SELF_UPDATE_COMPOSE_DIR = work;
+    const { plan, planPath } = signedPlan({ compose: { workingDir: work, configFiles: [ composeFile ], project: "test", service: "dockge" } });
+    fs.mkdirSync(path.join(root, "recovery"), { recursive: true });
+    fs.writeFileSync(path.join(root, "recovery", plan.recoveryFile), JSON.stringify({ id: plan.id, targetContainerId: plan.targetContainerId, targetContainerName: plan.targetContainerName, previousImage: plan.previousImage, previousImageId: plan.previousImageId, config: {}, hostConfig: {}, endpointsConfig: {} }));
+    let upCalls = 0; const time = clock();
+    const docker = args => {
+        if (args[1] === "inspect") return JSON.stringify({ Id: "container-id", Name: "/dockge-test", Config: { Image: "dockge-enhanced:test-v1" }, State: { Running: true, Status: "running" } });
+        if (args.includes("up")) { upCalls += 1; if (upCalls === 1) throw new Error("replacement creation failed"); return ""; }
+        if (args.includes("wget")) return "ok";
+        return "";
+    };
+    const result = await sidecar.run({ planPath, docker, ...time, stableMs: 2_000, timeoutMs: 4_000, pollMs: 1_000 });
+    assert.equal(result, "rolled-back");
+    assert.equal(upCalls, 2);
+    const status = JSON.parse(fs.readFileSync(path.join(root, "status.json")));
+    assert.equal(status.state, "rolled-back");
+});


### PR DESCRIPTION
## Résumé

Le sidecar de mise à jour pouvait supprimer le conteneur Dockge-Enhanced puis échouer avant sa recréation. Le rollback tentait alors d’inspecter ce conteneur absent et ne pouvait pas restaurer l’image précédente.

Le rollback Compose relance désormais directement la configuration avec l’image de récupération, sans dépendre de l’existence du conteneur de remplacement.

Un test de régression couvre cet échec de création suivi de la restauration.