### PR TITLE
Aligne les langues Enhanced en EN, FR, ES et zh-CN

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -8,13 +8,13 @@
 
 Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/dockge) — agrega monitoreo de imágenes, escaneo de seguridad, copias de seguridad automáticas, detección de bucles de fallo y gestión de recursos de Docker, todo desde la interfaz web.
 
-> 🇪🇸 Español · 🇬🇧 [English](README.md) · 🇫🇷 [Français](README.fr.md)
+> 🇪🇸 Español · 🇬🇧 [English](README.md) · 🇫🇷 [Français](README.fr.md) · 🇨🇳 [简体中文](README.zh-CN.md)
 
 <p align="center">
   <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
-  <img src="https://img.shields.io/badge/i18n-FR%20%7C%20EN-blue" alt="i18n">
+  <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT">
 </p>
@@ -55,7 +55,7 @@ Una vez instalada esta versión, la actualización automática funcionará con n
 | **Imágenes y seguridad** | Monitoreo de actualizaciones, actualización automática con reversión, autoactualizaciones programadas y pausables, escaneos Trivy y excepciones CVE |
 | **Monitoreo** | Barra de estado del sistema configurable arriba o abajo, tarjetas de resumen del panel, estadísticas del sistema, stack y contenedor, bucles de fallo, auto-reparación de healthchecks, registros responsivos y a pantalla completa e integraciones opcionales con Kula y Dozzle gestionado |
 | **Integraciones** | PlugNPiN opcional y asistente de etiquetas por servicio para Nginx Proxy Manager, Pi-hole y AdGuard Home |
-| **Notificaciones y acceso** | Discord, Apprise, 2FA, proxy de confianza, Turnstile y clientes móviles |
+| **Notificaciones y acceso** | Notificaciones Discord y Apprise localizadas en EN/FR/ES/zh-CN, 2FA, proxy de confianza, Turnstile y clientes móviles |
 
 
 <details>

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,13 +6,13 @@
 
 Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la surveillance d'images, le scan de sécurité, les sauvegardes automatiques, la détection de crash loop et la gestion des ressources Docker, le tout depuis l'interface web.
 
-> 🇫🇷 Français · 🇬🇧 [English](README.md) · 🇪🇸 [Español](README.es-ES.md) · [Article de présentation](https://upandclear.org/2026/08/30/dockge-enhanced-quelques-mois-plus-tard-le-petit-fork-a-bien-grandi/)
+> 🇫🇷 Français · 🇬🇧 [English](README.md) · 🇪🇸 [Español](README.es-ES.md) · 🇨🇳 [简体中文](README.zh-CN.md) · [Article de présentation](https://upandclear.org/2026/08/30/dockge-enhanced-quelques-mois-plus-tard-le-petit-fork-a-bien-grandi/)
 
 <p align="center">
   <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
-  <img src="https://img.shields.io/badge/i18n-FR%20%7C%20EN-blue" alt="i18n">
+  <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT">
 </p>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image monitoring, security scanning, automatic backups, crash-loop detection and Docker resource management, all from the web UI.
 
-> 🇬🇧 English · 🇫🇷 [Français](README.fr.md) · 🇪🇸 [Español](README.es-ES.md)
+> 🇬🇧 English · 🇫🇷 [Français](README.fr.md) · 🇪🇸 [Español](README.es-ES.md) · 🇨🇳 [简体中文](README.zh-CN.md)
 
 <p align="center">
   <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
-  <img src="https://img.shields.io/badge/i18n-FR%20%7C%20EN-blue" alt="i18n">
+  <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT">
 </p>
@@ -53,7 +53,7 @@ Once this version is installed, self-updates will work normally.
 | **Images & security** | Update monitoring, auto-update with rollback, scheduled and pausable self-updates, Trivy scans, and CVE exceptions |
 | **Monitoring** | Configurable header/bottom system status bar, dashboard health cards, system, stack, and container stats, crash loops, healthcheck auto-heal, responsive and fullscreen logs, and optional Kula and managed Dozzle integrations |
 | **Integrations** | Optional PlugNPiN and per-service label assistant for Nginx Proxy Manager, Pi-hole, and AdGuard Home |
-| **Notifications & access** | Discord, Apprise, 2FA, trusted proxy, Turnstile, and mobile clients |
+| **Notifications & access** | Discord and Apprise notifications localized in EN/FR/ES/zh-CN, 2FA, trusted proxy, Turnstile, and mobile clients |
 
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,220 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/Aerya/Dockge-Enhanced/main/frontend/public/icon.svg" width="120" alt="Dockge Enhanced logo">
+</p>
+
+# Dockge Enhanced
+
+[Dockge](https://github.com/louislam/dockge) 的增强功能分支 —— 在保留简洁 Compose 管理体验的基础上，加入镜像更新监控、安全扫描、自动备份、崩溃循环检测、多实例管理以及 Docker 资源管理。
+
+> 🇨🇳 简体中文 · 🇬🇧 [English](README.md) · 🇫🇷 [Français](README.fr.md) · 🇪🇸 [Español](README.es-ES.md)
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
+  <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
+  <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
+  <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
+  <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT">
+</p>
+
+> **正在使用？觉得不错？[⭐ 给项目一个 Star！](https://github.com/Aerya/Dockge-Enhanced)**
+
+---
+
+⚠️ **重要 — Dockge-Enhanced 自更新修复**
+
+曾有一个自更新问题可能导致 Sidecar 无法完成更新，即使界面显示更新正在进行。
+
+**该问题影响 2026 年 8 月 31 日晚至 2026 年 9 月 1 日上午期间更新的 Dockge-Enhanced 实例。**
+
+问题现已修复。**如果你在修复前启用了 Dockge-Enhanced 自更新，每个实例都需要最后手动更新一次**：
+
+`docker pull ghcr.io/aerya/dockge-enhanced:latest && docker compose up -d`
+
+安装修复版本后，自更新会恢复正常工作。
+
+<p align="center">
+  <img src="screens/D-E.vs.Others.EN.09.26.png" alt="Dockge Enhanced comparison" width="100%">
+</p>
+
+## 功能
+
+### Dockge Enhanced 的主要增强
+
+| 领域 | Dockge Enhanced 新增内容 |
+| --- | --- |
+| **多实例** | 添加或移除 Agent 时自动建立全网状联邦；可从任意已连接实例管理；支持多服务器筛选和分组、事务式复制/迁移、可恢复任务以及自动冷复制 |
+| **Stack 管理** | Stack 固定、可折叠和可调整宽度的侧栏、紧凑状态/资源指示器、可调整大小的 Logs/Compose 工作区、可靠的原始 YAML 复制、Stack/容器级操作与计划任务、主机启动前置条件、Build + Recreate、备注和 Git 工具 |
+| **备份与恢复** | Restic 多目标备份、卷数据、按 Stack 保持一致性、选择性恢复、快照测试与差异比较 |
+| **自动化与审计** | 按权限和 Stack 限定的 REST API、每 Stack Webhook、Home Assistant 示例、带来源和执行时间的集中审计历史 |
+| **Docker 资源** | 镜像、卷、未管理容器和网络；批量操作、自动清理以及高风险删除保护 |
+| **镜像与安全** | 镜像更新监控、带回滚的自动更新、可计划/暂停的 Dockge-Enhanced 自更新、Trivy 扫描和 CVE 忽略规则 |
+| **监控** | 可配置的顶部/底部系统状态栏、仪表盘健康卡片、系统/Stack/容器统计、崩溃循环检测、healthcheck 自动修复、响应式/全屏日志、可选 Kula 和受管 Dozzle |
+| **集成** | 可选 PlugNPiN，以及面向 Nginx Proxy Manager、Pi-hole 和 AdGuard Home 的服务标签助手 |
+| **通知与访问** | Discord 和 Apprise 通知支持 EN/FR/ES/zh-CN，另有 2FA、可信代理、Turnstile 和第三方客户端支持 |
+
+### 最近的重要变化
+
+- **2026-09-01 — 远程 Stack 更新标记**：Stack 列表现在会从每个远程 Dockge-Enhanced 实例读取镜像更新状态，并按 endpoint 隔离，因此远程 Stack 也能正确显示 **更新** 标记。
+- **2026-09-01 — 四语言 Enhanced 本地化**：Enhanced 自己新增的用户界面内容、更新弹窗，以及 Discord/Apprise 通知统一维护英语、法语、西班牙语和简体中文。
+- **2026-08-31 — 安全自更新**：自更新支持手动或受限 Sidecar 模式；执行前必须完成 Restic 备份和仓库验证，失败时自动回滚。
+- **2026-08-30 — 响应式界面和统一主题**：Stack 侧栏可折叠/调整大小，系统状态栏、健康卡片、自动主题以及移动端导航得到增强。
+- **2026-08-27 — Stack 启动前置条件**：可要求主机挂载点或 `systemd` 服务可用后再启动、重启或重新创建容器。
+- **2026-08-22 — 联邦凭据恢复**：多实例之间使用专用联邦 JWT，修改 WebUI 用户名或密码不会再让已连接实例离线。
+- **2026-08-20 — Stack 迁移增强**：支持必要时复制 Docker 镜像、加密迁移私有 Registry 凭据，并在部署前检测 `container_name` 冲突。
+
+完整历史和详细技术说明可参考 [英文 README](README.md)。
+
+---
+
+## 截图
+
+项目截图位于 [`screens/`](screens/) 目录。主 README 中展示了界面、更新、备份、Trivy、Discord 通知和多实例功能的最新截图。
+
+---
+
+## 安装
+
+```yaml
+# compose.yaml
+services:
+  dockge:
+    image: ghcr.io/aerya/dockge-enhanced:latest
+    container_name: dockge-enhanced
+    restart: unless-stopped
+    ports:
+      - 5001:5001
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../../data:/app/data
+      - ../../opt/stacks:/opt/stacks
+      - ../../backup/dockge:/backup          # 可选：独立本地备份目录
+      - ../../docker:/dockers-data           # 可选：额外需要备份的数据
+    environment:
+      - DOCKGE_STACKS_DIR=/opt/stacks
+      - DOCKGE_DATA_DIR=/app/data
+#      - DOCKER_API_VERSION=x.xx             # 可选：旧版 Docker API 的 NAS
+      - TZ=Europe/Paris                      # 时区，会影响计划任务
+```
+
+启动：
+
+```bash
+docker compose up -d
+```
+
+打开 **http://localhost:5001**，创建管理员账号，然后即可使用 Dockge Enhanced。
+
+> `/backup:/backup` 不是必需的，但如果使用 Restic 的本地目标，建议挂载一个独立主机目录并把备份目标设为 `/backup`。
+
+> 如果要备份多个数据目录，可以添加多个 volume，然后在 **Backup** 页面中的 **Additional paths** 注册对应的容器路径。
+
+> 如果要监控 `/` 之外的主机磁盘分区，请把目标路径只读挂载到容器，并在 **Monitoring** 页面中加入该路径。
+
+### 可选 PlugNPiN 集成
+
+在 **Settings → Integrations** 中配置 [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN)。只有明确启用并保存后，Dockge Enhanced 才会创建受管的 `plugnpin-dockge-enhanced` Stack。
+
+Nginx Proxy Manager 凭据是必需的；Pi-hole、AdGuard Home、metrics 和 debug 日志均可单独选择。密码通过 stdin 写入专用 Docker volume，不会返回浏览器，也不会写入生成的 Compose 文件。
+
+---
+
+## 环境变量
+
+| 变量 | 默认值 | 说明 |
+|---|---|---|
+| `DOCKGE_STACKS_DIR` | `/opt/stacks` | Docker Compose Stack 所在目录 |
+| `DOCKGE_DATA_DIR` | `/opt/dockge/data` | Dockge 数据目录；推荐与 volume 对应设置为 `/app/data` |
+| `DOCKGE_PUBLIC_URL` | 无 | Discord 通知中使用的公网 URL，例如 `https://dockge.example.com` |
+| `DOCKER_API_VERSION` | 无 | 固定 Docker Client 协商的 API 版本，适合部分 NAS |
+| `TZ` | `UTC` | 容器时区；计划自动更新依赖此值 |
+| `DOCKGE_PORT` | `5001` | Web UI 端口 |
+| `DOCKGE_SSL_KEY` / `DOCKGE_SSL_CERT` | — | 启用 HTTPS |
+| `DOCKGE_AUTH_MODE` | 未设置 | `local`、`disabled` 或 `trusted-proxy` |
+| `DOCKGE_AUTH_PROXY_HEADER` | `x-forwarded-user` | trusted-proxy 模式下包含已验证身份的 Header |
+| `DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS` | 必填（代理模式） | 允许提供身份 Header 的地址/CIDR |
+| `DOCKGE_BOOTSTRAP_USERNAME` | 无 | 数据库没有用户时创建的首个管理员名称 |
+| `DOCKGE_BOOTSTRAP_PASSWORD_FILE` | 无 | 管理员密码 Secret 文件；自动部署时推荐 |
+| `DOCKGE_BOOTSTRAP_PASSWORD` | 无 | 直接密码方式；由于会暴露在容器环境中，安全性较低 |
+| `DOCKGE_TRANSFER_RSYNC_PROFILES` | `[]` | 本地 SSH/rsync 传输配置 JSON |
+
+> ⚠️ 如果 volume 使用 `/app/data`，请始终设置 `DOCKGE_DATA_DIR=/app/data`，否则重启后设置可能无法持久化。
+
+### 身份验证与初始化
+
+现有安装无需修改。没有额外环境变量时，账号、登录页、2FA 和“禁用身份验证”功能与之前保持一致。
+
+自动初始化管理员时，推荐使用 Secret：
+
+```yaml
+services:
+  dockge:
+    environment:
+      - DOCKGE_BOOTSTRAP_USERNAME=admin
+      - DOCKGE_BOOTSTRAP_PASSWORD_FILE=/run/secrets/dockge_admin_password
+    secrets:
+      - dockge_admin_password
+
+secrets:
+  dockge_admin_password:
+    file: ./secrets/dockge_admin_password
+```
+
+可信代理示例：
+
+```yaml
+environment:
+  - DOCKGE_AUTH_MODE=trusted-proxy
+  - DOCKGE_AUTH_PROXY_HEADER=x-forwarded-user
+  - DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS=172.20.0.0/24
+```
+
+请把示例 CIDR 替换为代理的真实网络。Dockge 端口不应直接暴露；只有声明的可信代理可以提供用户身份。
+
+---
+
+## 自动更新
+
+该分支通过 GitHub Actions 跟踪上游 Dockge：
+
+- **每天**检查新的稳定版本；
+- 检测到上游更新时同步变更并创建 PR；
+- PR 合并后重新构建并发布 `amd64` + `arm64` Docker 镜像到 GHCR；
+- 发生认证相关冲突时，Enhanced 版本会被保留在同步分支中，并明确列出需要人工比较的文件。
+
+Dockge-Enhanced 自身的应用内自更新是独立功能，可在 **Updates** 页面配置。自动模式要求 Restic 备份与验证通过，并在健康检查失败时回滚。
+
+---
+
+## 移动应用 / 第三方客户端
+
+Dockge-Enhanced 是免费且开源的。
+
+本项目当前没有官方维护的 iOS 或 Android 应用。第三方客户端可能存在，但除非在此项目中明确列出，否则均独立于 Dockge-Enhanced。
+
+---
+
+## 署名
+
+如果你的应用、服务、文章或集成使用 Dockge-Enhanced 的功能、API、截图、文档或品牌，请注明本项目并链接到本仓库。
+
+MIT 许可证允许商业第三方客户端，但未经许可不得暗示其与 Dockge-Enhanced 存在官方关联。
+
+---
+
+## 致谢
+
+- [**Dockge**](https://github.com/louislam/dockge) by louislam — 原始项目（MIT）
+- [**Trivy**](https://github.com/aquasecurity/trivy) — 漏洞扫描
+- [**Restic**](https://restic.net/) — 加密备份
+- [**Apprise**](https://github.com/caronc/apprise-api) — 多平台通知网关
+- [**Kula**](https://github.com/c0m4r/kula) by c0m4r — 轻量系统监控
+- [**Dozzle**](https://github.com/amir20/dozzle) by Amir Rajan — Docker 实时日志查看器
+- [**PlugNPiN**](https://github.com/DeepSpace2/PlugNPiN) by DeepSpace2 — 可选 DNS / Nginx Proxy Manager 自动化
+- [**crossly/Dockge-Enhanced**](https://github.com/crossly/Dockge-Enhanced) — 已整合的重要 UI/UX、主题、国际化和前端架构改进来源
+
+---
+
+## 许可证
+
+MIT — 参见 [LICENSE](LICENSE)。

--- a/backend/notification/apprise.ts
+++ b/backend/notification/apprise.ts
@@ -13,6 +13,7 @@
  */
 
 import axios from "axios";
+import { getNotificationLang, notificationText } from "./notification-lang";
 
 export type AppriseNotifType = "info" | "success" | "warning" | "failure";
 
@@ -118,10 +119,23 @@ export class AppriseNotifier {
     /** Teste la connexion au serveur Apprise */
     async test(): Promise<boolean> {
         try {
+            const lang = await getNotificationLang();
             return await this.send({
-                title: "✅ Test de notification Dockge Enhanced",
-                body:  "Apprise est correctement configuré et connecté !",
-                type:  "success",
+                title: notificationText(
+                    lang,
+                    "✅ Test de notification Dockge Enhanced",
+                    "✅ Dockge Enhanced notification test",
+                    "✅ Prueba de notificación de Dockge Enhanced",
+                    "✅ Dockge Enhanced 通知测试",
+                ),
+                body: notificationText(
+                    lang,
+                    "Apprise est correctement configuré et connecté !",
+                    "Apprise is configured and connected correctly!",
+                    "¡Apprise está configurado y conectado correctamente!",
+                    "Apprise 配置并连接正确！",
+                ),
+                type: "success",
             });
         } catch {
             return false;

--- a/backend/notification/discord.ts
+++ b/backend/notification/discord.ts
@@ -4,6 +4,7 @@
  */
 
 import axios from "axios";
+import { getNotificationLang, notificationText } from "./notification-lang";
 
 const DISCORD_API_URL = "https://discord.com";
 const discordApi = axios.create({ baseURL: DISCORD_API_URL });
@@ -146,9 +147,22 @@ export class DiscordNotifier {
     /** Teste le premier webhook de la liste */
     async testWebhook(): Promise<boolean> {
         try {
+            const lang = await getNotificationLang();
             await this.sendEmbed({
-                title: "✅ Test de notification Dockge Enhanced",
-                description: "Le webhook Discord est correctement configuré !",
+                title: notificationText(
+                    lang,
+                    "✅ Test de notification Dockge Enhanced",
+                    "✅ Dockge Enhanced notification test",
+                    "✅ Prueba de notificación de Dockge Enhanced",
+                    "✅ Dockge Enhanced 通知测试",
+                ),
+                description: notificationText(
+                    lang,
+                    "Le webhook Discord est correctement configuré !",
+                    "The Discord webhook is configured correctly!",
+                    "¡El webhook de Discord está configurado correctamente!",
+                    "Discord Webhook 配置正确！",
+                ),
                 color: 0x22c55e,
                 footer: "Dockge Enhanced",
             });

--- a/backend/notification/notification-lang.ts
+++ b/backend/notification/notification-lang.ts
@@ -1,18 +1,37 @@
 import { Settings } from "../settings";
 
-export type NotificationLang = "fr" | "en";
+export type NotificationLang = "fr" | "en" | "es" | "zh-CN";
 
-/**
- * Langue des notifications (Discord / Apprise).
- *
- * Elle suit la langue de l'interface : le frontend pousse la locale
- * courante via l'événement socket "setUILocale" (au démarrage et à
- * chaque changement de langue). Les chaînes de notification n'existent
- * qu'en fr/en — tout ce qui n'est pas français retombe sur l'anglais.
- *
- * @returns "fr" si l'interface est en français, "en" sinon
- */
 export async function getNotificationLang(): Promise<NotificationLang> {
     const locale = await Settings.get("uiLocale");
-    return typeof locale === "string" && locale.startsWith("fr") ? "fr" : "en";
+    if (typeof locale !== "string") return "en";
+    const normalized = locale.toLowerCase();
+    if (normalized.startsWith("fr")) return "fr";
+    if (normalized.startsWith("es")) return "es";
+    if (normalized.startsWith("zh")) return "zh-CN";
+    return "en";
+}
+
+export function getNotificationLocale(lang: NotificationLang): string {
+    switch (lang) {
+        case "fr": return "fr-FR";
+        case "es": return "es-ES";
+        case "zh-CN": return "zh-CN";
+        default: return "en-GB";
+    }
+}
+
+export function notificationText(
+    lang: NotificationLang,
+    fr: string,
+    en: string,
+    es: string,
+    zhCN: string,
+): string {
+    switch (lang) {
+        case "fr": return fr;
+        case "es": return es;
+        case "zh-CN": return zhCN;
+        default: return en;
+    }
 }

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -9,7 +9,7 @@ import { TrivyScanner } from "../watchers/trivy-scanner";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
 import { Settings } from "../settings";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, notificationText } from "../notification/notification-lang";
 import { SelfUpdateOperation, SelfUpdatePlan, SelfUpdateProgress, SelfUpdateSettings } from "./types";
 import { DEFAULT_SELF_UPDATE_SETTINGS, normalizeSelfUpdateSettings, selfUpdateMayRun } from "./settings";
 import { isAllowedTargetImage, isPathInside, isSafeComposeName, isSelfUpdateActive, normalizeSelfRepository } from "./policy";
@@ -276,20 +276,108 @@ export class SelfUpdateManager {
     private async notify(title: string, body: string, type: "warning" | "success" | "failure"): Promise<boolean> {
         try {
             const watcher = ImageWatcher.getInstance().settings;
-            const en = (await getNotificationLang()) === "en";
-            const titleFr: Record<string, string> = {
-                "⏳ Dockge-Enhanced update deferred": "⏳ Mise à jour Dockge-Enhanced reportée",
-                "✅ Dockge-Enhanced self-update succeeded": "✅ Mise à jour Dockge-Enhanced réussie",
-                "❌ Dockge-Enhanced self-update failed": "❌ Échec de la mise à jour Dockge-Enhanced",
-                "↩️ Dockge-Enhanced rollback succeeded": "↩️ Restauration Dockge-Enhanced réussie",
-                "🚨 Dockge-Enhanced rollback failed": "🚨 Échec de la restauration Dockge-Enhanced",
+            const lang = await getNotificationLang();
+            const titleTranslations: Record<string, [string, string, string, string]> = {
+                "⏳ Dockge-Enhanced update deferred": [
+                    "⏳ Mise à jour Dockge-Enhanced reportée",
+                    "⏳ Dockge-Enhanced update deferred",
+                    "⏳ Actualización de Dockge-Enhanced aplazada",
+                    "⏳ Dockge-Enhanced 更新已推迟",
+                ],
+                "✅ Dockge-Enhanced self-update succeeded": [
+                    "✅ Mise à jour Dockge-Enhanced réussie",
+                    "✅ Dockge-Enhanced self-update succeeded",
+                    "✅ Actualización automática de Dockge-Enhanced correcta",
+                    "✅ Dockge-Enhanced 自更新成功",
+                ],
+                "❌ Dockge-Enhanced self-update failed": [
+                    "❌ Échec de la mise à jour Dockge-Enhanced",
+                    "❌ Dockge-Enhanced self-update failed",
+                    "❌ Error en la actualización automática de Dockge-Enhanced",
+                    "❌ Dockge-Enhanced 自更新失败",
+                ],
+                "↩️ Dockge-Enhanced rollback succeeded": [
+                    "↩️ Restauration Dockge-Enhanced réussie",
+                    "↩️ Dockge-Enhanced rollback succeeded",
+                    "↩️ Rollback de Dockge-Enhanced correcto",
+                    "↩️ Dockge-Enhanced 回滚成功",
+                ],
+                "🚨 Dockge-Enhanced rollback failed": [
+                    "🚨 Échec de la restauration Dockge-Enhanced",
+                    "🚨 Dockge-Enhanced rollback failed",
+                    "🚨 Error en el rollback de Dockge-Enhanced",
+                    "🚨 Dockge-Enhanced 回滚失败",
+                ],
             };
-            const bodyFr: Record<string, string> = {
-                "Dockge-Enhanced updated and remained ready": "Dockge-Enhanced a été mis à jour et est resté opérationnel.",
-                "Updater sidecar stopped unexpectedly before reporting its status": "Le sidecar de mise à jour s’est arrêté de façon inattendue avant de pouvoir transmettre son état.",
+            const bodyTranslations: Record<string, [string, string, string, string]> = {
+                "Dockge-Enhanced updated and remained ready": [
+                    "Dockge-Enhanced a été mis à jour et est resté opérationnel.",
+                    "Dockge-Enhanced updated and remained ready",
+                    "Dockge-Enhanced se actualizó y permaneció operativo.",
+                    "Dockge-Enhanced 已更新并保持正常运行。",
+                ],
+                "Updater sidecar stopped unexpectedly before reporting its status": [
+                    "Le sidecar de mise à jour s’est arrêté de façon inattendue avant de pouvoir transmettre son état.",
+                    "Updater sidecar stopped unexpectedly before reporting its status",
+                    "El sidecar de actualización se detuvo inesperadamente antes de informar de su estado.",
+                    "更新 Sidecar 在报告状态前意外停止。",
+                ],
             };
-            const localizedTitle = en ? title : (titleFr[title] ?? title);
-            const localizedBody = en ? body : (bodyFr[body] ?? body);
+            Object.assign(bodyTranslations, {
+                "Mandatory backup in progress": [
+                    "Backup obligatoire en cours",
+                    "Mandatory backup in progress",
+                    "Copia obligatoria en curso",
+                    "正在执行强制备份",
+                ],
+                "Restic repository verification in progress": [
+                    "Vérification du dépôt Restic en cours",
+                    "Restic repository verification in progress",
+                    "Verificación del repositorio Restic en curso",
+                    "正在验证 Restic 仓库",
+                ],
+                "Updater sidecar started": [
+                    "Sidecar de mise à jour démarré",
+                    "Updater sidecar started",
+                    "Sidecar de actualización iniciado",
+                    "更新 Sidecar 已启动",
+                ],
+            });
+            const titleSet = titleTranslations[title];
+            const bodySet = bodyTranslations[body];
+            const localizedTitle = titleSet ? notificationText(lang, ...titleSet) : title;
+            let localizedBody = bodySet ? notificationText(lang, ...bodySet) : body;
+            const prefixedBodies: Array<[string, [string, string, string, string]]> = [
+                ["Backup failed: ", [ "Échec du backup : ", "Backup failed: ", "Error en la copia: ", "备份失败：" ]],
+                ["Backup verification failed: ", [ "Échec de la vérification du backup : ", "Backup verification failed: ", "Error en la verificación de la copia: ", "备份验证失败：" ]],
+                ["Automatic self-update deferred: ", [ "Mise à jour automatique reportée : ", "Automatic self-update deferred: ", "Actualización automática aplazada: ", "自动更新已推迟：" ]],
+            ];
+            for (const [prefix, translatedPrefixes] of prefixedBodies) {
+                if (body.startsWith(prefix)) {
+                    localizedBody = `${notificationText(lang, ...translatedPrefixes)}${body.slice(prefix.length)}`;
+                    break;
+                }
+            }
+            const verificationMatch = body.match(/^Backup verification failed for (.+?): (.*)$/s);
+            if (verificationMatch) {
+                localizedBody = notificationText(
+                    lang,
+                    `Échec de la vérification du backup pour ${verificationMatch[1]} : ${verificationMatch[2]}`,
+                    body,
+                    `Error en la verificación de la copia para ${verificationMatch[1]}: ${verificationMatch[2]}`,
+                    `${verificationMatch[1]} 的备份验证失败：${verificationMatch[2]}`,
+                );
+            }
+            const deferredMatch = body.match(/^Automatic self-update was deferred because (.+)\. It will be retried by the existing update watcher\.$/s);
+            if (deferredMatch) {
+                localizedBody = notificationText(
+                    lang,
+                    `La mise à jour automatique a été reportée car ${deferredMatch[1]}. Elle sera retentée par le watcher de mise à jour existant.`,
+                    body,
+                    `La actualización automática se aplazó porque ${deferredMatch[1]}. El watcher de actualizaciones existente volverá a intentarlo.`,
+                    `自动更新已推迟，原因：${deferredMatch[1]}。现有更新监视器将稍后重试。`,
+                );
+            }
             const hostname = (await Settings.get("primaryHostname")) || "";
             const fullTitle = hostname ? `[${hostname}] ${localizedTitle}` : localizedTitle;
             if (watcher.discordWebhooks.length > 0) {

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -13,7 +13,7 @@ import * as path from "path";
 import * as yaml from "js-yaml";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
 import { ValidationError } from "../util-server";
 
@@ -130,7 +130,7 @@ export interface BackupSettings {
     includeEnvFiles: boolean;
     extraPaths: string[];
     volumeBackup: VolumeBackupConfig;
-    notificationLang: "fr" | "en";
+    notificationLang: NotificationLang;
     backupOnSave: boolean;               // déclenche un backup immédiat quand un compose est sauvegardé
     preventConcurrentBackups: boolean;   // refuse un nouveau backup tant que le précédent tourne
     excludedStacks: string[];            // stacks exclues de la sauvegarde
@@ -2052,16 +2052,25 @@ export class BackupManager {
         const apprise = await this.loadAppriseNotifier();
         if (!discord && !apprise) return;
 
-        const en     = (await getNotificationLang()) === "en";
-        const locale = en ? "en-GB" : "fr-FR";
+        const lang   = await getNotificationLang();
+        const locale = getNotificationLocale(lang);
+        const t      = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
         const hostname: string = await Settings.get("primaryHostname") || "";
         const hostnamePrefix   = hostname ? `[${hostname}] ` : "";
         const footerHost       = hostname ? ` · ${hostname}` : "";
         const hours  = Math.floor(ageMs / 3_600_000);
-        const title  = `${hostnamePrefix}${en ? "⚠️ Dockge backup overdue" : "⚠️ Backup Dockge en retard"}`;
-        const descr  = en
-            ? `No successful backup in the last **${hours}h**. Please check your backup configuration.`
-            : `Aucun backup réussi depuis **${hours}h**. Vérifiez votre configuration de backup.`;
+        const title  = `${hostnamePrefix}${t(
+            "⚠️ Backup Dockge en retard",
+            "⚠️ Dockge backup overdue",
+            "⚠️ Copia de Dockge atrasada",
+            "⚠️ Dockge 备份已逾期",
+        )}`;
+        const descr  = t(
+            `Aucun backup réussi depuis **${hours}h**. Vérifiez votre configuration de backup.`,
+            `No successful backup in the last **${hours}h**. Please check your backup configuration.`,
+            `No hay ninguna copia correcta desde hace **${hours} h**. Comprueba la configuración de copias de seguridad.`,
+            `过去 **${hours} 小时**没有成功备份。请检查备份配置。`,
+        );
 
         if (discord) {
             await discord.sendEmbed({
@@ -2096,29 +2105,30 @@ export class BackupManager {
         const apprise  = await this.loadAppriseNotifier();
         if (!discord && !apprise) return;
 
-        const en       = (await getNotificationLang()) === "en";
-        const locale   = en ? "en-GB" : "fr-FR";
-        const t        = (fr: string, enStr: string) => en ? enStr : fr;
+        const lang     = await getNotificationLang();
+        const locale   = getNotificationLocale(lang);
+        const t        = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
         const hostname: string = await Settings.get("primaryHostname") || "";
         const hostnamePrefix   = hostname ? `[${hostname}] ` : "";
         const footerHost       = hostname ? ` · ${hostname}` : "";
 
         if (result.success) {
-            const title  = `${hostnamePrefix}${t("✅ Backup Dockge réussi", "✅ Dockge backup successful")}`;
-            const descr  = `Snapshot \`${result.snapshotId}\` ${t("créé avec succès", "created successfully")}`;
+            const title  = `${hostnamePrefix}${t("✅ Backup Dockge réussi", "✅ Dockge backup successful", "✅ Copia de Dockge correcta", "✅ Dockge 备份成功")}`;
+            const descr  = `Snapshot \`${result.snapshotId}\` ${t("créé avec succès", "created successfully", "creada correctamente", "创建成功")}`;
             const fields: Array<{ name: string; value: string; inline: boolean }> = [
-                { name: t("Durée", "Duration"),
+                { name: t("Durée", "Duration", "Duración", "耗时"),
                   value: formatDuration(result.duration),                                  inline: true },
-                { name: t("Données ajoutées", "Data added"),
+                { name: t("Données ajoutées", "Data added", "Datos añadidos", "新增数据"),
                   value: formatBytes(result.dataAdded ?? 0),                               inline: true },
-                { name: t("Fichiers", "Files"),
-                  value: `${result.filesNew} ${t("nouveaux", "new")} · ${result.filesChanged} ${t("modifiés", "modified")}`,
+                { name: t("Fichiers", "Files", "Archivos", "文件"),
+                  value: `${result.filesNew} ${t("nouveaux", "new", "nuevos", "新增")} · ${result.filesChanged} ${t("modifiés", "modified", "modificados", "已修改")}`,
                   inline: true },
-                { name: t("Destinations", "Destinations"),
+                { name: t("Destinations", "Destinations", "Destinos", "目标"),
                   value: (result.destinations ?? [])
                       .map(d => {
                           const rt = d.restoreTest;
-                          const rtIcon = rt == null ? "" : (rt.ok ? " · Restore test ✅" : " · Restore test ❌");
+                          const rtLabel = t("Test de restauration", "Restore test", "Prueba de restauración", "恢复测试");
+                          const rtIcon = rt == null ? "" : (rt.ok ? ` · ${rtLabel} ✅` : ` · ${rtLabel} ❌`);
                           return `${d.success ? "✅" : "❌"} ${d.label}${rtIcon}`;
                       })
                       .join("\n") || "—",
@@ -2127,7 +2137,7 @@ export class BackupManager {
 
             if ((result.warnings ?? []).length > 0) {
                 fields.push({
-                    name: t("⚠️ Avertissements", "⚠️ Warnings"),
+                    name: t("⚠️ Avertissements", "⚠️ Warnings", "⚠️ Advertencias", "⚠️ 警告"),
                     value: result.warnings!.slice(0, 8).join("\n"),
                     inline: false,
                 });
@@ -2144,12 +2154,12 @@ export class BackupManager {
                 await apprise.send({ title, body, type: "success" });
             }
         } else {
-            const title  = `${hostnamePrefix}${t("❌ Échec du backup Dockge", "❌ Dockge backup failed")}`;
-            const descr  = `**${t("Erreur", "Error")} :** ${result.error}`;
+            const title  = `${hostnamePrefix}${t("❌ Échec du backup Dockge", "❌ Dockge backup failed", "❌ Error en la copia de Dockge", "❌ Dockge 备份失败")}`;
+            const descr  = `**${t("Erreur", "Error", "Error", "错误")} :** ${result.error}`;
             const fields: Array<{ name: string; value: string; inline: boolean }> = [
-                { name: t("Durée", "Duration"),
+                { name: t("Durée", "Duration", "Duración", "耗时"),
                   value: formatDuration(result.duration),                                  inline: true },
-                { name: t("Destinations", "Destinations"),
+                { name: t("Destinations", "Destinations", "Destinos", "目标"),
                   value: (result.destinations ?? [])
                       .map(d => `${d.success ? "✅" : "❌"} ${d.label}`)
                       .join("\n") || "—",
@@ -2158,7 +2168,7 @@ export class BackupManager {
 
             if ((result.warnings ?? []).length > 0) {
                 fields.push({
-                    name: t("⚠️ Avertissements", "⚠️ Warnings"),
+                    name: t("⚠️ Avertissements", "⚠️ Warnings", "⚠️ Advertencias", "⚠️ 警告"),
                     value: result.warnings!.slice(0, 8).join("\n"),
                     inline: false,
                 });

--- a/backend/watchers/image-watcher.ts
+++ b/backend/watchers/image-watcher.ts
@@ -18,7 +18,7 @@ import { parse as parseDotenv } from "dotenv";
 EventEmitter.defaultMaxListeners = 50;
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
 import {
   acceptedComposeFileNames,
@@ -76,7 +76,7 @@ export interface WatcherSettings {
   intervalHours: number;
   discordWebhooks: string[]; // liste de webhooks (migration auto depuis discordWebhook)
   credentials: RegistryCredential[];
-  notificationLang: "fr" | "en";
+  notificationLang: NotificationLang;
   autoUpdateConfig: Record<string, AutoUpdateEntry>; // clé "stack::image" → config màj auto
   pendingAutoUpdates: string[]; // clés en attente de màj planifiée
   appriseServerUrl: string; // URL du serveur Apprise (ex: "http://apprise:8000")
@@ -1477,9 +1477,9 @@ export class ImageWatcher {
         )
       : null;
     const uiUrl = this.baseUrl || null;
-    const en = (await getNotificationLang()) === "en";
-    const locale = en ? "en-GB" : "fr-FR";
-    const t = (fr: string, enStr: string) => (en ? enStr : fr);
+    const lang = await getNotificationLang();
+    const locale = getNotificationLocale(lang);
+    const t = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
     const hostname: string = (await Settings.get("primaryHostname")) || "";
     const hostnamePrefix = hostname ? `[${hostname}] ` : "";
     const footerHost = hostname ? ` · ${hostname}` : "";
@@ -1503,17 +1503,19 @@ export class ImageWatcher {
       title = `${hostnamePrefix}${t(
         `✅ ${autoUpdated.length} image(s) mise(s) à jour automatiquement`,
         `✅ ${autoUpdated.length} image(s) auto-updated`,
+        `✅ ${autoUpdated.length} imagen(es) actualizada(s) automáticamente`,
+        `✅ ${autoUpdated.length} 个镜像已自动更新`,
       )}`;
     } else if (autoUpdated.length > 0) {
       const parts = [
         autoUpdated.length > 0
-          ? `${autoUpdated.length} ${t("auto", "auto")}`
+          ? `${autoUpdated.length} ${t("auto", "auto", "auto", "自动")}`
           : "",
         scheduled.length > 0
-          ? `${scheduled.length} ${t("planifiée(s)", "scheduled")}`
+          ? `${scheduled.length} ${t("planifiée(s)", "scheduled", "programada(s)", "计划")}`
           : "",
         manual.length > 0
-          ? `${manual.length} ${t("manuelle(s)", "manual")}`
+          ? `${manual.length} ${t("manuelle(s)", "manual", "manual(es)", "手动")}`
           : "",
       ]
         .filter(Boolean)
@@ -1521,11 +1523,15 @@ export class ImageWatcher {
       title = `${hostnamePrefix}${t(
         `🐳 ${updates.length} mise(s) à jour — ${parts}`,
         `🐳 ${updates.length} update(s) — ${parts}`,
+        `🐳 ${updates.length} actualización(es) — ${parts}`,
+        `🐳 ${updates.length} 个更新 — ${parts}`,
       )}`;
     } else {
       title = `${hostnamePrefix}${t(
         `🐳 ${updates.length} mise(s) à jour disponible(s)`,
         `🐳 ${updates.length} update(s) available`,
+        `🐳 ${updates.length} actualización(es) disponible(s)`,
+        `🐳 ${updates.length} 个更新可用`,
       )}`;
     }
 
@@ -1540,33 +1546,39 @@ export class ImageWatcher {
             ? `🕐 \`${u.image}\``
             : `🔄 \`${u.image}\``,
         value:
-          `${t("Stack", "Stack")} : **${u.stack}**\n` +
+          `${t("Stack", "Stack", "Stack", "堆栈")} : **${u.stack}**\n` +
           (wasAutoUpdated
-            ? t("Mise à jour immédiate effectuée.", "Immediate update applied.")
+            ? t("Mise à jour immédiate effectuée.", "Immediate update applied.", "Actualización inmediata aplicada.", "已执行即时更新。")
             : isSched
               ? t(
                   `Mise à jour planifiée à **${entry!.time}**.`,
                   `Scheduled update at **${entry!.time}**.`,
+                  `Actualización programada a las **${entry!.time}**.`,
+                  `计划于 **${entry!.time}** 更新。`,
                 )
-              : `${t("Distant", "Remote")} : \`${u.remoteDigest.slice(0, 19)}…\`\n` +
+              : `${t("Distant", "Remote", "Remoto", "远程")} : \`${u.remoteDigest.slice(0, 19)}…\`\n` +
                 (u.localDigest
-                  ? `${t("Local", "Local")}   : \`${u.localDigest.slice(0, 19)}…\``
+                  ? `${t("Local", "Local", "Local", "本地")}   : \`${u.localDigest.slice(0, 19)}…\``
                   : t(
                       "⚠️ Image non présente localement",
                       "⚠️ Image not present locally",
+                      "⚠️ La imagen no está disponible localmente",
+                      "⚠️ 本地不存在该镜像",
                     ))),
         inline: false,
       };
     };
 
     const description =
-      `${totalChecked} ${t("image(s) vérifiée(s)", "image(s) checked")} · ${new Date().toLocaleString(locale)}\n` +
+      `${totalChecked} ${t("image(s) vérifiée(s)", "image(s) checked", "imagen(es) comprobada(s)", "个镜像已检查")} · ${new Date().toLocaleString(locale)}\n` +
       (notAuto.length > 0
         ? uiUrl
-          ? `[${t("Ouvrir Dockge", "Open Dockge")}](${uiUrl}) ${t("pour décider des mises à jour en attente.", "to review pending updates.")}`
+          ? `[${t("Ouvrir Dockge", "Open Dockge", "Abrir Dockge", "打开 Dockge")}](${uiUrl}) ${t("pour décider des mises à jour en attente.", "to review pending updates.", "para revisar las actualizaciones pendientes.", "以查看待处理更新。")}`
           : t(
               "Connectez-vous à **Dockge** pour décider des mises à jour en attente.",
               "Log in to **Dockge** to review pending updates.",
+              "Inicia sesión en **Dockge** para revisar las actualizaciones pendientes.",
+              "登录 **Dockge** 以查看待处理更新。",
             )
         : "");
 

--- a/backend/watchers/monitoring-watcher.ts
+++ b/backend/watchers/monitoring-watcher.ts
@@ -11,7 +11,7 @@ import { R } from "redbean-node";
 import yaml from "yaml";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
 import { DockgeServer } from "../dockge-server";
 import { Stack } from "../stack";
@@ -41,7 +41,7 @@ export interface MonitoringSettings {
     healthcheckCooldownMinutes: number;
     discordWebhooks: string[];
     appriseUrls: string[];
-    notificationLang: "fr" | "en";
+    notificationLang: NotificationLang;
     lowPowerMode: boolean;
 }
 
@@ -427,22 +427,27 @@ export class MonitoringWatcher {
         const hostnamePrefix = hostname ? `[${hostname}] ` : "";
         const footerHost     = hostname ? ` - ${hostname}` : "";
 
-        const en = (await getNotificationLang()) === "en";
-        const tr = (fr: string, enStr: string) => en ? enStr : fr;
+        const lang = await getNotificationLang();
+        const locale = getNotificationLocale(lang);
+        const tr = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
 
         const title = `${hostnamePrefix}` + tr(
             `Boucle de crash - ${event.containerName}`,
             `Crash loop - ${event.containerName}`,
+            `Bucle de fallos - ${event.containerName}`,
+            `崩溃循环 - ${event.containerName}`,
         );
         const desc = tr(
             `Le conteneur **${event.containerName}** a redémarré **${event.restartCount} fois** en ${event.windowMinutes} min.`,
             `Container **${event.containerName}** restarted **${event.restartCount} times** in ${event.windowMinutes} min.`,
+            `El contenedor **${event.containerName}** se reinició **${event.restartCount} veces** en ${event.windowMinutes} min.`,
+            `容器 **${event.containerName}** 在 ${event.windowMinutes} 分钟内重启了 **${event.restartCount} 次**。`,
         );
 
         if (discord) {
             await discord.sendEmbed({
                 title, color: 0xef4444, description: desc, fields: [],
-                footer: `Dockge Enhanced - Monitoring${footerHost} - ${new Date().toLocaleString(en ? "en-GB" : "fr-FR")}`,
+                footer: `Dockge Enhanced - Monitoring${footerHost} - ${new Date().toLocaleString(locale)}`,
             });
         }
         if (apprise) await apprise.send({ title, body: desc, type: "failure" });
@@ -459,22 +464,27 @@ export class MonitoringWatcher {
         const hostnamePrefix = hostname ? `[${hostname}] ` : "";
         const footerHost     = hostname ? ` - ${hostname}` : "";
 
-        const en = (await getNotificationLang()) === "en";
-        const tr = (fr: string, enStr: string) => en ? enStr : fr;
-        const actionLabel = this.healthActionLabel(event.action, en);
+        const lang = await getNotificationLang();
+        const locale = getNotificationLocale(lang);
+        const tr = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
+        const actionLabel = this.healthActionLabel(event.action, lang);
         const statusLabel = event.actionStatus === "success"
-            ? tr("action réussie", "action succeeded")
+            ? tr("action réussie", "action succeeded", "acción correcta", "操作成功")
             : event.actionStatus === "failed"
-                ? tr("action échouée", "action failed")
-                : tr("notification seule", "notification only");
+                ? tr("action échouée", "action failed", "acción fallida", "操作失败")
+                : tr("notification seule", "notification only", "solo notificación", "仅通知");
 
         const title = `${hostnamePrefix}` + tr(
             `Healthcheck unhealthy - ${event.containerName}`,
             `Healthcheck unhealthy - ${event.containerName}`,
+            `Healthcheck unhealthy - ${event.containerName}`,
+            `健康检查异常 - ${event.containerName}`,
         );
         const desc = tr(
             `Le conteneur **${event.containerName}** est passé en **unhealthy**. Mode: **${actionLabel}** (${statusLabel}). ${event.message}`,
             `Container **${event.containerName}** became **unhealthy**. Mode: **${actionLabel}** (${statusLabel}). ${event.message}`,
+            `El contenedor **${event.containerName}** pasó a **unhealthy**. Modo: **${actionLabel}** (${statusLabel}). ${event.message}`,
+            `容器 **${event.containerName}** 变为 **unhealthy**。模式：**${actionLabel}**（${statusLabel}）。${event.message}`,
         );
 
         if (discord) {
@@ -483,23 +493,23 @@ export class MonitoringWatcher {
                 color: event.actionStatus === "failed" ? 0xef4444 : 0xf59e0b,
                 description: desc,
                 fields: [
-                    { name: "Stack", value: event.stackName ?? "-", inline: true },
-                    { name: "Service", value: event.serviceName ?? "-", inline: true },
+                    { name: tr("Stack", "Stack", "Stack", "堆栈"), value: event.stackName ?? "-", inline: true },
+                    { name: tr("Service", "Service", "Servicio", "服务"), value: event.serviceName ?? "-", inline: true },
                 ],
-                footer: `Dockge Enhanced - Monitoring${footerHost} - ${new Date().toLocaleString(en ? "en-GB" : "fr-FR")}`,
+                footer: `Dockge Enhanced - Monitoring${footerHost} - ${new Date().toLocaleString(locale)}`,
             });
         }
         if (apprise) await apprise.send({ title, body: desc, type: event.actionStatus === "failed" ? "failure" : "warning" });
     }
 
-    private healthActionLabel(action: HealthAutoHealMode, en: boolean): string {
-        const labels: Record<HealthAutoHealMode, { fr: string; en: string }> = {
-            notify: { fr: "Notification seule", en: "Notify only" },
-            restart_container: { fr: "Redémarrer le conteneur", en: "Restart container" },
-            restart_service: { fr: "Redémarrer le service Compose", en: "Restart Compose service" },
-            stack_aware: { fr: "Intelligent stack/network", en: "Stack/network aware" },
+    private healthActionLabel(action: HealthAutoHealMode, lang: NotificationLang): string {
+        const labels: Record<HealthAutoHealMode, [string, string, string, string]> = {
+            notify: [ "Notification seule", "Notify only", "Solo notificación", "仅通知" ],
+            restart_container: [ "Redémarrer le conteneur", "Restart container", "Reiniciar contenedor", "重启容器" ],
+            restart_service: [ "Redémarrer le service Compose", "Restart Compose service", "Reiniciar servicio Compose", "重启 Compose 服务" ],
+            stack_aware: [ "Intelligent stack/network", "Stack/network aware", "Inteligente stack/red", "智能堆栈/网络" ],
         };
-        return en ? labels[action].en : labels[action].fr;
+        return notificationText(lang, ...labels[action]);
     }
 
     getRecentCrashEvents(): CrashEvent[] {

--- a/backend/watchers/self-update-checker.ts
+++ b/backend/watchers/self-update-checker.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 import axios from "axios";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, notificationText } from "../notification/notification-lang";
 import { Settings } from "../settings";
 import { SelfUpdateManager } from "../self-update/manager";
 import { atomicWriteJson } from "../self-update/state-file";
@@ -470,58 +470,72 @@ export class SelfUpdateChecker {
     const apprise = await this._loadApprise();
     if (webhooks.length === 0 && !apprise) return;
 
-    const en = (await getNotificationLang()) === "en";
+    const lang = await getNotificationLang();
+    const t = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
     const hostname = (await Settings.get("primaryHostname")) || "";
     const hostnamePrefix = hostname ? `[${hostname}] ` : "";
     const footerHost = hostname ? ` · ${hostname}` : "";
 
-    const title = `${hostnamePrefix}${en ? "🔔 Dockge-Enhanced update available" : "🔔 Mise à jour Dockge-Enhanced disponible"}`;
-    const releaseNotes = en
-      ? [
-          "**What’s new:**",
-          "• Automatic Dockge-Enhanced updates now use the exact detected digest, preserve Compose/relative bind-mount context, wait for real application readiness and keep a Restic recovery snapshot.",
-          "• The Updates tab can schedule or pause image and Dockge-Enhanced automatic updates, with mandatory Restic backup/verification and rollback on failed health checks.",
-          `Read the full changelog: https://github.com/${repo}`,
-        ]
-      : [
-          "**Nouveautés :**",
-          "• Les auto-mises à jour Dockge-Enhanced utilisent le digest exact détecté, conservent le contexte Compose et les bind mounts relatifs, attendent une application réellement prête et gardent un snapshot de récupération Restic.",
-          "• L’onglet Mises à jour permet de planifier ou suspendre les mises à jour automatiques, avec backup/vérification Restic obligatoires et rollback si le healthcheck échoue.",
-          `Lire le changelog complet : https://github.com/${repo}`,
-        ];
+    const title = `${hostnamePrefix}${t(
+      "🔔 Mise à jour Dockge-Enhanced disponible",
+      "🔔 Dockge-Enhanced update available",
+      "🔔 Actualización de Dockge-Enhanced disponible",
+      "🔔 Dockge-Enhanced 有可用更新",
+    )}`;
+    const releaseNotes = [
+      t("**Nouveautés :**", "**What’s new:**", "**Novedades:**", "**更新内容：**"),
+      t(
+        "• Les auto-mises à jour Dockge-Enhanced utilisent le digest exact détecté, conservent le contexte Compose et les bind mounts relatifs, attendent une application réellement prête et gardent un snapshot de récupération Restic.",
+        "• Automatic Dockge-Enhanced updates now use the exact detected digest, preserve Compose/relative bind-mount context, wait for real application readiness and keep a Restic recovery snapshot.",
+        "• Las actualizaciones automáticas de Dockge-Enhanced usan el digest exacto detectado, conservan el contexto Compose y los bind mounts relativos, esperan a que la aplicación esté realmente lista y mantienen una instantánea de recuperación Restic.",
+        "• Dockge-Enhanced 自动更新现在使用检测到的精确摘要，保留 Compose 上下文和相对绑定挂载，等待应用真正就绪，并保留 Restic 恢复快照。",
+      ),
+      t(
+        "• L’onglet Mises à jour permet de planifier ou suspendre les mises à jour automatiques, avec backup/vérification Restic obligatoires et rollback si le healthcheck échoue.",
+        "• The Updates tab can schedule or pause image and Dockge-Enhanced automatic updates, with mandatory Restic backup/verification and rollback on failed health checks.",
+        "• La pestaña Actualizaciones permite programar o pausar las actualizaciones automáticas, con copia/verificación Restic obligatorias y rollback si falla el healthcheck.",
+        "• “更新”标签页可安排或暂停自动更新，并要求 Restic 备份/验证；健康检查失败时会自动回滚。",
+      ),
+      t(
+        `Lire le changelog complet : https://github.com/${repo}`,
+        `Read the full changelog: https://github.com/${repo}`,
+        `Leer el registro de cambios completo: https://github.com/${repo}`,
+        `查看完整更新日志：https://github.com/${repo}`,
+      ),
+    ];
 
     const body = automaticMode
       ? [
-          en
-            ? "A new image is available on GHCR. Automatic Sidecar update is configured."
-            : "Une nouvelle image est disponible sur GHCR. La mise à jour automatique par sidecar est configurée.",
+          t(
+            "Une nouvelle image est disponible sur GHCR. La mise à jour automatique par sidecar est configurée.",
+            "A new image is available on GHCR. Automatic Sidecar update is configured.",
+            "Hay una nueva imagen disponible en GHCR. La actualización automática mediante Sidecar está configurada.",
+            "GHCR 上有新镜像可用，并已配置 Sidecar 自动更新。",
+          ),
           "",
           ...releaseNotes,
-        ].join("\n")
-      : en
-      ? [
-          "A new image is available on GHCR.",
-          "",
-          ...releaseNotes,
-          "",
-          "**To update:**",
-          "```bash",
-          `docker pull ghcr.io/${repo}:${SELF_TAG}`,
-          `docker compose up -d`,
-          "```",
-          "_Run from the folder containing your compose.yaml_",
         ].join("\n")
       : [
-          "Une nouvelle image est disponible sur GHCR.",
+          t(
+            "Une nouvelle image est disponible sur GHCR.",
+            "A new image is available on GHCR.",
+            "Hay una nueva imagen disponible en GHCR.",
+            "GHCR 上有新镜像可用。",
+          ),
           "",
           ...releaseNotes,
           "",
-          "**Pour mettre à jour :**",
+          t("**Pour mettre à jour :**", "**To update:**", "**Para actualizar:**", "**更新方法：**"),
           "```bash",
           `docker pull ghcr.io/${repo}:${SELF_TAG}`,
           `docker compose up -d`,
           "```",
-          "_Exécuter depuis le dossier contenant votre compose.yaml_",
+          t(
+            "_Exécuter depuis le dossier contenant votre compose.yaml_",
+            "_Run from the folder containing your compose.yaml_",
+            "_Ejecutar desde la carpeta que contiene compose.yaml_",
+            "_请在包含 compose.yaml 的目录中执行_",
+          ),
         ].join("\n");
 
     if (webhooks.length > 0) {
@@ -545,21 +559,32 @@ export class SelfUpdateChecker {
     const apprise = await this._loadApprise();
     if (webhooks.length === 0 && !apprise) return;
 
-    const en = (await getNotificationLang()) === "en";
+    const lang = await getNotificationLang();
+    const t = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
     const hostname = (await Settings.get("primaryHostname")) || "";
     const hostnamePrefix = hostname ? `[${hostname}] ` : "";
     const footerHost = hostname ? ` · ${hostname}` : "";
 
-    const title = `${hostnamePrefix}${en ? "✅ Dockge-Enhanced updated" : "✅ Dockge-Enhanced mis à jour"}`;
-    const body = en
-      ? [
-          `The container **${containerName}** is now running a new image.`,
-          `New digest: \`${newDigest.slice(7, 19)}\``,
-        ].join("\n")
-      : [
-          `Le conteneur **${containerName}** utilise désormais une nouvelle image.`,
-          `Nouveau digest : \`${newDigest.slice(7, 19)}\``,
-        ].join("\n");
+    const title = `${hostnamePrefix}${t(
+      "✅ Dockge-Enhanced mis à jour",
+      "✅ Dockge-Enhanced updated",
+      "✅ Dockge-Enhanced actualizado",
+      "✅ Dockge-Enhanced 已更新",
+    )}`;
+    const body = [
+      t(
+        `Le conteneur **${containerName}** utilise désormais une nouvelle image.`,
+        `The container **${containerName}** is now running a new image.`,
+        `El contenedor **${containerName}** utiliza ahora una nueva imagen.`,
+        `容器 **${containerName}** 现在正在运行新镜像。`,
+      ),
+      t(
+        `Nouveau digest : \`${newDigest.slice(7, 19)}\``,
+        `New digest: \`${newDigest.slice(7, 19)}\``,
+        `Nuevo digest: \`${newDigest.slice(7, 19)}\``,
+        `新摘要：\`${newDigest.slice(7, 19)}\``,
+      ),
+    ].join("\n");
 
     if (webhooks.length > 0) {
       await new DiscordNotifier(webhooks).sendEmbed({

--- a/backend/watchers/trivy-scanner.ts
+++ b/backend/watchers/trivy-scanner.ts
@@ -9,7 +9,7 @@ import { promisify } from "util";
 import * as path from "path";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
-import { getNotificationLang } from "../notification/notification-lang";
+import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
 
 const execFileAsync = promisify(execFile);
@@ -72,7 +72,7 @@ interface ScannerSettings {
     minSeverityAlert: Severity;
     ignoreUnfixed: boolean;
     scanTimeoutMinutes: number;
-    notificationLang: "fr" | "en";
+    notificationLang: NotificationLang;
     ignoredCVEs: string[];        // CVE IDs ignorés globalement (pas de notif, masqués dans l'UI)
 }
 
@@ -481,9 +481,9 @@ export class TrivyScanner {
     }
 
     private async sendImageAlert(discord: DiscordNotifier | null, apprise: AppriseNotifier | null, result: ScanResult): Promise<void> {
-        const en     = (await getNotificationLang()) === "en";
-        const locale = en ? "en-GB" : "fr-FR";
-        const t      = (fr: string, enStr: string) => en ? enStr : fr;
+        const lang   = await getNotificationLang();
+        const locale = getNotificationLocale(lang);
+        const t      = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
         const hostname: string = await Settings.get("primaryHostname") || "";
         const hostnamePrefix   = hostname ? `[${hostname}] ` : "";
         const footerHost       = hostname ? ` · ${hostname}` : "";
@@ -508,7 +508,7 @@ export class TrivyScanner {
             .join("\n");
 
         if (countLines) {
-            fields.push({ name: t("Résumé", "Summary"), value: countLines, inline: true });
+            fields.push({ name: t("Résumé", "Summary", "Resumen", "摘要"), value: countLines, inline: true });
         }
 
         const allVulns: Vulnerability[] = result.results.flatMap(r => r.Vulnerabilities || []);
@@ -522,19 +522,19 @@ export class TrivyScanner {
         if (topVulns.length > 0) {
             const vulnLines = topVulns.map(v => {
                 const fix = v.FixedVersion
-                    ? `→ fix: ${v.FixedVersion}`
-                    : t("→ pas de fix", "→ no fix");
+                    ? `→ ${t("correctif", "fix", "corrección", "修复")}: ${v.FixedVersion}`
+                    : t("→ pas de fix", "→ no fix", "→ sin corrección", "→ 暂无修复");
                 const url = v.PrimaryURL ?? `https://nvd.nist.gov/vuln/detail/${v.VulnerabilityID}`;
                 return `${SEVERITY_EMOJI[v.Severity]} [${v.VulnerabilityID}](${url}) **${v.PkgName}** ${v.InstalledVersion} ${fix}`;
             }).join("\n");
-            fields.push({ name: t("Top vulnérabilités", "Top vulnerabilities"), value: vulnLines, inline: false });
+            fields.push({ name: t("Top vulnérabilités", "Top vulnerabilities", "Principales vulnerabilidades", "主要漏洞"), value: vulnLines, inline: false });
         }
 
         const uiUrl = this.baseUrl || null;
-        const title = `${hostnamePrefix}${SEVERITY_EMOJI[result.maxSeverity]} ${t("Alerte sécurité", "Security alert")} — ${result.image}`;
+        const title = `${hostnamePrefix}${SEVERITY_EMOJI[result.maxSeverity]} ${t("Alerte sécurité", "Security alert", "Alerta de seguridad", "安全警报")} — ${result.image}`;
         const description =
-            `${t("Stack", "Stack")} : **${result.stack}**\n${t("Sévérité max", "Max severity")} : **${result.maxSeverity}**` +
-            (uiUrl ? `\n\n[${t("Ouvrir Dockge", "Open Dockge")}](${uiUrl})` : "");
+            `${t("Stack", "Stack", "Stack", "堆栈")} : **${result.stack}**\n${t("Sévérité max", "Max severity", "Severidad máxima", "最高严重级别")} : **${result.maxSeverity}**` +
+            (uiUrl ? `\n\n[${t("Ouvrir Dockge", "Open Dockge", "Abrir Dockge", "打开 Dockge")}](${uiUrl})` : "");
 
         if (discord) {
             await discord.sendEmbed({
@@ -558,9 +558,9 @@ export class TrivyScanner {
     }
 
     private async sendSummary(discord: DiscordNotifier | null, apprise: AppriseNotifier | null, results: ScanResult[]): Promise<void> {
-        const en     = (await getNotificationLang()) === "en";
-        const locale = en ? "en-GB" : "fr-FR";
-        const t      = (fr: string, enStr: string) => en ? enStr : fr;
+        const lang   = await getNotificationLang();
+        const locale = getNotificationLocale(lang);
+        const t      = (fr: string, en: string, es: string, zhCN: string) => notificationText(lang, fr, en, es, zhCN);
         const hostname: string = await Settings.get("primaryHostname") || "";
         const hostnamePrefix   = hostname ? `[${hostname}] ` : "";
         const footerHost       = hostname ? ` · ${hostname}` : "";
@@ -592,7 +592,7 @@ export class TrivyScanner {
         const uiUrl = this.baseUrl || null;
         const imageLines = results.map(r => {
             const header = `${SEVERITY_EMOJI[r.maxSeverity]} \`${r.image}\` (${r.stack})`;
-            if (r.error) return `${header}\n  ${t("⚠️ Erreur de scan", "⚠️ Scan error")}`;
+            if (r.error) return `${header}\n  ${t("⚠️ Erreur de scan", "⚠️ Scan error", "⚠️ Error de análisis", "⚠️ 扫描错误")}`;
 
             const topVulns = r.results
                 .flatMap(res => res.Vulnerabilities || [])
@@ -621,15 +621,20 @@ export class TrivyScanner {
             imagesValue += addition;
         }
         if (truncatedCount > 0) {
-            imagesValue += `\n_+${truncatedCount} ${t("autre(s) image(s)", "more image(s)")}_`;
+            imagesValue += `\n_+${truncatedCount} ${t("autre(s) image(s)", "more image(s)", "imagen(es) más", "个其他镜像")}_`;
         }
 
         const title = hasCritical
-            ? `${hostnamePrefix}🚨 ${t("Rapport de sécurité — Vulnérabilités détectées", "Security report — Vulnerabilities detected")}`
-            : `${hostnamePrefix}✅ ${t(`Rapport de sécurité — ${results.length} image(s) scannée(s)`, `Security report — ${results.length} image(s) scanned`)}`;
+            ? `${hostnamePrefix}🚨 ${t("Rapport de sécurité — Vulnérabilités détectées", "Security report — Vulnerabilities detected", "Informe de seguridad — Vulnerabilidades detectadas", "安全报告 — 检测到漏洞")}`
+            : `${hostnamePrefix}✅ ${t(
+                `Rapport de sécurité — ${results.length} image(s) scannée(s)`,
+                `Security report — ${results.length} image(s) scanned`,
+                `Informe de seguridad — ${results.length} imagen(es) analizada(s)`,
+                `安全报告 — 已扫描 ${results.length} 个镜像`,
+            )}`;
         const description =
-            (summaryLines || t("Aucune vulnérabilité significative détectée.", "No significant vulnerabilities detected.")) +
-            (uiUrl ? `\n\n[${t("Ouvrir Dockge", "Open Dockge")}](${uiUrl})` : "");
+            (summaryLines || t("Aucune vulnérabilité significative détectée.", "No significant vulnerabilities detected.", "No se detectaron vulnerabilidades significativas.", "未检测到重大漏洞。")) +
+            (uiUrl ? `\n\n[${t("Ouvrir Dockge", "Open Dockge", "Abrir Dockge", "打开 Dockge")}](${uiUrl})` : "");
 
         if (discord) {
             await discord.sendEmbed({
@@ -639,7 +644,7 @@ export class TrivyScanner {
                 description,
                 fields: [
                     {
-                        name: t("Images scannées", "Scanned images"),
+                        name: t("Images scannées", "Scanned images", "Imágenes analizadas", "已扫描镜像"),
                         value: imagesValue,
                         inline: false,
                     }
@@ -651,7 +656,7 @@ export class TrivyScanner {
         if (apprise) {
             await apprise.send({
                 title,
-                body:  `${description}\n\n**${t("Images scannées", "Scanned images")}**\n${imagesValue}`.trim(),
+                body:  `${description}\n\n**${t("Images scannées", "Scanned images", "Imágenes analizadas", "已扫描镜像")}**\n${imagesValue}`.trim(),
                 type:  hasCritical ? "failure" : "success",
             });
         }

--- a/frontend/src/components/backup/shared.ts
+++ b/frontend/src/components/backup/shared.ts
@@ -80,7 +80,7 @@ export interface Settings {
     retention: Retention;
     includeEnvFiles: boolean;
     discordWebhooks?: string[];
-    notificationLang?: "fr" | "en";
+    notificationLang?: "fr" | "en" | "es" | "zh-CN";
     volumeBackup: VolumeBackupConfig;
     extraPaths?: string[];
     backupOnSave: boolean;

--- a/frontend/src/lang/README.md
+++ b/frontend/src/lang/README.md
@@ -1,5 +1,16 @@
 # Translations
 
+## Dockge Enhanced translation policy
+
+Dockge Enhanced keeps its own new user-facing strings aligned in these four reference languages:
+
+- English (`en`)
+- French (`fr`)
+- Spanish (`es`)
+- Simplified Chinese (`zh-CN`)
+
+This applies to Enhanced-specific UI additions, the “What’s new” popup, project README files, and Discord/Apprise notification text. Other inherited Dockge translations remain available and continue to follow the upstream/Weblate workflow.
+
 A simple guide on how to translate `Dockge` in your native language.
 
 ## How to Translate

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -31,6 +31,7 @@
     "releaseNews.item.safeSelfUpdates": "An Updates tab lets you schedule or pause automatic updates for images and Dockge-Enhanced. Sidecar mode displays the mandatory Restic backup and verification, prefers the existing Compose stack and automatically restores the previous container if its health check fails.",
     "releaseNews.item.selfUpdateHardening": "Dockge-Enhanced self-updates now use the exact detected digest, preserve Compose paths and relative bind mounts, wait for real application readiness and keep a recovery snapshot in the Restic backup.",
     "releaseNews.item.remoteUpdateBadges": "Image update badges in the stack list now also show updates detected by remote Dockge-Enhanced instances, with status kept separate for each server.",
+    "releaseNews.item.fourLanguageEnhanced": "Enhanced-specific user-facing additions now stay aligned in English, French, Spanish and Simplified Chinese. Discord and Apprise notifications follow the selected UI language, and a Simplified Chinese README is now available.",
     "releaseNews.close": "Close",
     "releaseNews.gotIt": "Got it",
     "Create your admin account": "Create your admin account",

--- a/frontend/src/lang/es.json
+++ b/frontend/src/lang/es.json
@@ -32,6 +32,7 @@
     "releaseNews.item.safeSelfUpdates": "La pestaña Actualizaciones permite programar o pausar las actualizaciones automáticas de imágenes y Dockge-Enhanced. El modo Sidecar muestra la copia Restic y su verificación obligatoria, prioriza la stack Compose existente y restaura automáticamente el contenedor anterior si falla el healthcheck.",
     "releaseNews.item.selfUpdateHardening": "Las autoactualizaciones de Dockge-Enhanced usan ahora el digest exacto detectado, conservan las rutas Compose y los bind mounts relativos, esperan a que la aplicación esté realmente lista y guardan una instantánea de recuperación en la copia Restic.",
     "releaseNews.item.remoteUpdateBadges": "Los indicadores de actualización de la lista de stacks ahora también muestran las actualizaciones detectadas por instancias remotas de Dockge-Enhanced, manteniendo el estado separado para cada servidor.",
+    "releaseNews.item.fourLanguageEnhanced": "Las novedades de cara al usuario propias de Enhanced se mantienen ahora de forma coherente en inglés, francés, español y chino simplificado. Las notificaciones de Discord y Apprise siguen el idioma de la interfaz y ya hay un README en chino simplificado.",
     "logLineWrap": "Ajuste de línea",
     "logLineWrapToggle": "Activar o desactivar el ajuste automático de línea",
     "logLineWrapOn": "Líneas ajustadas",

--- a/frontend/src/lang/fr.json
+++ b/frontend/src/lang/fr.json
@@ -31,6 +31,7 @@
     "releaseNews.item.safeSelfUpdates": "Un onglet Mises à jour permet de planifier ou suspendre les mises à jour automatiques des images et de Dockge-Enhanced. Le mode Sidecar affiche le backup Restic et sa vérification obligatoire, privilégie la stack Compose existante et restaure automatiquement le conteneur précédent si le healthcheck échoue.",
     "releaseNews.item.selfUpdateHardening": "Les auto-mises à jour Dockge-Enhanced utilisent désormais le digest exact détecté, conservent les chemins Compose et bind mounts relatifs, attendent une application réellement prête et conservent un snapshot de récupération dans le backup Restic.",
     "releaseNews.item.remoteUpdateBadges": "Les badges MàJ de la liste des stacks affichent désormais aussi les mises à jour détectées par les instances Dockge-Enhanced distantes, avec un état séparé pour chaque serveur.",
+    "releaseNews.item.fourLanguageEnhanced": "Les ajouts utilisateur propres à Enhanced sont désormais maintenus de façon cohérente en anglais, français, espagnol et chinois simplifié. Les notifications Discord et Apprise suivent la langue de l’interface, et un README en chinois simplifié est maintenant disponible.",
     "releaseNews.close": "Fermer",
     "releaseNews.gotIt": "J'ai compris",
     "Create your admin account": "Créez votre compte administrateur",

--- a/frontend/src/lang/zh-CN.json
+++ b/frontend/src/lang/zh-CN.json
@@ -301,6 +301,7 @@
     "releaseNews.item.safeSelfUpdates": "“更新”标签页可为镜像和 Dockge-Enhanced 安排或暂停自动更新。Sidecar 模式会显示必需的 Restic 备份及验证，优先使用现有 Compose 堆栈，并在健康检查失败时自动恢复此前的容器。",
     "releaseNews.item.selfUpdateHardening": "Dockge-Enhanced 自更新现在使用检测到的精确摘要，保留 Compose 路径和相对绑定挂载，等待应用真正就绪，并在 Restic 备份中保存恢复快照。",
     "releaseNews.item.remoteUpdateBadges": "堆栈列表中的镜像更新标记现在也会显示远程 Dockge-Enhanced 实例检测到的更新，并按服务器分别保存状态。",
+    "releaseNews.item.fourLanguageEnhanced": "Enhanced 面向用户的新增内容现在会在英语、法语、西班牙语和简体中文之间保持一致。Discord 和 Apprise 通知会跟随界面语言，并新增了简体中文 README。",
     "releaseNews.item.logWrap": "日志按钮可切换自动换行，或将每条完整日志保持在一行并支持横向滚动。",
     "releaseNews.item.logs": "响应式日志面板，支持搜索、服务筛选、时间戳，以及 x1、x1.5 或 x2 高度。",
     "releaseNews.item.rawComposeCopy": "专用操作可复制不带行号或视觉选择痕迹的原始 Compose YAML。",

--- a/frontend/src/release-news.js
+++ b/frontend/src/release-news.js
@@ -116,6 +116,12 @@ export const RELEASE_NEWS = [
             "releaseNews.item.remoteUpdateBadges",
         ],
     },
+    {
+        id: "2026-09-01-four-language-enhanced",
+        items: [
+            "releaseNews.item.fourLanguageEnhanced",
+        ],
+    },
 ];
 
 export function getReleaseNewsSince(lastSeenId) {


### PR DESCRIPTION
## Modifications

- définit EN, FR, ES et zh-CN comme langues de référence pour les ajouts propres à Dockge-Enhanced ;
- fait suivre aux notifications Discord et Apprise la langue actuellement sélectionnée dans l'interface ;
- étend la localisation aux notifications de mises à jour d'images, backups Restic, Trivy, monitoring et auto-mise à jour de Dockge-Enhanced ;
- localise également les notifications de test Discord et Apprise ;
- conserve l'anglais comme repli pour les autres langues de l'interface ;
- ajoute `README.zh-CN.md` et les liens vers le README chinois dans les README existants ;
- met à jour les badges i18n et documente la politique de traduction des ajouts Enhanced ;
- ajoute cette évolution au popup « Nouveautés » en EN, FR, ES et zh-CN.