### PR TITLE
Corriger le rollback critique de l’auto-mise à jour

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -6,6 +6,10 @@
 
 # Dockge Enhanced
 
+> [!IMPORTANT]
+> **Corrección crítica de la autoactualización — actualización obligatoria.** Las builds publicadas entre **la tarde/noche del 31/08/2026 y la tarde/noche del 01/09/2026** contenían una ruta de autoactualización de Dockge-Enhanced que podía eliminar el contenedor en ejecución y no conseguir recrearlo si fallaba el reemplazo mediante Compose. **No conserve ni reinstale ninguna versión publicada durante ese intervalo. No utilice su autoactualización integrada para salir de ese intervalo: actualice manualmente con Docker Compose directamente a la versión 1.5.1 o posterior y, después, vuelva a activar las actualizaciones automáticas.** Este problema no elimina sus stacks ni sus datos persistentes; afecta a la recreación del propio contenedor Dockge-Enhanced. La versión 1.5.1 añade un rollback secundario e independiente basado en el snapshot de recuperación, sin depender de que el contenedor de reemplazo siga existiendo.
+
+
 Un fork con funcionalidades adicionales de [Dockge](https://github.com/louislam/dockge) — agrega monitoreo de imágenes, escaneo de seguridad, copias de seguridad automáticas, detección de bucles de fallo y gestión de recursos de Docker, todo desde la interfaz web.
 
 > 🇪🇸 Español · 🇬🇧 [English](README.md) · 🇫🇷 [Français](README.fr.md) · 🇨🇳 [简体中文](README.zh-CN.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,6 +4,10 @@
 
 # Dockge Enhanced
 
+> [!IMPORTANT]
+> **Correctif critique de l’auto-mise à jour — mise à jour impérative.** Les builds publiés entre **le soir du 31/08/2026 et le soir du 01/09/2026** contenaient un chemin d’auto-mise à jour Dockge-Enhanced pouvant supprimer le conteneur en cours puis ne pas réussir à le recréer si le remplacement Compose échouait. **N’utilisez plus et ne réinstallez aucune version publiée dans cette fenêtre. N’utilisez pas son auto-mise à jour intégrée pour en sortir : effectuez une mise à jour manuelle avec Docker Compose directement vers la 1.5.1 ou supérieure, puis réactivez les mises à jour automatiques.** Ce problème ne supprime pas vos stacks ni leurs données persistantes ; il concerne la recréation du conteneur Dockge-Enhanced lui-même. La 1.5.1 ajoute un second rollback indépendant à partir du snapshot de récupération, qui ne dépend plus de l’existence du conteneur de remplacement.
+
+
 Un fork enrichi de [Dockge](https://github.com/louislam/dockge) — ajoute la surveillance d'images, le scan de sécurité, les sauvegardes automatiques, la détection de crash loop et la gestion des ressources Docker, le tout depuis l'interface web.
 
 > 🇫🇷 Français · 🇬🇧 [English](README.md) · 🇪🇸 [Español](README.es-ES.md) · 🇨🇳 [简体中文](README.zh-CN.md) · [Article de présentation](https://upandclear.org/2026/08/30/dockge-enhanced-quelques-mois-plus-tard-le-petit-fork-a-bien-grandi/)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 # Dockge Enhanced
 
+> [!IMPORTANT]
+> **Critical self-update fix — update immediately.** Builds published between **2026-08-31 evening and 2026-09-01 evening** contained an unsafe Dockge-Enhanced self-update path that could remove the running container and fail to recreate it if the Compose replacement failed. **Do not keep or reinstall any build from that window. Do not use its built-in self-update to leave that window: update manually with Docker Compose directly to 1.5.1 or newer, then re-enable automatic self-updates.** Your stacks and persistent data are not deleted by this issue; the failure concerns recreation of the Dockge-Enhanced container itself. Version 1.5.1 adds an independent recovery-snapshot fallback so rollback no longer depends on the replacement container still existing.
+
+
 A feature fork of [Dockge](https://github.com/louislam/dockge) — adds image monitoring, security scanning, automatic backups, crash-loop detection and Docker resource management, all from the web UI.
 
 > 🇬🇧 English · 🇫🇷 [Français](README.fr.md) · 🇪🇸 [Español](README.es-ES.md) · 🇨🇳 [简体中文](README.zh-CN.md)

--- a/extra/self-update-sidecar/index.js
+++ b/extra/self-update-sidecar/index.js
@@ -112,11 +112,15 @@ function composeUpdate(plan, image, deps = {}) {
     (deps.docker || docker)([ ...base, "up", "-d", "--no-deps", plan.compose.service ], { timeout: 180_000 });
     return override;
 }
-function dockerApi(method, requestPath, body) {
+function dockerApi(method, requestPath, body, options = {}) {
     return new Promise((resolve, reject) => {
         const req = http.request({ socketPath, path: requestPath, method, headers: body ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body) } : undefined }, res => {
             let raw = ""; res.on("data", chunk => { raw += chunk; });
-            res.on("end", () => res.statusCode >= 200 && res.statusCode < 300 ? resolve(raw) : reject(new Error(`Docker API ${method} ${requestPath}: ${res.statusCode} ${raw.slice(0, 500)}`)));
+            res.on("end", () => {
+                if (res.statusCode >= 200 && res.statusCode < 300) return resolve(raw);
+                if (options.allow404 && res.statusCode === 404) return resolve("");
+                reject(new Error(`Docker API ${method} ${requestPath}: ${res.statusCode} ${raw.slice(0, 500)}`));
+            });
         });
         req.on("error", reject); if (body) req.write(body); req.end();
     });
@@ -125,8 +129,15 @@ async function snapshotCreate(recovery, currentId, image, deps = {}) {
     const config = { ...(recovery.config || {}), Image: image };
     const body = JSON.stringify({ ...config, HostConfig: recovery.hostConfig, NetworkingConfig: { EndpointsConfig: recovery.endpointsConfig || {} } });
     const api = deps.dockerApi || dockerApi;
-    await api("POST", `/containers/${encodeURIComponent(currentId)}/stop?t=30`);
-    await api("DELETE", `/containers/${encodeURIComponent(currentId)}?force=1`);
+    const stopAndRemove = async identifier => {
+        if (!identifier) return;
+        await api("POST", `/containers/${encodeURIComponent(identifier)}/stop?t=30`, undefined, { allow404: true });
+        await api("DELETE", `/containers/${encodeURIComponent(identifier)}?force=1`, undefined, { allow404: true });
+    };
+    // Remove whichever incarnation exists. During a failed Compose replace the
+    // original ID may already be gone while a half-created replacement owns the name.
+    await stopAndRemove(currentId);
+    if (currentId !== recovery.targetContainerName) await stopAndRemove(recovery.targetContainerName);
     const created = JSON.parse(await api("POST", `/containers/create?name=${encodeURIComponent(recovery.targetContainerName)}`, body));
     await api("POST", `/containers/${encodeURIComponent(created.Id)}/start`);
 }
@@ -151,15 +162,32 @@ async function run(deps = {}) {
         } catch (error) { updateError = error; }
         writeStatus("rolling-back", `Update failed; restoring the previous image: ${updateError instanceof Error ? updateError.message : String(updateError)}`, true, plan);
         try {
-            // A Compose update can remove the old container before the replacement
-            // is created.  Do not inspect the replacement before restoring: it may
-            // not exist, which would otherwise skip the only recovery path.
+            let composeRollbackError;
             if (plan.compose) {
-                override = composeUpdate(plan, plan.previousImageId, deps);
-            } else {
-                const current = inspect(plan.targetContainerName, deps);
-                await snapshotCreate(recovery, current.Id, plan.previousImageId, deps);
+                try {
+                    override = composeUpdate(plan, plan.previousImageId, deps);
+                    if (waitReady(plan.targetContainerName, deps)) {
+                        writeStatus("rolled-back", `Update failed and the previous container was restored through Compose: ${updateError instanceof Error ? updateError.message : String(updateError)}`, true, plan);
+                        return "rolled-back";
+                    }
+                    composeRollbackError = new Error("Compose restored the previous image but it did not become ready");
+                } catch (error) {
+                    composeRollbackError = error;
+                }
+                // Compose is the preferred recovery path because it preserves project
+                // semantics. If it cannot recreate a usable container, fall back to
+                // the signed pre-update Docker snapshot. This path deliberately does
+                // not inspect the missing replacement first.
+                await snapshotCreate(recovery, null, plan.previousImageId, deps);
+                if (waitReady(plan.targetContainerName, deps)) {
+                    writeStatus("rolled-back", `Update failed and Compose rollback failed (${composeRollbackError instanceof Error ? composeRollbackError.message : String(composeRollbackError)}); the previous container was restored from the recovery snapshot`, true, plan);
+                    return "rolled-back";
+                }
+                throw new Error(`Compose rollback failed (${composeRollbackError instanceof Error ? composeRollbackError.message : String(composeRollbackError)}) and snapshot recovery did not become ready`);
             }
+            let currentId = null;
+            try { currentId = inspect(plan.targetContainerName, deps).Id; } catch { /* replacement may not exist */ }
+            await snapshotCreate(recovery, currentId, plan.previousImageId, deps);
             if (waitReady(plan.targetContainerName, deps)) { writeStatus("rolled-back", `Update failed and the previous container was restored: ${updateError instanceof Error ? updateError.message : String(updateError)}`, true, plan); return "rolled-back"; }
             throw new Error("Previous container did not become ready");
         } catch (rollbackError) {
@@ -171,5 +199,5 @@ async function run(deps = {}) {
     } catch (error) { writeStatus("failed", error instanceof Error ? error.message : String(error), false, plan); return "failed"; }
     finally { if (override) fs.rmSync(override, { force: true }); if (claimed) fs.rmSync(claimed, { force: true }); }
 }
-module.exports = { applicationReady, atomicWriteJson, composeUpdate, imageRepository, inside, readAndClaimPlan, run, validateCompose, waitReady, writeStatus };
+module.exports = { applicationReady, atomicWriteJson, composeUpdate, dockerApi, imageRepository, inside, readAndClaimPlan, run, snapshotCreate, validateCompose, waitReady, writeStatus };
 if (require.main === module) run().then(result => { if ([ "failed", "rollback-failed" ].includes(result)) process.exitCode = 1; }).catch(error => { console.error(error); process.exitCode = 1; });

--- a/extra/self-update-sidecar/index.test.js
+++ b/extra/self-update-sidecar/index.test.js
@@ -129,3 +129,48 @@ test("a Compose creation failure restores the previous image without inspecting 
     const status = JSON.parse(fs.readFileSync(path.join(root, "status.json")));
     assert.equal(status.state, "rolled-back");
 });
+
+test("Compose rollback failure falls back to the signed recovery snapshot when the target container no longer exists", async () => {
+    process.env.SELF_UPDATE_ALLOW_TEST_IMAGES = "dockge-enhanced:test-v2";
+    const work = path.join(root, "snapshot-fallback"); fs.mkdirSync(work, { recursive: true });
+    const composeFile = path.join(work, "compose.yaml"); fs.writeFileSync(composeFile, "services:\n  dockge:\n    image: dockge-enhanced:test-v1\n");
+    process.env.SELF_UPDATE_COMPOSE_DIR = work;
+    const { plan, planPath } = signedPlan({ compose: { workingDir: work, configFiles: [ composeFile ], project: "test", service: "dockge" } });
+    fs.mkdirSync(path.join(root, "recovery"), { recursive: true });
+    fs.writeFileSync(path.join(root, "recovery", plan.recoveryFile), JSON.stringify({ id: plan.id, targetContainerId: plan.targetContainerId, targetContainerName: plan.targetContainerName, previousImage: plan.previousImage, previousImageId: plan.previousImageId, config: {}, hostConfig: {}, endpointsConfig: {} }));
+    const time = clock(); let initialInspect = true; let recovered = false; const apiCalls = [];
+    const docker = args => {
+        if (args[1] === "inspect") {
+            if (initialInspect) { initialInspect = false; return JSON.stringify({ Id: "container-id", Name: "/dockge-test", Config: { Image: "dockge-enhanced:test-v1" }, State: { Running: true, Status: "running" } }); }
+            if (!recovered) throw new Error("No such container: dockge-test");
+            return JSON.stringify({ Id: "recovered-id", Name: "/dockge-test", Config: { Image: plan.previousImageId }, State: { Running: true, Status: "running" } });
+        }
+        if (args.includes("up")) throw new Error("compose create failed");
+        if (args.includes("wget")) return "ok";
+        return "";
+    };
+    const dockerApi = async (method, requestPath) => {
+        apiCalls.push([ method, requestPath ]);
+        if (method === "POST" && requestPath.startsWith("/containers/create")) { recovered = true; return JSON.stringify({ Id: "recovered-id" }); }
+        return "";
+    };
+    const result = await sidecar.run({ planPath, docker, dockerApi, ...time, stableMs: 2_000, timeoutMs: 4_000, pollMs: 1_000 });
+    assert.equal(result, "rolled-back");
+    assert.ok(apiCalls.some(([ method, requestPath ]) => method === "POST" && requestPath.startsWith("/containers/create?name=dockge-test")));
+    const status = JSON.parse(fs.readFileSync(path.join(root, "status.json")));
+    assert.match(status.message, /restored from the recovery snapshot/);
+});
+
+test("snapshot recovery tolerates an already deleted container and removes any replacement by name", async () => {
+    const calls = [];
+    const recovery = { targetContainerName: "dockge-test", config: {}, hostConfig: {}, endpointsConfig: {} };
+    const dockerApi = async (method, requestPath, body, options = {}) => {
+        calls.push({ method, requestPath, options });
+        if (method === "POST" && requestPath.startsWith("/containers/create")) return JSON.stringify({ Id: "restored-id" });
+        return "";
+    };
+    await sidecar.snapshotCreate(recovery, null, `sha256:${"2".repeat(64)}`, { dockerApi });
+    assert.ok(calls.some(call => call.requestPath === "/containers/dockge-test/stop?t=30" && call.options.allow404 === true));
+    assert.ok(calls.some(call => call.requestPath === "/containers/dockge-test?force=1" && call.options.allow404 === true));
+    assert.ok(calls.some(call => call.requestPath === "/containers/create?name=dockge-test"));
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dockge-enhanced",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dockge-enhanced",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "dependencies": {
                 "@homebridge/node-pty-prebuilt-multiarch": "0.14.1",
                 "@inventage/envsubst": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockge-enhanced",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "type": "module",
     "engines": {
         "node": ">= 22.14.0"


### PR DESCRIPTION
Corrige le chemin critique de rollback de l’auto-mise à jour Dockge-Enhanced.

- conserve un fallback indépendant basé sur le snapshot Docker capturé avant l’update ;
- restaure l’ancienne instance même si le conteneur de remplacement a disparu ;
- ne dépend plus d’un `docker inspect` sur un conteneur déjà supprimé pour reconstruire le rollback ;
- supprime un éventuel remplacement partiel avant la restauration de secours ;
- ajoute des tests de régression couvrant la disparition du conteneur après un échec Compose ;
- passe l’updater en 1.5.1 ;
- ajoute dans les README FR/EN/ES un avertissement impératif demandant d’abandonner les builds publiés entre le 31/08/2026 au soir et le 01/09/2026 au soir et de sortir de cette fenêtre par une mise à jour Docker Compose manuelle.