### PR TITLE
Qualifier les logs des services Enhanced

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -54,6 +54,11 @@ vulnerabilities:
     expired_at: 2026-09-13
     statement: Restic 0.19.1 embarque une stdlib Go vulnérable (Go crypto/tls); aucune release Go corrigée stable n'est encore disponible.
 
+  - id: CVE-2026-84304
+    paths: ["usr/local/bin/restic"]
+    expired_at: 2026-09-13
+    statement: Restic 0.19.1 est la dernière release stable et embarque encore google.golang.org/grpc 1.81.1; le correctif grpc 1.83.1 n'est pas encore disponible dans une release officielle Restic.
+
 misconfigurations:
   - id: AVD-DS-0002
     paths: ["Dockerfile"]

--- a/backend/notification/apprise.ts
+++ b/backend/notification/apprise.ts
@@ -14,6 +14,7 @@
 
 import axios from "axios";
 import { getNotificationLang, notificationText } from "./notification-lang";
+import { log } from "../log";
 
 export type AppriseNotifType = "info" | "success" | "warning" | "failure";
 
@@ -89,7 +90,7 @@ export class AppriseNotifier {
                 });
                 // Apprise renvoie 200 pour succès, 204 si aucun plugin configuré
                 if (res.status === 200 || res.status === 204) {
-                    console.log(`[AppriseNotifier] Notification envoyée : ${options.title}`);
+                    log.info("apprise", `Notification envoyée — title=${options.title}`);
                     return true;
                 }
                 console.warn(`[AppriseNotifier] Réponse inattendue : HTTP ${res.status}`);

--- a/backend/notification/discord.ts
+++ b/backend/notification/discord.ts
@@ -5,6 +5,7 @@
 
 import axios from "axios";
 import { getNotificationLang, notificationText } from "./notification-lang";
+import { log } from "../log";
 
 const DISCORD_API_URL = "https://discord.com";
 const discordApi = axios.create({ baseURL: DISCORD_API_URL });
@@ -126,7 +127,7 @@ export class DiscordNotifier {
         const results = await Promise.all(this.urls.map(url => this.sendEmbedToUrl(url, options)));
         const sent = results.filter(Boolean).length;
         const failed = this.urls.length - sent;
-        if (sent > 0) console.log(`[DiscordNotifier] Notification envoyée (${sent}/${this.urls.length} webhook(s)) : ${options.title}`);
+        if (sent > 0) log.info("discord", `Notification envoyée — success=${sent}/${this.urls.length} title=${options.title}`);
         if (failed > 0 && sent === 0) console.error(`[DiscordNotifier] Échec total — aucun webhook n'a reçu : ${options.title}`);
     }
 

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -15,6 +15,7 @@ import { DEFAULT_SELF_UPDATE_SETTINGS, normalizeSelfUpdateSettings, selfUpdateMa
 import { isAllowedTargetImage, isPathInside, isSafeComposeName, isSelfUpdateActive, normalizeSelfRepository } from "./policy";
 import { atomicWriteFile, atomicWriteJson } from "./state-file";
 import packageJSON from "../../package.json";
+import { log } from "../log";
 
 const execFileAsync = promisify(execFile);
 const DATA_DIR = process.env.DOCKGE_DATA_DIR ?? "/opt/dockge/data";
@@ -168,11 +169,17 @@ export class SelfUpdateManager {
         if (!inspected.Image || !/^sha256:[a-f0-9]{64}$/i.test(inspected.Image)) throw new Error("Current immutable Docker image identifier is unavailable");
         const plan = await this.buildPlan(inspected, safePlanId(), targetImage, previousImage, repository);
         const recoveryPath = path.join(RECOVERY_DIR, plan.recoveryFile);
+        const startedMs = Date.now();
+        log.info(
+            "self-update",
+            `Opération créée — id=${plan.id} automatic=${automatic} container=${containerName} current=${inspected.Image} target=${targetImage} repository=${repository}`,
+        );
         await atomicWriteJson(recoveryPath, this.buildRecoverySnapshot(inspected, plan));
 
         this.operation = { id: plan.id, state: "backing-up", message: "Mandatory backup in progress", startedAt: new Date().toISOString(), finishedAt: null, targetImage, rollbackAttempted: false };
         this.progress = null;
         await this.saveOperation();
+        log.info("self-update", `Étape 1/4 — backup Restic minimal démarré — id=${plan.id} data=${DATA_DIR} recovery=${recoveryPath}`);
         let backup;
         try {
             backup = await BackupManager.getInstance().runBackup({
@@ -188,12 +195,15 @@ export class SelfUpdateManager {
             return this.getOperation();
         }
         if (!backup.success) {
+            log.error("self-update", `Backup Restic échoué — id=${plan.id} error=${backup.error ?? "unknown error"}`);
             this.operation = { ...this.operation, state: "failed", message: `Backup failed: ${backup.error ?? "unknown error"}`, finishedAt: new Date().toISOString() };
             await this.saveOperation();
             return this.getOperation();
         }
 
+        log.info("self-update", `Backup Restic terminé — id=${plan.id} duration=${Date.now() - startedMs}ms`);
         this.operation = { ...this.operation, state: "verifying-backup", message: "Restic repository verification in progress" };
+        log.info("self-update", `Étape 2/4 — vérification Restic — id=${plan.id}`);
         this.progress = null;
         await this.saveOperation();
         let verification;
@@ -258,7 +268,9 @@ export class SelfUpdateManager {
         if (plan.compose) {
             args.splice(args.length - 1, 0, "-v", `${plan.compose.workingDir}:${plan.compose.workingDir}:ro`, "-e", `SELF_UPDATE_COMPOSE_DIR=${plan.compose.workingDir}`);
         }
+        log.info("self-update", `Étape 3/4 — lancement sidecar — id=${plan.id} image=${sidecarImage}`);
         await docker(args);
+        log.info("self-update", `Sidecar lancé — id=${plan.id} container=dockge-enhanced-updater-${plan.id}`);
         this.operation = { ...this.operation, state: "updating", message: "Updater sidecar started" };
         await this.saveOperation();
         return this.getOperation();

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -16,6 +16,7 @@ import { AppriseNotifier } from "../notification/apprise";
 import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
 import { ValidationError } from "../util-server";
+import { log } from "../log";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -980,7 +981,7 @@ export class BackupManager {
     async initRepoFor(dest: BackupDestination): Promise<void> {
         try {
             await this.resticFor(dest, [ "snapshots", "--quiet" ]);
-            console.log(`[BackupManager] "${dest.label}" déjà initialisé.`);
+            log.info("backup", `Repository déjà initialisé — label=${dest.label} type=${dest.type}`);
         } catch (e: any) {
             const msg = e?.message ?? "";
             if (msg.includes("wrong password") || msg.includes("no key found")) {
@@ -1134,7 +1135,7 @@ export class BackupManager {
 
             const destStart = Date.now();
             this.runningDests.set(dest.label, destStart);
-            console.log(`[BackupManager] ▶ "${dest.label}" démarré…`);
+            log.info("backup", `Destination démarrée — label=${dest.label} type=${dest.type} trigger=${trigger}`);
 
             try {
                 if (!dest.resticPassword) {

--- a/backend/watchers/image-watcher.ts
+++ b/backend/watchers/image-watcher.ts
@@ -20,6 +20,7 @@ import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
 import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
+import { log } from "../log";
 import {
   acceptedComposeFileNames,
   envsubstYAML,
@@ -876,7 +877,7 @@ export class ImageWatcher {
       return [];
     }
     this._checkRunning = true;
-    console.log("[ImageWatcher] Vérification des images...");
+    log.info("image-watcher", "Vérification des images démarrée");
     const results: ImageStatus[] = [];
 
     let entries: string[];

--- a/backend/watchers/self-update-checker.ts
+++ b/backend/watchers/self-update-checker.ts
@@ -16,6 +16,7 @@ import { getNotificationLang, notificationText } from "../notification/notificat
 import { Settings } from "../settings";
 import { SelfUpdateManager } from "../self-update/manager";
 import { atomicWriteJson } from "../self-update/state-file";
+import { log } from "../log";
 
 const SELF_REPO = "aerya/dockge-enhanced";
 const SELF_TAG = "latest";
@@ -374,6 +375,7 @@ export class SelfUpdateChecker {
   }
 
   start(): void {
+    log.info("self-update-checker", `Démarrage — premier check dans ${STARTUP_DELAY / 1000}s puis toutes les ~${CHECK_INTERVAL / 60000} min (jitter ±${CHECK_JITTER / 60000} min)`);
     this._loadDigestCache().then(() => {
       this._startupTimer = setTimeout(async () => {
         await this.check();
@@ -461,6 +463,11 @@ export class SelfUpdateChecker {
         await this._saveDigestCache(localDigest);
       }
 
+      log.info(
+        "self-update-checker",
+        `Check GHCR — container=${containerName} repo=${repo} platform=${platformToString(remoteInfo.platform)} local=${localDigest || "indisponible"} remote=${remoteDigest || "indisponible"} update=${updateAvailable}`,
+      );
+
       this._status = {
         updateAvailable,
         localDigest,
@@ -491,9 +498,13 @@ export class SelfUpdateChecker {
       }
 
       if (updateAvailable && SelfUpdateManager.getInstance().canAutoUpdate()) {
+        log.info("self-update-checker", `Auto-update demandée — target=ghcr.io/${repo}@${remoteDigest}`);
         await SelfUpdateManager.getInstance().requestSidecarUpdate(`ghcr.io/${repo}@${remoteDigest}`, true);
+      } else if (updateAvailable) {
+        log.info("self-update-checker", "Mise à jour détectée mais auto-update non exécutable actuellement");
       }
     } catch (e: any) {
+      log.error("self-update-checker", `Check échoué — ${e?.message ?? String(e)}`);
       this._status = {
         ...this._status,
         checkedAt: new Date().toISOString(),

--- a/backend/watchers/trivy-scanner.ts
+++ b/backend/watchers/trivy-scanner.ts
@@ -11,6 +11,7 @@ import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
 import { getNotificationLang, getNotificationLocale, notificationText, NotificationLang } from "../notification/notification-lang";
 import { Settings } from "../settings";
+import { log } from "../log";
 
 const execFileAsync = promisify(execFile);
 
@@ -233,7 +234,7 @@ export class TrivyScanner {
         const intervalHours = sanitizeIntervalHours(this.settings.intervalHours);
         this.settings.intervalHours = intervalHours;
         const cronExpr = `0 */${intervalHours} * * *`;
-        console.log(`[TrivyScanner] Démarrage — scan toutes les ${intervalHours}h`);
+        log.info("trivy", `Démarrage — scan toutes les ${intervalHours}h`);
         this.cronJob = cron.schedule(cronExpr, () => this.runScan());
     }
 


### PR DESCRIPTION
Cette PR améliore les journaux des principaux services Enhanced :

- self-update : ID d’opération, cible, digest courant, étapes, sidecar et durée ;
- checker GHCR : digest local/distant, plateforme, résultat du check et décision d’auto-update ;
- Restic : déclencheur, périmètre, nombre de chemins, destination et snapshot ;
- image watcher : début/fin des vérifications et auto-updates mieux qualifiés ;
- Trivy : messages cohérents via le logger central ;
- Discord/Apprise : résultat d’envoi contextualisé.

L’objectif est de rendre `docker logs dockge-enhanced` directement exploitable lors d’un incident, sans modifier le comportement fonctionnel des services.