### PR TITLE
Fiabiliser définitivement l’auto-update Dockge-Enhanced

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -136,6 +136,7 @@ jobs:
           version=$(jq -r .version package.json)
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:${version} \
+            -t ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:${GITHUB_SHA} \
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:amd64 \
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:arm64
           docker buildx imagetools create \

--- a/backend/self-update/manager.test.ts
+++ b/backend/self-update/manager.test.ts
@@ -49,3 +49,13 @@ test("expired plans and obsolete recovery snapshots are cleaned without removing
     assert.equal(await fs.stat(path.join(recoveryDir, `${ids[2]}.json`)).then(() => true).catch(() => false), true);
     await fs.rm(dataDir, { recursive: true, force: true });
 });
+
+
+test("automatic retry of the same digest is blocked after rollback", async () => {
+    const { SelfUpdateManager } = await import(`./manager.ts?retry=${Date.now()}`);
+    const manager = SelfUpdateManager.getInstance() as any;
+    const target = `ghcr.io/aerya/dockge-enhanced@sha256:${"c".repeat(64)}`;
+    manager.operation = { id: "f".repeat(32), state: "rolled-back", message: "rollback", startedAt: new Date().toISOString(), finishedAt: new Date().toISOString(), targetImage: target, rollbackAttempted: true };
+    assert.equal(manager.shouldBlockAutomaticRetry(target), true);
+    assert.equal(manager.shouldBlockAutomaticRetry(`ghcr.io/aerya/dockge-enhanced@sha256:${"d".repeat(64)}`), false);
+});

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -137,7 +137,7 @@ export class SelfUpdateManager {
 
     isAutomaticMode(): boolean { return this.settings.mode === "sidecar"; }
 
-    async requestSidecarUpdate(targetImage: string, automatic = false): Promise<SelfUpdateOperation> {
+    async requestSidecarUpdate(targetImage: string, automatic = false, targetRevision?: string): Promise<SelfUpdateOperation> {
         const resumingScheduled = automatic && this.operation.state === "scheduled";
         if (this.requestInFlight || (isSelfUpdateActive(this.operation.state) && !resumingScheduled)) throw new Error("A self-update is already running");
         this.requestInFlight = true;
@@ -167,7 +167,7 @@ export class SelfUpdateManager {
         const testImages = (process.env.DOCKGE_SELF_UPDATE_TEST_IMAGE ?? "").split(",").map(value => value.trim()).filter(Boolean);
         if (!isAllowedTargetImage(targetImage, repository, testImages)) throw new Error("The requested self-update image is not allowed");
         if (!inspected.Image || !/^sha256:[a-f0-9]{64}$/i.test(inspected.Image)) throw new Error("Current immutable Docker image identifier is unavailable");
-        const plan = await this.buildPlan(inspected, safePlanId(), targetImage, previousImage, repository);
+        const plan = await this.buildPlan(inspected, safePlanId(), targetImage, previousImage, repository, targetRevision);
         const recoveryPath = path.join(RECOVERY_DIR, plan.recoveryFile);
         const startedMs = Date.now();
         log.info(
@@ -202,30 +202,33 @@ export class SelfUpdateManager {
         }
 
         log.info("self-update", `Backup Restic terminé — id=${plan.id} duration=${Date.now() - startedMs}ms`);
-        this.operation = { ...this.operation, state: "verifying-backup", message: "Restic repository verification in progress" };
-        log.info("self-update", `Étape 2/4 — vérification Restic — id=${plan.id}`);
+        this.operation = { ...this.operation, state: "verifying-backup", message: "Self-update snapshot verification in progress" };
+        log.info("self-update", `Étape 2/4 — validation ciblée du snapshot Restic — id=${plan.id}`);
         this.progress = null;
         await this.saveOperation();
-        let verification;
         try {
-            verification = await BackupManager.getInstance().runCheck(undefined, (progress) => { this.progress = progress; });
+            const verification = await BackupManager.getInstance().verifyFreshBackup(backup);
+            const failed = verification.find((result) => !result.ok);
+            if (failed) {
+                this.operation = {
+                    ...this.operation,
+                    state: "failed",
+                    message: `Backup verification failed for ${failed.label}: ${failed.output}`,
+                    finishedAt: new Date().toISOString(),
+                    notificationPending: true,
+                    notificationSentAt: null,
+                };
+                await this.saveOperation();
+                return this.getOperation();
+            }
         } catch (error) {
             this.operation = {
                 ...this.operation,
                 state: "failed",
                 message: `Backup verification failed: ${error instanceof Error ? error.message : String(error)}`,
                 finishedAt: new Date().toISOString(),
-            };
-            await this.saveOperation();
-            return this.getOperation();
-        }
-        const failedVerification = verification.find((result) => !result.ok);
-        if (failedVerification) {
-            this.operation = {
-                ...this.operation,
-                state: "failed",
-                message: `Backup verification failed for ${failedVerification.label}: ${failedVerification.output}`,
-                finishedAt: new Date().toISOString(),
+                notificationPending: true,
+                notificationSentAt: null,
             };
             await this.saveOperation();
             return this.getOperation();
@@ -234,6 +237,8 @@ export class SelfUpdateManager {
 
         const stateMount = (inspected.Mounts ?? []).find((mount) => mount.Destination === DATA_DIR);
         if (!stateMount?.Source) throw new Error(`The ${DATA_DIR} volume is required for self-update state`);
+        plan.issuedAt = new Date().toISOString();
+        plan.expiresAt = new Date(Date.now() + 15 * 60_000).toISOString();
         const secret = await this.getOrCreateSecret();
         const payload = { plan, signature: signPlan(plan, secret) };
         await this.cleanupArtifacts(plan.id);
@@ -242,9 +247,29 @@ export class SelfUpdateManager {
         const stateSource = stateMount.Type === "volume" ? (stateMount.Name ?? stateMount.Source) : stateMount.Source;
         const dockerSocket = process.env.DOCKGE_DOCKER_SOCKET ?? "/var/run/docker.sock";
         const socketGroup = (await fs.stat(dockerSocket)).gid;
-        const sidecarImage = process.env.DOCKGE_SELF_UPDATE_SIDECAR_IMAGE?.trim() || `ghcr.io/${plan.allowedRepository}-updater:${packageJSON.version}`;
+        const sidecarImage = process.env.DOCKGE_SELF_UPDATE_SIDECAR_IMAGE?.trim()
+            || (plan.targetRevision
+                ? `ghcr.io/${plan.allowedRepository}-updater:${plan.targetRevision}`
+                : `ghcr.io/${plan.allowedRepository}-updater:${packageJSON.version}`);
+
+        log.info("self-update", `Téléchargement du sidecar — id=${plan.id} image=${sidecarImage}`);
+        try {
+            await docker([ "image", "pull", sidecarImage ], 10 * 60_000);
+        } catch (error) {
+            this.operation = {
+                ...this.operation,
+                state: "failed",
+                message: `Updater sidecar pull failed: ${error instanceof Error ? error.message : String(error)}`,
+                finishedAt: new Date().toISOString(),
+                notificationPending: true,
+                notificationSentAt: null,
+            };
+            await this.saveOperation();
+            return this.getOperation();
+        }
+
         const args = [
-            "run", "-d", "--rm",
+            "run", "--pull=always", "-d", "--rm",
             "--name", `dockge-enhanced-updater-${plan.id}`,
             "--label", "io.dockge-enhanced.self-update=true",
             // State files are intentionally 0600 in a 0700 directory. The updater
@@ -269,7 +294,20 @@ export class SelfUpdateManager {
             args.splice(args.length - 1, 0, "-v", `${plan.compose.workingDir}:${plan.compose.workingDir}:ro`, "-e", `SELF_UPDATE_COMPOSE_DIR=${plan.compose.workingDir}`);
         }
         log.info("self-update", `Étape 3/4 — lancement sidecar — id=${plan.id} image=${sidecarImage}`);
-        await docker(args);
+        try {
+            await docker(args, 10 * 60_000);
+        } catch (error) {
+            this.operation = {
+                ...this.operation,
+                state: "failed",
+                message: `Updater sidecar launch failed: ${error instanceof Error ? error.message : String(error)}`,
+                finishedAt: new Date().toISOString(),
+                notificationPending: true,
+                notificationSentAt: null,
+            };
+            await this.saveOperation();
+            return this.getOperation();
+        }
         log.info("self-update", `Sidecar lancé — id=${plan.id} container=dockge-enhanced-updater-${plan.id}`);
         this.operation = { ...this.operation, state: "updating", message: "Updater sidecar started" };
         await this.saveOperation();
@@ -406,7 +444,7 @@ export class SelfUpdateManager {
         }
     }
 
-    private async buildPlan(inspected: DockerInspect, id: string, targetImage: string, previousImage: string, repository: string): Promise<SelfUpdatePlan> {
+    private async buildPlan(inspected: DockerInspect, id: string, targetImage: string, previousImage: string, repository: string, targetRevision?: string): Promise<SelfUpdatePlan> {
         const labels = inspected.Config?.Labels ?? {};
         const workingDir = labels["com.docker.compose.project.working_dir"];
         const configFiles = labels["com.docker.compose.project.config_files"]?.split(",").map((file) => file.trim()).filter(Boolean) ?? [];
@@ -433,6 +471,7 @@ export class SelfUpdateManager {
             targetContainerId: inspected.Id ?? process.env.HOSTNAME ?? "",
             targetContainerName: (inspected.Name ?? "").replace(/^\//, ""),
             targetImage,
+            targetRevision: targetRevision && /^[a-f0-9]{40}$/i.test(targetRevision) ? targetRevision.toLowerCase() : undefined,
             previousImage,
             previousImageId: inspected.Image ?? "",
             allowedRepository: repository,
@@ -507,6 +546,13 @@ export class SelfUpdateManager {
             this.operation = { ...this.operation, notificationPending: false, notificationSentAt: new Date().toISOString() };
             await this.saveOperation();
         }
+    }
+
+    shouldBlockAutomaticRetry(targetImage: string): boolean {
+        return (
+            [ "failed", "rolled-back", "rollback-failed" ].includes(this.operation.state)
+            && this.operation.targetImage === targetImage
+        );
     }
 
     wasSuccessfulTargetNotified(digest: string): boolean {

--- a/backend/self-update/types.ts
+++ b/backend/self-update/types.ts
@@ -22,6 +22,7 @@ export interface SelfUpdatePlan {
     targetContainerId: string;
     targetContainerName: string;
     targetImage: string;
+    targetRevision?: string;
     previousImage: string;
     previousImageId: string;
     allowedRepository: string;

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -189,6 +189,7 @@ export interface SnapshotFile {
 
 export interface RestoreTestResult {
     ok: boolean;
+    skipped?: boolean;
     testedFile?: string;
     error?: string;
 }
@@ -1217,7 +1218,7 @@ export class BackupManager {
         }
 
         // La rétention et le test de lecture n'exigent pas que les applications restent arrêtées.
-        if (!opts.skipForget) {
+        if (!opts.skipForget && opts.tag !== "self-update") {
             for (let i = 0; i < activeDests.length; i++) {
                 const dest = activeDests[i];
                 const destResult = result.destinations![i];
@@ -1926,7 +1927,7 @@ export class BackupManager {
             if (!composePath) {
                 // Snapshot vide ou sans compose — test trivial passé
                 console.log(`[BackupManager] Restore test "${dest.label}" — aucun compose trouvé dans le snapshot, test ignoré`);
-                return { ok: true };
+                return { ok: false, skipped: true, error: "Aucun compose trouvé dans le snapshot" };
             }
 
             // 3. Lire le fichier (déchiffrement + vérification de l'intégrité des données)
@@ -1940,6 +1941,39 @@ export class BackupManager {
             const raw = e instanceof Error ? e.message : String(e);
             return { ok: false, error: raw.slice(0, 300) };
         }
+    }
+
+    async verifyFreshBackup(result: BackupResult): Promise<Array<{ label: string; ok: boolean; output: string }>> {
+        const destinations = result.destinations ?? [];
+        const enabled = this.settings.destinations.filter(dest => dest.enabled);
+        const checks: Array<{ label: string; ok: boolean; output: string }> = [];
+
+        for (let i = 0; i < destinations.length; i++) {
+            const destResult = destinations[i];
+            const dest = enabled[i];
+            if (!dest || !destResult?.success || !destResult.snapshotId) {
+                checks.push({ label: destResult?.label ?? dest?.label ?? `destination-${i + 1}`, ok: false, output: "Snapshot fraîchement créé introuvable" });
+                continue;
+            }
+            try {
+                const safeId = assertSafeResticId(destResult.snapshotId);
+                const ls = await this.resticFor(dest, [ "ls", safeId, "--json" ]);
+                const file = ls.split("\n").filter(Boolean).map(line => {
+                    try { return JSON.parse(line) as Record<string, unknown>; }
+                    catch { return null; }
+                }).find(entry => entry?.struct_type === "node" && entry?.type === "file" && typeof entry?.path === "string");
+
+                if (!file?.path || typeof file.path !== "string") {
+                    checks.push({ label: dest.label, ok: false, output: "Aucun fichier lisible dans le snapshot fraîchement créé" });
+                    continue;
+                }
+                const content = await this.resticDump(dest, safeId, file.path);
+                checks.push({ label: dest.label, ok: content.length > 0, output: content.length > 0 ? `Lecture OK: ${file.path}` : `Fichier vide: ${file.path}` });
+            } catch (error) {
+                checks.push({ label: dest.label, ok: false, output: error instanceof Error ? error.message : String(error) });
+            }
+        }
+        return checks;
     }
 
     /** Exécute `restic dump` sans `--json` pour récupérer le contenu brut d'un fichier */
@@ -2141,7 +2175,7 @@ export class BackupManager {
                       .map(d => {
                           const rt = d.restoreTest;
                           const rtLabel = t("Test de restauration", "Restore test", "Prueba de restauración", "恢复测试");
-                          const rtIcon = rt == null ? "" : (rt.ok ? ` · ${rtLabel} ✅` : ` · ${rtLabel} ❌`);
+                          const rtIcon = rt == null ? "" : (rt.skipped ? ` · ${rtLabel} ⏭️` : (rt.ok ? ` · ${rtLabel} ✅` : ` · ${rtLabel} ❌`));
                           return `${d.success ? "✅" : "❌"} ${d.label}${rtIcon}`;
                       })
                       .join("\n") || "—",

--- a/backend/watchers/self-update-checker.ts
+++ b/backend/watchers/self-update-checker.ts
@@ -497,9 +497,20 @@ export class SelfUpdateChecker {
         await this._notifyAvailable(containerName, repo, automaticMode);
       }
 
-      if (updateAvailable && SelfUpdateManager.getInstance().canAutoUpdate()) {
-        log.info("self-update-checker", `Auto-update demandée — target=ghcr.io/${repo}@${remoteDigest}`);
-        await SelfUpdateManager.getInstance().requestSidecarUpdate(`ghcr.io/${repo}@${remoteDigest}`, true);
+      const targetImage = `ghcr.io/${repo}@${remoteDigest}`;
+      if (
+        updateAvailable
+        && SelfUpdateManager.getInstance().canAutoUpdate()
+        && !SelfUpdateManager.getInstance().shouldBlockAutomaticRetry(targetImage)
+      ) {
+        log.info("self-update-checker", `Auto-update demandée — target=${targetImage}`);
+        await SelfUpdateManager.getInstance().requestSidecarUpdate(
+          targetImage,
+          true,
+          remoteInfo.build.revision || undefined,
+        );
+      } else if (updateAvailable && SelfUpdateManager.getInstance().shouldBlockAutomaticRetry(targetImage)) {
+        log.warn("self-update-checker", `Retry automatique bloqué pour ce digest après échec/rollback — target=${targetImage}`);
       } else if (updateAvailable) {
         log.info("self-update-checker", "Mise à jour détectée mais auto-update non exécutable actuellement");
       }

--- a/frontend/src/components/backup/shared.ts
+++ b/frontend/src/components/backup/shared.ts
@@ -132,6 +132,7 @@ export interface SnapshotFile {
 
 export interface RestoreTestResult {
     ok: boolean;
+    skipped?: boolean;
     testedFile?: string;
     error?: string;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockge-enhanced",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "type": "module",
     "engines": {
         "node": ">= 22.14.0"


### PR DESCRIPTION
Cette PR durcit l’ensemble du chemin d’auto-update après les échecs reproduits.

- Dockge-Enhanced télécharge explicitement son sidecar avant de le lancer ;
- `docker run --pull=always` empêche la réutilisation d’un sidecar périmé ;
- l’updater est publié sous un tag immuable correspondant au SHA exact du build cible ;
- le SHA OCI distant est transmis jusqu’au plan signé ;
- un même digest n’est plus retenté automatiquement après échec ou rollback ;
- le self-update ne lance plus de `restic check` global ;
- le snapshot fraîchement créé est vérifié directement par lecture Restic ;
- aucun `forget --prune` n’est exécuté dans le chemin critique du self-update ;
- l’expiration du plan est recalculée après la validation du backup ;
- les erreurs de pull/lancement du sidecar deviennent des états terminaux persistés et notifiés ;
- un restore test ignoré n’est plus présenté comme réussi.

Le comportement des backups généraux reste inchangé.