### PR TITLE
Utiliser systématiquement le dernier updater

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -135,6 +135,7 @@ jobs:
           done
           version=$(jq -r .version package.json)
           docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:latest \
             -t ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:${version} \
             -t ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:${GITHUB_SHA} \
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-updater:amd64 \

--- a/backend/self-update/manager.test.ts
+++ b/backend/self-update/manager.test.ts
@@ -59,3 +59,11 @@ test("automatic retry of the same digest is blocked after rollback", async () =>
     assert.equal(manager.shouldBlockAutomaticRetry(target), true);
     assert.equal(manager.shouldBlockAutomaticRetry(`ghcr.io/aerya/dockge-enhanced@sha256:${"d".repeat(64)}`), false);
 });
+
+
+test("updater latest is the default sidecar channel", async () => {
+    const source = await fs.readFile(new URL("./manager.ts", import.meta.url), "utf8");
+    assert.match(source, /-updater:latest/);
+    assert.match(source, /image\", \"pull\", sidecarImage/);
+    assert.match(source, /run\", \"--pull=always/);
+});

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -248,9 +248,7 @@ export class SelfUpdateManager {
         const dockerSocket = process.env.DOCKGE_DOCKER_SOCKET ?? "/var/run/docker.sock";
         const socketGroup = (await fs.stat(dockerSocket)).gid;
         const sidecarImage = process.env.DOCKGE_SELF_UPDATE_SIDECAR_IMAGE?.trim()
-            || (plan.targetRevision
-                ? `ghcr.io/${plan.allowedRepository}-updater:${plan.targetRevision}`
-                : `ghcr.io/${plan.allowedRepository}-updater:${packageJSON.version}`);
+            || `ghcr.io/${plan.allowedRepository}-updater:latest`;
 
         log.info("self-update", `Téléchargement du sidecar — id=${plan.id} image=${sidecarImage}`);
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockge-enhanced",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "type": "module",
     "engines": {
         "node": ">= 22.14.0"


### PR DESCRIPTION
Cette PR simplifie et fiabilise le bootstrap de l’auto-update Dockge-Enhanced.

- le dernier build de `dockge-enhanced-updater` est désormais publié sous le tag conventionnel `:latest` ;
- Dockge-Enhanced utilise `ghcr.io/<repo>/dockge-enhanced-updater:latest` par défaut ;
- avant chaque auto-update, Dockge-Enhanced exécute explicitement un pull de cet updater ;
- le lancement conserve également `--pull=always` comme seconde protection contre le cache ;
- les tags versionnés et SHA restent publiés en complément ;
- l’image principale Dockge-Enhanced conserve son propre tag `:latest`.

Closes #303