### PR TITLE
Éviter les faux positifs du self-update

### DIFF
--- a/backend/self-update/manager.test.ts
+++ b/backend/self-update/manager.test.ts
@@ -67,3 +67,28 @@ test("updater latest is the default sidecar channel", async () => {
     assert.match(source, /image\", \"pull\", sidecarImage/);
     assert.match(source, /run\", \"--pull=always/);
 });
+
+
+test("obsolete rollback state is cleared once the installed build is current", async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "dockge-self-update-clear-"));
+    process.env.DOCKGE_DATA_DIR = dataDir;
+    const { SelfUpdateManager } = await import(`./manager.ts?clear=${Date.now()}`);
+    const manager = SelfUpdateManager.getInstance() as any;
+    manager.operation = {
+        id: "a".repeat(32),
+        state: "rolled-back",
+        message: "old rollback",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        targetImage: `ghcr.io/aerya/dockge-enhanced@sha256:${"b".repeat(64)}`,
+        rollbackAttempted: true,
+    };
+
+    await manager.clearObsoleteFailureState();
+
+    assert.equal(manager.operation.state, "idle");
+    assert.equal(manager.operation.targetImage, "");
+    const persisted = JSON.parse(await fs.readFile(path.join(dataDir, "self-update", "status.json"), "utf8"));
+    assert.equal(persisted.state, "idle");
+    await fs.rm(dataDir, { recursive: true, force: true });
+});

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -546,6 +546,17 @@ export class SelfUpdateManager {
         }
     }
 
+    async clearObsoleteFailureState(): Promise<void> {
+        if (![ "failed", "rolled-back", "rollback-failed" ].includes(this.operation.state)) return;
+        log.info(
+            "self-update",
+            `Ancien état terminal effacé — state=${this.operation.state} target=${this.operation.targetImage || "indisponible"}`,
+        );
+        this.operation = idle();
+        this.progress = null;
+        await this.saveOperation();
+    }
+
     shouldBlockAutomaticRetry(targetImage: string): boolean {
         return (
             [ "failed", "rolled-back", "rollback-failed" ].includes(this.operation.state)

--- a/backend/watchers/self-update-checker.test.ts
+++ b/backend/watchers/self-update-checker.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import test from "node:test";
+
+
+test("same OCI build revision suppresses digest-only self-update false positives", async () => {
+    const source = await fs.readFile(new URL("./self-update-checker.ts", import.meta.url), "utf8");
+    assert.match(source, /const sameBuildRevision/);
+    assert.match(source, /localInfo\.build\.revision === remoteInfo\.build\.revision/);
+    assert.match(source, /!sameBuildRevision/);
+    assert.match(source, /clearObsoleteFailureState/);
+});

--- a/backend/watchers/self-update-checker.ts
+++ b/backend/watchers/self-update-checker.ts
@@ -442,11 +442,19 @@ export class SelfUpdateChecker {
       const remoteDigest = remoteInfo.platformDigest;
 
       // Docker/Podman peuvent exposer dans RepoDigests soit le digest du manifest plateforme,
-      // soit celui de l'index multi-arch. On accepte les deux pour éviter les faux positifs ARM64.
+      // soit celui de l'index multi-arch. La révision OCI reste l'identifiant fonctionnel
+      // du build : si elle est identique localement et à distance, il n'y a aucune mise à jour,
+      // même si les digests exposés par Docker/GHCR diffèrent.
+      const sameBuildRevision = !!(
+        localInfo.build.revision &&
+        remoteInfo.build.revision &&
+        localInfo.build.revision === remoteInfo.build.revision
+      );
       const updateAvailable = !!(
         localInfo.comparable &&
         localDigest &&
         remoteDigest &&
+        !sameBuildRevision &&
         !digestEquals(localDigest, remoteInfo.platformDigest) &&
         !digestEquals(localDigest, remoteInfo.indexDigest)
       );
@@ -481,6 +489,10 @@ export class SelfUpdateChecker {
           ? null
           : "Digest local registry indisponible",
       };
+
+      if (sameBuildRevision) {
+        await SelfUpdateManager.getInstance().clearObsoleteFailureState();
+      }
 
       // Notif "mise à jour appliquée" — le digest local a changé depuis le dernier check
       if (wasUpdated && !SelfUpdateManager.getInstance().wasSuccessfulTargetNotified(localDigest)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockge-enhanced",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "type": "module",
     "engines": {
         "node": ">= 22.14.0"


### PR DESCRIPTION
Cette PR corrige deux incohérences observées après une mise à jour manuelle réussie :

- si la révision OCI du build installé est identique à celle du build distant, Dockge-Enhanced ne considère plus qu’une mise à jour est disponible même si Docker/GHCR exposent des digests différents pour le manifest plateforme et l’index multi-arch ;
- lorsqu’un build installé correspond déjà au build distant, un ancien état `failed`, `rolled-back` ou `rollback-failed` devenu obsolète est automatiquement effacé afin de ne plus conserver un bandeau d’échec après une mise à jour réussie.

Les opérations actives et les états de succès ne sont pas modifiés.

La version passe en 1.5.4.