### PR TITLE
Préciser le correctif critique de l’auto-mise à jour

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -8,22 +8,30 @@
 
 ⚠️ **Importante — corrección crítica de la actualización automática de Dockge-Enhanced**
 
-Un error en el mecanismo de actualización automática de Dockge-Enhanced afectó a algunas versiones publicadas entre **la noche del 31 de agosto de 2026 y la noche del 1 de septiembre de 2026**.
+Varios builds publicados entre **el 31 de agosto de 2026 y el 2 de septiembre de 2026** contenían defectos en el mecanismo de actualización automática de Dockge-Enhanced.
 
-En determinadas condiciones, el sidecar podía detener y eliminar el contenedor Dockge-Enhanced y después no conseguir crear la nueva versión **ni restaurar automáticamente la anterior**.
+En determinadas condiciones, el sidecar podía detener el contenedor Dockge-Enhanced, no conseguir crear la nueva versión y, en algunos builds, tampoco restaurar automáticamente la versión anterior.
 
-**Si tu instalación procede de este periodo, actualízala manualmente a la última versión antes de volver a activar las actualizaciones automáticas:**
+El mecanismo ha sido corregido y reforzado. A partir del build **`0fc2564` / versión 1.5.4**, la actualización automática:
+
+- descarga siempre el último `dockge-enhanced-updater:latest` antes de cada actualización;
+- descarga explícitamente la imagen objetivo de Dockge-Enhanced;
+- realiza una copia Restic obligatoria antes del reemplazo;
+- verifica el nuevo contenedor antes de validar la actualización;
+- conserva el rollback y un snapshot de recuperación.
+
+**Si tu instalación utiliza un build anterior a `0fc2564` / versión 1.5.4, realiza una última actualización manual antes de activar o volver a activar las actualizaciones automáticas:**
 
 ```bash
 docker pull ghcr.io/aerya/dockge-enhanced:latest
 docker compose up -d
 ```
 
+Una vez completada esta actualización, puedes activar **Automática mediante sidecar protegido**: Dockge-Enhanced gestionará automáticamente las siguientes actualizaciones.
+
 Las stacks gestionadas por Dockge-Enhanced y sus datos persistentes no se ven afectados por este problema.
 
-El mecanismo ha sido corregido y reforzado con una vía de recuperación adicional e independiente, capaz de recrear la instancia anterior incluso si falla el reemplazo mediante Docker Compose.
-
-**Mis disculpas a todos los usuarios afectados.** Una función diseñada precisamente para hacer las actualizaciones más seguras no debería poder dejar Dockge-Enhanced fuera de servicio. Gracias a todos los que utilizan, prueban y reportan problemas: vuestros comentarios permiten identificarlos y corregirlos rápidamente.
+**Mis disculpas a todos los usuarios afectados.** Una función diseñada precisamente para hacer las actualizaciones más seguras no debería poder dejar Dockge-Enhanced fuera de servicio. Gracias a todos los que utilizan, prueban y reportan problemas: vuestros comentarios permitieron identificar y corregir rápidamente estos defectos.
 
 
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,22 +6,30 @@
 
 ⚠️ **Important — correctif critique de l’auto-mise à jour de Dockge-Enhanced**
 
-Une erreur dans le mécanisme d’auto-mise à jour de Dockge-Enhanced a affecté certaines versions publiées entre **le 31 août 2026 au soir et le 1er septembre 2026 au soir**.
+Plusieurs builds publiés entre **le 31 août 2026 et le 2 septembre 2026** ont comporté des défauts dans le mécanisme d’auto-mise à jour de Dockge-Enhanced.
 
-Dans certaines conditions, le sidecar pouvait arrêter et supprimer le conteneur Dockge-Enhanced, puis échouer à recréer la nouvelle version **ainsi qu’à restaurer automatiquement l’ancienne**.
+Dans certaines conditions, le sidecar pouvait arrêter le conteneur Dockge-Enhanced, échouer à recréer la nouvelle version et, sur certains builds, échouer également à restaurer automatiquement l’ancienne.
 
-**Si votre installation provient de cette période, merci de la mettre à jour manuellement vers la dernière version avant de réactiver l’auto-mise à jour :**
+Le mécanisme a depuis été corrigé et renforcé. À partir du build **`0fc2564` / version 1.5.4**, l’auto-mise à jour :
+
+- télécharge systématiquement le dernier `dockge-enhanced-updater:latest` avant chaque mise à jour ;
+- télécharge explicitement l’image Dockge-Enhanced cible ;
+- effectue un backup Restic obligatoire avant remplacement ;
+- vérifie le nouveau conteneur avant de valider la mise à jour ;
+- conserve un mécanisme de rollback et un snapshot de récupération.
+
+**Si votre installation utilise un build antérieur à `0fc2564` / version 1.5.4, effectuez une dernière mise à jour manuelle avant d’activer ou réactiver les mises à jour automatiques :**
 
 ```bash
 docker pull ghcr.io/aerya/dockge-enhanced:latest
 docker compose up -d
 ```
 
+Une fois cette mise à jour effectuée, vous pouvez activer **Automatique via sidecar protégé** : les mises à jour suivantes sont prises en charge automatiquement par Dockge-Enhanced.
+
 Les stacks gérées par Dockge-Enhanced et leurs données persistantes ne sont pas concernées par ce problème.
 
-Le mécanisme a été corrigé et renforcé avec un chemin de restauration supplémentaire indépendant, permettant de recréer l’instance précédente même si le remplacement via Docker Compose échoue.
-
-**Toutes mes excuses aux utilisateurs concernés.** Une fonction conçue précisément pour rendre les mises à jour plus sûres ne doit évidemment pas pouvoir laisser Dockge-Enhanced hors ligne. Merci à ceux qui utilisent, testent et signalent les problèmes : vos retours permettent de les identifier et de les corriger rapidement.
+**Toutes mes excuses aux utilisateurs concernés.** Une fonction conçue précisément pour rendre les mises à jour plus sûres ne doit évidemment pas pouvoir laisser Dockge-Enhanced hors ligne. Merci à ceux qui utilisent, testent et signalent les problèmes : vos retours ont permis d’identifier puis de corriger rapidement ces défauts.
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,30 @@
 
 ⚠️ **Important — critical Dockge-Enhanced self-update fix**
 
-An issue in the Dockge-Enhanced self-update mechanism affected some versions published between **the evening of August 31, 2026 and the evening of September 1, 2026**.
+Several builds published between **August 31, 2026 and September 2, 2026** contained defects in the Dockge-Enhanced self-update mechanism.
 
-Under certain conditions, the sidecar could stop and remove the Dockge-Enhanced container, then fail both to create the new version **and to automatically restore the previous one**.
+Under certain conditions, the sidecar could stop the Dockge-Enhanced container, fail to create the new version and, on some builds, also fail to automatically restore the previous one.
 
-**If your installation comes from this period, please update it manually to the latest version before enabling self-updates again:**
+The mechanism has since been fixed and hardened. Starting with build **`0fc2564` / version 1.5.4**, self-update:
+
+- always pulls the latest `dockge-enhanced-updater:latest` before each update;
+- explicitly pulls the target Dockge-Enhanced image;
+- performs a mandatory Restic backup before replacement;
+- verifies the new container before confirming the update;
+- keeps rollback support and a recovery snapshot.
+
+**If your installation is running a build older than `0fc2564` / version 1.5.4, perform one final manual update before enabling or re-enabling automatic updates:**
 
 ```bash
 docker pull ghcr.io/aerya/dockge-enhanced:latest
 docker compose up -d
 ```
 
+Once this update is complete, you can enable **Automatic via protected sidecar**: subsequent updates are handled automatically by Dockge-Enhanced.
+
 Stacks managed by Dockge-Enhanced and their persistent data are not affected by this issue.
 
-The update mechanism has now been fixed and strengthened with an additional independent recovery path, allowing the previous instance to be recreated even if the Docker Compose replacement fails.
-
-**My apologies to everyone affected.** A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helps identify and fix these problems quickly.
+**My apologies to everyone affected.** A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helped identify and fix these defects quickly.
 
 
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,22 +6,30 @@
 
 ⚠️ **重要 — Dockge-Enhanced 自动更新关键修复**
 
-Dockge-Enhanced 的自动更新机制中存在一个错误，影响了 **2026 年 8 月 31 日晚至 2026 年 9 月 1 日晚** 期间发布的部分版本。
+**2026 年 8 月 31 日至 2026 年 9 月 2 日** 期间发布的多个 build 在 Dockge-Enhanced 自动更新机制中存在缺陷。
 
-在某些情况下，sidecar 可能会停止并删除 Dockge-Enhanced 容器，但随后既无法创建新版本，**也无法自动恢复之前的版本**。
+在某些情况下，sidecar 可能会停止 Dockge-Enhanced 容器，但随后无法创建新版本；在部分 build 中，也可能无法自动恢复之前的版本。
 
-**如果您的安装来自这一时间段，请先手动更新到最新版本，然后再重新启用自动更新：**
+该机制现已修复并进一步加强。从 build **`0fc2564` / 版本 1.5.4** 开始，自动更新会：
 
-```bash id="bluwho"
+- 在每次更新前始终拉取最新的 `dockge-enhanced-updater:latest`；
+- 显式拉取目标 Dockge-Enhanced 镜像；
+- 在替换前执行强制 Restic 备份；
+- 在确认更新成功前验证新容器；
+- 保留 rollback 机制和恢复 snapshot。
+
+**如果您的安装版本早于 `0fc2564` / 1.5.4，请在启用或重新启用自动更新前，最后手动更新一次：**
+
+```bash
 docker pull ghcr.io/aerya/dockge-enhanced:latest
 docker compose up -d
 ```
 
+完成此次更新后，即可启用 **通过受保护 sidecar 自动更新**；之后的更新将由 Dockge-Enhanced 自动处理。
+
 Dockge-Enhanced 管理的 stacks 及其持久化数据不受此问题影响。
 
-该机制现已修复并进一步加强，增加了一条独立的恢复路径：即使通过 Docker Compose 替换失败，也可以重新创建之前的实例。
-
-**对于受到影响的用户，我深表歉意。** 一个本应让更新更加安全的功能，不应该让 Dockge-Enhanced 自身处于离线状态。感谢所有使用、测试并反馈问题的用户，你们的反馈帮助我们更快发现并修复这类问题。
+**对于受到影响的用户，我深表歉意。** 一个本应让更新更加安全的功能，不应该让 Dockge-Enhanced 自身处于离线状态。感谢所有使用、测试并反馈问题的用户，你们的反馈帮助我们快速定位并修复了这些缺陷。
 
 [Dockge](https://github.com/louislam/dockge) 的增强功能分支 —— 在保留简洁 Compose 管理体验的基础上，加入镜像更新监控、安全扫描、自动备份、崩溃循环检测、多实例管理以及 Docker 资源管理。
 


### PR DESCRIPTION
Met à jour les quatre README principaux afin de préciser la période concernée par les builds défectueux et d’indiquer clairement le point de reprise sûr.

- les builds publiés entre le 31 août et le 2 septembre 2026 sont signalés comme potentiellement concernés ;
- les installations antérieures au build `0fc2564` / version 1.5.4 doivent effectuer une dernière mise à jour manuelle ;
- à partir de ce build, l’auto-mise à jour utilise `dockge-enhanced-updater:latest`, avec pull explicite, backup Restic, healthcheck et rollback ;
- les instructions sont harmonisées en français, anglais, espagnol et chinois simplifié.

Modification documentaire uniquement : aucun build Docker n’est nécessaire.