### PR TITLE
docs: retire les icônes des catalogues de fonctionnalités

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -122,14 +122,14 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 
 ## Catálogo de funcionalidades
 
-### 🌐 Multiservidor y federación
+### Multiservidor y federación
 - Federación en malla completa
 - Administración desde cualquier instancia vinculada
 - Selección y agrupación de servidores
 - Estado remoto de stacks y actualizaciones
 - Tokens de federación dedicados y recuperación de enlaces
 
-### 📦 Gestión de stacks
+### Gestión de stacks
 - Crear, editar, iniciar, detener y recrear stacks Compose
 - Stacks fijadas y ordenación avanzada
 - Notas y herramientas Git
@@ -139,7 +139,7 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - Requisitos de host y protecciones VPN
 - Barra lateral redimensionable con indicadores de recursos
 
-### 🔄 Migración y replicación
+### Migración y replicación
 - Copia o movimiento entre instancias
 - Transferencia de Compose, bind mounts y volúmenes
 - Trabajos reanudables y SHA-256
@@ -148,54 +148,54 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - Detección de conflictos `container_name`
 - Replicación en frío programada
 
-### 💾 Copias y recuperación
+### Copias y recuperación
 - Restic multidestino
 - Bind mounts y volúmenes
 - Restauración selectiva
 - Verificación de repositorios y snapshots
 - Historial e integración con recuperación protegida
 
-### ⬆️ Actualizaciones
+### Actualizaciones
 - Monitorización y detección remota
 - Actualización manual y automática
 - Rollback, programación y pausas
 - Autoactualización protegida de Dockge-Enhanced
 - Copia Restic, integridad, readiness y recuperación automática
 
-### 🛡️ Seguridad
+### Seguridad
 - Trivy y excepciones CVE
 - 2FA, Turnstile y trusted proxy
 - Sidecar restringido y plan firmado
 - Protecciones destructivas
 - Transferencia cifrada de credenciales
 
-### 📊 Monitorización
+### Monitorización
 - Estadísticas del sistema, stacks y contenedores
 - Barra de estado y tarjetas de salud
 - Crash loops y auto-heal
 - Logs live/pantalla completa
 - Kula y Dozzle
 
-### 🐳 Recursos Docker
+### Recursos Docker
 - Imágenes, volúmenes, redes y contenedores no gestionados
 - Acciones masivas y auto-prune
 - Protecciones de borrado
 
-### 🤖 Automatización y auditoría
+### Automatización y auditoría
 - API REST
 - Webhooks
 - Home Assistant
 - Operaciones programadas
 - Historial centralizado
 
-### 🔌 Integraciones
+### Integraciones
 - PlugNPiN
 - Nginx Proxy Manager
 - Pi-hole
 - AdGuard Home
 - Dozzle y Kula
 
-### 🔔 Notificaciones y acceso
+### Notificaciones y acceso
 - Discord y Apprise
 - EN / FR / ES / zh-CN
 - 2FA, trusted proxy, Turnstile

--- a/README.fr.md
+++ b/README.fr.md
@@ -34,7 +34,6 @@
 ---
 
 Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnalités, qui transforme son expérience simple de gestion Docker Compose en une plateforme Docker plus complète — avec fédération multi-serveurs, migration et réplication de stacks, sauvegardes Restic, mises à jour des images et de Dockge-Enhanced avec rollback, scan de sécurité, supervision, automatisation, notifications et gestion des ressources Docker, le tout depuis l'interface web.
-Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnalités, qui transforme son expérience simple de gestion Docker Compose en une plateforme Docker plus complète — avec fédération multi-serveurs, migration et réplication de stacks, sauvegardes Restic, mises à jour des images et de Dockge-Enhanced avec rollback, scan de sécurité, supervision, automatisation, notifications et gestion des ressources Docker, le tout depuis l'interface web.
 
 <p align="center">
   🇫🇷 Français ·
@@ -121,7 +120,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 
 ## Catalogue des fonctionnalités
 
-### 🌐 Multi-serveurs & fédération
+### Multi-serveurs & fédération
 - Fédération en maillage complet entre instances Dockge-Enhanced
 - Administration depuis n'importe quelle instance liée
 - Sélection et regroupement des serveurs
@@ -130,7 +129,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Récupération d'une liaison de fédération cassée
 - Gestion multi-instance unifiée
 
-### 📦 Gestion des stacks
+### Gestion des stacks
 - Création, édition, démarrage, arrêt et recréation des stacks Compose
 - Stacks épinglées
 - Tri par date de création ou dernière mise à jour
@@ -144,7 +143,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Colonne des stacks repliable et redimensionnable
 - Indicateurs compacts d'état, CPU et RAM
 
-### 🔄 Migration & réplication
+### Migration & réplication
 - Copie ou déplacement de stacks entre instances
 - Transfert de la configuration Compose
 - Transfert des bind mounts et volumes nommés
@@ -157,7 +156,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Réplication froide planifiée
 - Snapshots et mécanismes de récupération
 
-### 💾 Sauvegarde & restauration
+### Sauvegarde & restauration
 - Sauvegardes Restic
 - Plusieurs destinations de backup
 - Sauvegardes cohérentes par stack
@@ -168,7 +167,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Historique des sauvegardes
 - Intégration aux workflows de récupération et de mise à jour
 
-### ⬆️ Mises à jour
+### Mises à jour
 - Surveillance des mises à jour d'images Docker
 - Détection des mises à jour distantes
 - Mises à jour manuelles et automatiques
@@ -179,7 +178,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Backup Restic et contrôle d'intégrité obligatoires
 - Vérification de disponibilité et récupération automatique
 
-### 🛡️ Sécurité
+### Sécurité
 - Scan Trivy
 - Exceptions CVE
 - 2FA
@@ -189,7 +188,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Protections autour des opérations destructives
 - Transfert chiffré des identifiants de registries privés
 
-### 📊 Supervision
+### Supervision
 - Statistiques système, stacks et conteneurs
 - Barre d'état système configurable
 - Cartes de santé
@@ -199,26 +198,26 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Pause de l'autoscroll et gestion des longues lignes
 - Intégrations Kula et Dozzle
 
-### 🐳 Ressources Docker
+### Ressources Docker
 - Images, volumes, réseaux et conteneurs non gérés
 - Actions groupées
 - Auto-prune
 - Protections contre les suppressions à risque
 
-### 🤖 Automatisation & audit
+### Automatisation & audit
 - API REST limitée par permissions et stacks
 - Webhooks par stack
 - Exemples Home Assistant
 - Opérations planifiées
 - Historique centralisé avec origine, statut et durée
 
-### 🔌 Intégrations
+### Intégrations
 - PlugNPiN
 - Assistants de labels Nginx Proxy Manager, Pi-hole et AdGuard Home
 - Dozzle
 - Kula
 
-### 🔔 Notifications & accès
+### Notifications & accès
 - Discord et Apprise
 - Notifications localisées en EN / FR / ES / zh-CN
 - 2FA, trusted proxy et Cloudflare Turnstile

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 ---
 
 **My apologies to everyone affected.** A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helped identify and fix these defects quickly.
-**My apologies to everyone affected.** A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helped identify and fix these defects quickly.
 
 
 
@@ -124,7 +123,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 
 ## Feature catalogue
 
-### 🌐 Multi-server & federation
+### Multi-server & federation
 - Full-mesh federation between Dockge-Enhanced instances
 - Administration from any linked instance
 - Server selection and grouping
@@ -133,7 +132,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Recovery of broken federation links
 - Unified multi-instance management
 
-### 📦 Stack management
+### Stack management
 - Create, edit, start, stop and recreate Compose stacks
 - Pinned stacks
 - Sort by creation date or last update
@@ -147,7 +146,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Collapsible and resizable stack sidebar
 - Compact status, CPU and RAM indicators
 
-### 🔄 Migration & replication
+### Migration & replication
 - Copy or move stacks between instances
 - Compose configuration transfer
 - Bind mount and named-volume transfer
@@ -160,7 +159,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Scheduled cold replication
 - Recovery snapshots and workflows
 
-### 💾 Backup & recovery
+### Backup & recovery
 - Restic backups
 - Multiple backup destinations
 - Stack-consistent backups
@@ -171,7 +170,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Backup history
 - Integration with protected update and recovery workflows
 
-### ⬆️ Updates
+### Updates
 - Docker image update monitoring
 - Remote update detection
 - Manual and automatic image updates
@@ -182,7 +181,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Mandatory Restic backup and integrity verification
 - Readiness validation and automatic recovery
 
-### 🛡️ Security
+### Security
 - Trivy vulnerability scanning
 - CVE exceptions
 - 2FA
@@ -192,7 +191,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Destructive-operation safeguards
 - Encrypted private-registry credential transfer
 
-### 📊 Monitoring
+### Monitoring
 - System, stack and container statistics
 - Configurable system status bar
 - Dashboard health cards
@@ -202,26 +201,26 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Autoscroll pause and long-line handling
 - Kula and Dozzle integrations
 
-### 🐳 Docker resources
+### Docker resources
 - Images, volumes, networks and unmanaged containers
 - Bulk actions
 - Auto-prune
 - Risky-deletion safeguards
 
-### 🤖 Automation & audit
+### Automation & audit
 - Permission- and stack-scoped REST API
 - Per-stack webhooks
 - Home Assistant examples
 - Scheduled operations
 - Centralized history with origin, status and duration
 
-### 🔌 Integrations
+### Integrations
 - PlugNPiN
 - Nginx Proxy Manager, Pi-hole and AdGuard Home label assistants
 - Dozzle
 - Kula
 
-### 🔔 Notifications & access
+### Notifications & access
 - Discord and Apprise
 - Notifications localized in EN / FR / ES / zh-CN
 - 2FA, trusted proxy and Cloudflare Turnstile

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,14 +130,14 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 
 ## 功能目录
 
-### 🌐 多服务器与联邦
+### 多服务器与联邦
 - 全网状联邦
 - 从任意已连接实例管理
 - 服务器选择与分组
 - 远程 Stack 与更新状态
 - 专用联邦 Token 与连接恢复
 
-### 📦 Stack 管理
+### Stack 管理
 - 创建、编辑、启动、停止和重新创建 Compose Stack
 - 固定与排序
 - 备注和 Git 工具
@@ -146,7 +146,7 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - 主机前置条件与 VPN namespace 保护
 - 可折叠/调整大小的侧栏与资源指标
 
-### 🔄 迁移与复制
+### 迁移与复制
 - 实例间复制或移动
 - Compose、bind mount 与卷传输
 - 可恢复任务和 SHA-256 校验
@@ -155,14 +155,14 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - `container_name` 冲突检测
 - 计划冷复制
 
-### 💾 备份与恢复
+### 备份与恢复
 - Restic 多目标备份
 - Bind mount 与卷
 - 选择性恢复
 - 仓库与 Snapshot 检查
 - 历史记录与恢复流程集成
 
-### ⬆️ 更新
+### 更新
 - 镜像更新监控与远程检测
 - 手动和自动更新
 - Rollback、计划与暂停
@@ -170,40 +170,40 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - 强制 Restic 备份、完整性和可用性检查
 - 失败时自动恢复
 
-### 🛡️ 安全
+### 安全
 - Trivy 与 CVE 例外
 - 2FA、Turnstile、trusted proxy
 - 受限制 sidecar 与签名计划
 - Docker 破坏性操作保护
 - 私有 Registry 凭据加密传输
 
-### 📊 监控
+### 监控
 - 系统、Stack 和容器统计
 - 状态栏与健康卡片
 - Crash loop 与 healthcheck 自动修复
 - 实时/全屏日志
 - Kula 与 Dozzle
 
-### 🐳 Docker 资源
+### Docker 资源
 - 镜像、卷、网络和未管理容器
 - 批量操作与自动清理
 - 高风险删除保护
 
-### 🤖 自动化与审计
+### 自动化与审计
 - REST API
 - 每 Stack Webhook
 - Home Assistant 示例
 - 计划操作
 - 集中历史记录
 
-### 🔌 集成
+### 集成
 - PlugNPiN
 - Nginx Proxy Manager
 - Pi-hole
 - AdGuard Home
 - Dozzle 与 Kula
 
-### 🔔 通知与访问
+### 通知与访问
 - Discord 与 Apprise
 - EN / FR / ES / zh-CN
 - 2FA、trusted proxy、Turnstile


### PR DESCRIPTION
## Résumé

- retire les icônes des titres du catalogue de fonctionnalités dans les quatre README ;
- conserve une présentation sobre et homogène des catégories ;
- nettoie deux doublons accidentels déjà présents dans les README anglais et français.

Documentation uniquement.
