### PR TITLE
Corriger les vulnérabilités HIGH de fast-uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5893,9 +5893,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Objectif

Mettre à jour la dépendance transitive `fast-uri` de `3.1.5` vers `3.1.6`.

La version `3.1.5` est concernée par plusieurs avis de sécurité HIGH récemment publiés :

- GHSA-5jgf-p345-68v8
- GHSA-f65p-4m7j-42xc
- GHSA-fph4-wmhf-6fwf
- GHSA-jqff-g426-hqxp

La branche `3.x` est corrigée à partir de `3.1.6`.

`fast-uri` est utilisé transitivement par `ajv 8.20.0`, qui déclare déjà `fast-uri ^3.0.1`. La mise à jour reste donc dans la plage de versions existante et ne change aucune dépendance directe.

## Portée

- uniquement `package-lock.json` ;
- aucune modification de `package.json` ;
- aucune modification applicative ;
- aucune modification du self-update, du sidecar, de Restic, du rollback ou de l’ImageWatcher.

Cette correction rétablit également le passage de `npm audit --audit-level=high`, actuellement bloquant sur les PR.