### PR TITLE
Éviter les builds lourds pour les PR documentaires

### DIFF
--- a/.github/scripts/is-docs-only.sh
+++ b/.github/scripts/is-docs-only.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+
+[[ -n "$BASE_SHA" && -n "$HEAD_SHA" ]] || exit 2
+
+mapfile -t changed < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+[[ "${#changed[@]}" -gt 0 ]] || exit 1
+
+for file in "${changed[@]}"; do
+    case "$file" in
+        README*.md|CHANGELOG*.md|*.md|docs/*|docs/**|screens/*|screens/**)
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+done
+
+exit 0

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -5,7 +5,10 @@ on:
     branches: [main]
     paths-ignore:
       - "README*.md"
+      - "CHANGELOG*.md"
+      - "docs/**"
       - "screens/**"
+      - "*.md"
       - "*.sh"
       - ".github/workflows/sync-upstream.yml"
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,58 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Détecter une PR documentaire
+        if: github.event_name == 'pull_request'
+        id: docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if .github/scripts/is-docs-only.sh "$BASE_SHA" "$HEAD_SHA"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "PR documentaire : CI frontend ignorée."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: PR documentaire — validation légère
+        if: steps.docs.outputs.docs_only == 'true'
+        run: echo "Aucun fichier applicatif modifié."
 
       - name: Setup Node.js 22
+        if: steps.docs.outputs.docs_only != 'true'
         uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Installer les dépendances
+        if: steps.docs.outputs.docs_only != 'true'
         run: npm ci
 
       - name: Vérification TypeScript (tsc --noEmit)
+        if: steps.docs.outputs.docs_only != 'true'
         run: npm run check-ts
 
       - name: Tests d’authentification
+        if: steps.docs.outputs.docs_only != 'true'
         run: npx tsx --test backend/auth.test.ts
 
       - name: Tests des prérequis de démarrage
+        if: steps.docs.outputs.docs_only != 'true'
         run: npx tsx --test backend/start-guard.test.ts
 
       - name: Compatibilité du runtime frontend
+        if: steps.docs.outputs.docs_only != 'true'
         run: npx tsx --test frontend/src/i18n-compat.test.ts
 
       - name: Audit npm HIGH/CRITICAL
+        if: steps.docs.outputs.docs_only != 'true'
         run: npm audit --audit-level=high
 
       - name: Build frontend (Vite)
+        if: steps.docs.outputs.docs_only != 'true'
         run: npm run build:frontend

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,33 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Détecter une PR documentaire
+        if: github.event_name == 'pull_request'
+        id: docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if .github/scripts/is-docs-only.sh "$BASE_SHA" "$HEAD_SHA"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: PR documentaire — validation légère
+        if: steps.docs.outputs.docs_only == 'true'
+        run: echo "Analyse CodeQL ignorée pour une PR purement documentaire."
 
       - uses: github/codeql-action/init@v4
+        if: steps.docs.outputs.docs_only != 'true'
         with:
           languages: javascript-typescript
           build-mode: none
 
       - uses: github/codeql-action/analyze@v4
+        if: steps.docs.outputs.docs_only != 'true'
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -16,8 +16,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Détection des changements
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.docs.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Détecter une PR documentaire
+        id: docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && .github/scripts/is-docs-only.sh "$BASE_SHA" "$HEAD_SHA"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-platform:
     name: Build ${{ matrix.platform }}
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -105,10 +129,15 @@ jobs:
   build:
     name: Build linux/amd64,linux/arm64
     if: always()
-    needs: build-platform
+    needs: [changes, build-platform]
     runs-on: ubuntu-latest
     steps:
+      - name: PR documentaire — validation légère
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Aucun build Docker nécessaire."
+
       - name: Vérifier les deux architectures
+        if: needs.changes.outputs.docs_only != 'true'
         env:
           BUILD_RESULT: ${{ needs.build-platform.result }}
         run: test "$BUILD_RESULT" = "success"

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -29,7 +29,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Détecter une PR documentaire
+        if: github.event_name == 'pull_request'
+        id: docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if .github/scripts/is-docs-only.sh "$BASE_SHA" "$HEAD_SHA"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: PR documentaire — validation légère
+        if: steps.docs.outputs.docs_only == 'true'
+        run: echo "Scan Trivy ignoré pour une PR purement documentaire."
+
       - name: Analyser la révision courante
+        if: steps.docs.outputs.docs_only != 'true'
         run: |
           docker run --rm -v "$PWD:/work" -v "$PWD/.trivyignore.yaml:/trivyignore.yaml:ro" -v trivy-cache:/root/.cache/ "$TRIVY_IMAGE" fs \
             --db-repository ghcr.io/aquasecurity/trivy-db:2 \
@@ -43,7 +61,7 @@ jobs:
             --ignore-unfixed --format sarif --output /work/trivy-head.sarif /work || true
 
       - name: Analyser la base de la PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.docs.outputs.docs_only != 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -57,7 +75,7 @@ jobs:
           git worktree remove /tmp/trivy-base --force
 
       - name: Refuser uniquement les nouvelles régressions corrigibles
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.docs.outputs.docs_only != 'true'
         run: python3 .github/scripts/trivy_compare.py trivy-base.json trivy-head.json
 
       - name: Refuser le passif HIGH/CRITICAL sur main
@@ -70,7 +88,7 @@ jobs:
             --ignore-unfixed --exit-code 1 /work
 
       - name: Publier le rapport SARIF
-        if: always() && hashFiles('trivy-head.sarif') != ''
+        if: always() && steps.docs.outputs.docs_only != 'true' && hashFiles('trivy-head.sarif') != ''
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
@@ -78,7 +96,7 @@ jobs:
           category: trivy-filesystem
 
       - name: Conserver le rapport JSON
-        if: always() && hashFiles('trivy-head.json') != ''
+        if: always() && steps.docs.outputs.docs_only != 'true' && hashFiles('trivy-head.json') != ''
         uses: actions/upload-artifact@v7
         with:
           name: trivy-${{ github.sha }}


### PR DESCRIPTION
## Objectif

Éviter de lancer les builds Docker, scans et builds frontend coûteux lorsqu’une PR ne modifie que la documentation ou les captures.

## Fonctionnement

- détection centralisée des PR docs-only ;
- les checks requis conservent leurs noms et restent présents pour la protection de `main` ;
- TypeScript/frontend, Docker multi-arch, Trivy et CodeQL passent en validation légère pour les PR purement documentaires ;
- les PR qui touchent au code, aux workflows, aux dépendances ou à la configuration continuent de lancer toute la CI ;
- après merge, `build-publish` ignore aussi README, changelogs, docs et captures afin de ne pas republier une image Docker inutilement.

Sont considérés documentaires : fichiers Markdown, `README*.md`, `CHANGELOG*.md`, `docs/**` et `screens/**`.