### PR TITLE
Rendre les erreurs de self-update lisibles dans les notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
         if: steps.docs.outputs.docs_only != 'true'
         run: npx tsx --test backend/self-update/manager.test.ts
 
+      - name: Tests des détails d’erreur du self-update
+        if: steps.docs.outputs.docs_only != 'true'
+        run: npx tsx --test backend/self-update/failure-detail.test.ts
+
       - name: Tests du restore-test Restic
         if: steps.docs.outputs.docs_only != 'true'
         run: npx tsx --test backend/watchers/backup-restore-test.test.ts

--- a/CHANGELOG.es-ES.md
+++ b/CHANGELOG.es-ES.md
@@ -1,5 +1,7 @@
 # Changelog de Dockge Enhanced
 
+**2026-09-03 — Notificaciones de rollback más legibles** — Los errores brutos de Docker/GHCR siguen disponibles en el estado y los logs, pero Discord/Apprise ya no muestra las largas URL temporales firmadas de `pkg-containers.githubusercontent.com`. Las notificaciones resumen ahora la causa útil (timeout de red, autenticación, acceso denegado, imagen/digest ausente, DNS o fallo técnico genérico), también después de un rollback correcto.
+
 **2026-09-03 — Notificación terminal autónoma de la autoactualización** — Tras un reinicio provocado por el sidecar, Dockge-Enhanced supervisa ahora por sí mismo el estado persistente de la autoactualización hasta obtener un resultado terminal. Las notificaciones de éxito, fallo o rollback por Discord/Apprise ya no dependen de abrir la WebUI ni de llamar a `/self/status`. La supervisión, limitada a 15 minutos, cubre `updating`, `waiting-health`, `rolling-back` y cualquier notificación terminal pendiente.
 
 **2026-09-03 — Corrección de la prueba de restauración Restic** — La prueba posterior al backup solicita ahora realmente la salida JSON de `restic ls`, prefiere un archivo Compose no vacío cuando existe y, en caso contrario, prueba otro archivo real del snapshot. Un backup válido de Dockge sin Compose ya no se marca erróneamente como fallo de restauración. Un snapshot sin archivos sigue siendo un fallo real y uno compuesto únicamente por archivos vacíos se marca como prueba de contenido omitida.

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1,5 +1,7 @@
 # Changelog Dockge Enhanced
 
+**2026-09-03 — Notifications de rollback plus lisibles** — Les erreurs brutes Docker/GHCR restent disponibles dans l’état et les logs, mais Discord/Apprise n’affiche plus les longues URL signées temporaires de `pkg-containers.githubusercontent.com`. Les notifications de self-update résument désormais la cause utile (timeout réseau, authentification, accès refusé, image/digest introuvable, DNS ou erreur technique générique), notamment après un rollback réussi.
+
 **2026-09-03 — Notification terminale autonome du self-update** — Après le redémarrage provoqué par le sidecar, Dockge-Enhanced surveille désormais lui-même l’état persistant du self-update jusqu’au résultat terminal. La notification Discord/Apprise de succès, d’échec ou de rollback ne dépend donc plus de l’ouverture de la WebUI ou d’un appel à `/self/status`. Une surveillance bornée à 15 minutes couvre les états `updating`, `waiting-health` et `rolling-back`, ainsi que toute notification terminale encore en attente.
 
 **2026-09-03 — Correction du restore-test Restic** — Le test de restauration post-backup utilise désormais réellement la sortie JSON de `restic ls`, préfère un Compose non vide lorsqu’il existe et teste sinon un autre fichier réel du snapshot. Un backup Dockge valide sans Compose n’est donc plus signalé à tort comme « Restore test échoué ». Un snapshot sans aucun fichier reste un échec réel, tandis qu’un snapshot ne contenant que des fichiers vides est explicitement marqué comme test de contenu ignoré.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Dockge Enhanced Changelog
 
+**2026-09-03 — Cleaner rollback notifications** — Raw Docker/GHCR errors remain available in state and logs, but Discord/Apprise no longer exposes long temporary signed `pkg-containers.githubusercontent.com` URLs. Self-update notifications now summarize the useful cause (network timeout, authentication, forbidden access, missing image/digest, DNS, or a generic technical failure), including after a successful rollback.
+
 **2026-09-03 — Autonomous self-update terminal notification** — After a sidecar-triggered restart, Dockge-Enhanced now monitors the persisted self-update state by itself until a terminal result is written. Discord/Apprise success, failure or rollback notifications therefore no longer depend on opening the WebUI or calling `/self/status`. A 15-minute bounded watcher covers `updating`, `waiting-health` and `rolling-back`, plus any terminal notification still pending.
 
 **2026-09-03 — Fix Restic restore test** — The post-backup restore test now actually requests JSON output from `restic ls`, prefers a non-empty Compose file when available, and otherwise tests another real file from the snapshot. A valid Dockge backup without a Compose file is therefore no longer reported as a failed restore test. A snapshot with no files remains a real failure, while an all-empty-file snapshot is explicitly marked as a skipped content test.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,7 @@
 # Dockge Enhanced 更新日志
 
+**2026-09-03 — 回滚通知更加简洁** — Docker/GHCR 的完整原始错误仍保留在状态和日志中，但 Discord/Apprise 不再显示 `pkg-containers.githubusercontent.com` 的超长临时签名 URL。自更新通知现在只概括有用原因：网络超时、身份验证失败、访问被拒绝、镜像/摘要不存在、DNS 错误或通用技术故障，包括成功回滚后的通知。
+
 **2026-09-03 — 自更新终态通知改为自主处理** — Sidecar 触发容器重启后，Dockge-Enhanced 现在会自行监控持久化的自更新状态直到出现终态。Discord/Apprise 的成功、失败或回滚通知不再依赖打开 WebUI 或调用 `/self/status`。该监控最长持续 15 分钟，覆盖 `updating`、`waiting-health`、`rolling-back` 以及仍待发送的终态通知。
 
 **2026-09-03 — 修复 Restic 恢复测试** — 备份后的恢复测试现在会正确请求 `restic ls` 的 JSON 输出，优先读取非空 Compose 文件；如果不存在，则读取快照中的其他真实非空文件。因此，不含 Compose 的有效 Dockge 备份不会再被误报为恢复测试失败。完全没有文件的快照仍视为真实失败，而只包含空文件的快照会明确标记为跳过内容读取测试。

--- a/backend/self-update/failure-detail.test.ts
+++ b/backend/self-update/failure-detail.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifySelfUpdateFailure } from "./failure-detail";
+
+test("classe un timeout GHCR même avec une URL signée très longue", () => {
+    const raw = [
+        "Command failed: docker image pull ghcr.io/aerya/dockge-enhanced@sha256:abc",
+        "failed to copy: httpReadSeeker: failed open: failed to do request:",
+        'Get "https://pkg-containers.githubusercontent.com/ghcrblobs11/blobs/sha256:deadbeef?se=2026-09-02T23%3A20%3A00Z&sig=very-long-signed-query":',
+        "net/http: timeout awaiting response headers",
+    ].join("\n");
+
+    assert.equal(classifySelfUpdateFailure(raw), "network-timeout");
+});
+
+test("classe les principaux échecs de registre", () => {
+    assert.equal(classifySelfUpdateFailure("unauthorized: authentication required"), "registry-auth");
+    assert.equal(classifySelfUpdateFailure("denied: requested access to the resource is denied"), "registry-forbidden");
+    assert.equal(classifySelfUpdateFailure("manifest unknown: manifest unknown"), "image-not-found");
+});
+
+test("classe les erreurs DNS", () => {
+    assert.equal(classifySelfUpdateFailure("dial tcp: lookup ghcr.io: no such host"), "dns");
+});
+
+test("conserve un fallback générique", () => {
+    assert.equal(classifySelfUpdateFailure("unexpected docker failure"), "generic");
+});

--- a/backend/self-update/failure-detail.ts
+++ b/backend/self-update/failure-detail.ts
@@ -1,0 +1,44 @@
+export type SelfUpdateFailureKind =
+    | "network-timeout"
+    | "registry-auth"
+    | "registry-forbidden"
+    | "image-not-found"
+    | "dns"
+    | "generic";
+
+export function classifySelfUpdateFailure(raw: string): SelfUpdateFailureKind {
+    const text = raw.toLowerCase();
+
+    if (
+        text.includes("timeout awaiting response headers")
+        || text.includes("context deadline exceeded")
+        || text.includes("i/o timeout")
+        || text.includes("connection timed out")
+    ) return "network-timeout";
+
+    if (
+        text.includes("status code 401")
+        || text.includes("unauthorized")
+        || text.includes("authentication required")
+    ) return "registry-auth";
+
+    if (
+        text.includes("status code 403")
+        || text.includes("denied:")
+        || text.includes("requested access to the resource is denied")
+    ) return "registry-forbidden";
+
+    if (
+        text.includes("status code 404")
+        || text.includes("manifest unknown")
+        || text.includes("not found")
+    ) return "image-not-found";
+
+    if (
+        text.includes("no such host")
+        || text.includes("temporary failure in name resolution")
+        || text.includes("name or service not known")
+    ) return "dns";
+
+    return "generic";
+}

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -14,6 +14,7 @@ import { DEFAULT_SELF_UPDATE_SETTINGS, normalizeSelfUpdateSettings, selfUpdateMa
 import { isAllowedTargetImage, isPathInside, isSafeComposeName, isSelfUpdateActive, normalizeSelfRepository } from "./policy";
 import { atomicWriteFile, atomicWriteJson } from "./state-file";
 import { getSelfUpdateBlocker } from "./operation-guard";
+import { classifySelfUpdateFailure } from "./failure-detail";
 import packageJSON from "../../package.json";
 import { log } from "../log";
 
@@ -370,6 +371,49 @@ export class SelfUpdateManager {
         );
     }
 
+    private summarizeFailureForNotification(body: string, lang: string): string {
+        const kind = classifySelfUpdateFailure(body);
+        const messages: Record<ReturnType<typeof classifySelfUpdateFailure>, [string, string, string, string]> = {
+            "network-timeout": [
+                "Timeout réseau lors du téléchargement de l’image GHCR.",
+                "Network timeout while downloading the GHCR image.",
+                "Tiempo de espera de red agotado al descargar la imagen GHCR.",
+                "下载 GHCR 镜像时发生网络超时。",
+            ],
+            "registry-auth": [
+                "Authentification refusée par le registre GHCR.",
+                "Authentication was rejected by the GHCR registry.",
+                "El registro GHCR rechazó la autenticación.",
+                "GHCR 注册表拒绝了身份验证。",
+            ],
+            "registry-forbidden": [
+                "Accès refusé par le registre GHCR.",
+                "Access was denied by the GHCR registry.",
+                "El registro GHCR denegó el acceso.",
+                "GHCR 注册表拒绝了访问。",
+            ],
+            "image-not-found": [
+                "Image ou digest introuvable sur GHCR.",
+                "Image or digest not found on GHCR.",
+                "Imagen o digest no encontrado en GHCR.",
+                "在 GHCR 上找不到镜像或摘要。",
+            ],
+            dns: [
+                "Résolution DNS impossible pour le registre GHCR.",
+                "DNS resolution failed for the GHCR registry.",
+                "No se pudo resolver por DNS el registro GHCR.",
+                "无法解析 GHCR 注册表的 DNS。",
+            ],
+            generic: [
+                "Échec technique lors de la récupération ou de l’application de l’image GHCR.",
+                "Technical failure while fetching or applying the GHCR image.",
+                "Fallo técnico al descargar o aplicar la imagen GHCR.",
+                "获取或应用 GHCR 镜像时发生技术错误。",
+            ],
+        };
+        return notificationText(lang, ...messages[kind]);
+    }
+
     private async notify(title: string, body: string, type: "warning" | "success" | "failure"): Promise<boolean> {
         try {
             const watcher = ImageWatcher.getInstance().settings;
@@ -491,6 +535,7 @@ export class SelfUpdateManager {
                     ].filter(Boolean).join("\n"),
                 );
             } else if (title === "↩️ Dockge-Enhanced rollback succeeded") {
+                const failureSummary = this.summarizeFailureForNotification(body, lang);
                 localizedBody = notificationText(
                     lang,
                     [
@@ -500,7 +545,7 @@ export class SelfUpdateManager {
                         "**Rollback** · Réussi",
                         "**État** · Opérationnel",
                         "",
-                        `Détail : ${body}`,
+                        `**Cause** · ${failureSummary}`,
                     ].join("\n"),
                     [
                         "The update failed, but the previous version was restored automatically.",
@@ -509,7 +554,7 @@ export class SelfUpdateManager {
                         "**Rollback** · Successful",
                         "**Status** · Operational",
                         "",
-                        `Details: ${body}`,
+                        `**Cause** · ${failureSummary}`,
                     ].join("\n"),
                     [
                         "La actualización falló, pero la versión anterior se restauró automáticamente.",
@@ -518,7 +563,7 @@ export class SelfUpdateManager {
                         "**Rollback** · Correcto",
                         "**Estado** · Operativo",
                         "",
-                        `Detalle: ${body}`,
+                        `**Causa** · ${failureSummary}`,
                     ].join("\n"),
                     [
                         "更新失败，但旧版本已自动恢复。",
@@ -527,8 +572,17 @@ export class SelfUpdateManager {
                         "**回滚** · 成功",
                         "**状态** · 运行正常",
                         "",
-                        `详情：${body}`,
+                        `**原因** · ${failureSummary}`,
                     ].join("\n"),
+                );
+            } else if (title === "❌ Dockge-Enhanced self-update failed") {
+                const failureSummary = this.summarizeFailureForNotification(body, lang);
+                localizedBody = notificationText(
+                    lang,
+                    `La mise à jour automatique a échoué.\n\n**Cause** · ${failureSummary}`,
+                    `The automatic update failed.\n\n**Cause** · ${failureSummary}`,
+                    `La actualización automática falló.\n\n**Causa** · ${failureSummary}`,
+                    `自动更新失败。\n\n**原因** · ${failureSummary}`,
                 );
             }
             const prefixedBodies: Array<[string, [string, string, string, string]]> = [

--- a/backend/self-update/manager.ts
+++ b/backend/self-update/manager.ts
@@ -8,7 +8,7 @@ import { ImageWatcher } from "../watchers/image-watcher";
 import { DiscordNotifier } from "../notification/discord";
 import { AppriseNotifier } from "../notification/apprise";
 import { Settings } from "../settings";
-import { getNotificationLang, notificationText } from "../notification/notification-lang";
+import { getNotificationLang, notificationText, type NotificationLang } from "../notification/notification-lang";
 import { SelfUpdateOperation, SelfUpdatePlan, SelfUpdateProgress, SelfUpdateSettings } from "./types";
 import { DEFAULT_SELF_UPDATE_SETTINGS, normalizeSelfUpdateSettings, selfUpdateMayRun } from "./settings";
 import { isAllowedTargetImage, isPathInside, isSafeComposeName, isSelfUpdateActive, normalizeSelfRepository } from "./policy";
@@ -371,7 +371,7 @@ export class SelfUpdateManager {
         );
     }
 
-    private summarizeFailureForNotification(body: string, lang: string): string {
+    private summarizeFailureForNotification(body: string, lang: NotificationLang): string {
         const kind = classifySelfUpdateFailure(body);
         const messages: Record<ReturnType<typeof classifySelfUpdateFailure>, [string, string, string, string]> = {
             "network-timeout": [


### PR DESCRIPTION
## Problème

Lorsqu’un téléchargement GHCR échoue, Docker peut retourner une erreur contenant une URL temporaire signée `pkg-containers.githubusercontent.com` extrêmement longue.

Cette erreur brute est utile dans les logs, mais sa reprise intégrale dans Discord/Apprise rend la notification difficile à lire et noie l’information importante.

## Correction

Les erreurs brutes restent inchangées dans l’état du self-update et dans les logs.

Pour les notifications uniquement, Dockge-Enhanced classe maintenant la cause et affiche un résumé court et localisé :

- timeout réseau ;
- authentification GHCR refusée ;
- accès GHCR refusé ;
- image ou digest introuvable ;
- erreur DNS ;
- erreur technique générique.

Les notifications de rollback réussi et d’échec terminal utilisent ce résumé et ne republient plus l’URL signée ou le message Docker complet.

Exemple :

`Cause · Timeout réseau lors du téléchargement de l’image GHCR.`