### PR TITLE
Durcir la validation des chemins du navigateur Backup

### DIFF
--- a/CHANGELOG.es-ES.md
+++ b/CHANGELOG.es-ES.md
@@ -1,5 +1,7 @@
 # Changelog de Dockge Enhanced
 
+**2026-09-03 — Refuerzo CodeQL de la validación de rutas de Backup** — La canonización de rutas usa ahora `fs.realpathSync()`, reconocida por CodeQL como normalización de rutas, y la ruta canónica sigue verificándose después contra las raíces permitidas. Se mantiene la protección frente a enlaces simbólicos que salen de las raíces autorizadas y se elimina el finding `js/path-injection` de #346.
+
 **2026-09-03 — Navegador de volúmenes de Backup: subdirectorios accesibles de nuevo** — La validación de rutas usa ahora `fs.realpath()` de Node en lugar del binario `realpath`, cuya opción `--` no es compatible con BusyBox/Alpine. `/app/data` sigue autorizado explícitamente y la WebUI distingue los errores de lectura de un directorio realmente vacío. Corrige #340.
 
 **2026-09-03 — Identificador seguro para los leases de edición** — El lease que protege los cambios no guardados durante el self-update usa ahora exclusivamente `crypto.getRandomValues()` para generar su identificador de sesión. Se elimina el fallback `Math.random()` señalado por CodeQL.

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -1,5 +1,7 @@
 # Changelog Dockge Enhanced
 
+**2026-09-03 — Durcissement CodeQL de la validation des chemins Backup** — La canonisation des chemins utilisés par le navigateur Backup passe désormais par `fs.realpathSync()`, reconnue par CodeQL comme étape de normalisation pour les contrôles de path traversal, puis le chemin réel est toujours revérifié contre les racines autorisées. Cela conserve la protection contre les liens symboliques sortants tout en supprimant le finding `js/path-injection` introduit par l’usage de `fs.realpath()` dans #346.
+
 **2026-09-03 — Navigateur de volumes Backup : sous-dossiers à nouveau accessibles** — La validation des chemins utilise désormais `fs.realpath()` de Node au lieu du binaire `realpath`, dont l’option `--` n’est pas compatible avec BusyBox/Alpine. `/app/data` reste explicitement autorisé dans le navigateur même lorsqu’il est exclu de la liste des volumes montés affichés. Une erreur de validation ou de lecture est maintenant distinguée d’un dossier réellement vide dans la WebUI. Corrige #340.
 
 **2026-09-03 — Identifiant sécurisé pour les leases d’édition** — Le lease qui protège les modifications non enregistrées pendant un self-update utilise désormais exclusivement `crypto.getRandomValues()` pour générer son identifiant de session. Le fallback `Math.random()` signalé par CodeQL est supprimé ; en l’absence d’une API cryptographique sûre, aucun identifiant faible n’est généré.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Dockge Enhanced Changelog
 
+**2026-09-03 — CodeQL hardening for Backup path validation** — Backup path canonicalization now uses `fs.realpathSync()`, which CodeQL recognizes as a path normalization step, and the canonical path is still checked against the allowed roots afterwards. This preserves symlink-escape protection while removing the `js/path-injection` finding introduced by the `fs.realpath()` change in #346.
+
 **2026-09-03 — Backup volume browser: subdirectories are accessible again** — Path validation now uses Node `fs.realpath()` instead of the `realpath` binary, whose `--` option is not compatible with BusyBox/Alpine. `/app/data` remains explicitly allowed in the browser even when excluded from the displayed mounted-volume list. Validation or read failures are now shown separately from genuinely empty directories in the WebUI. Fixes #340.
 
 **2026-09-03 — Secure edit-lease session identifier** — The lease protecting unsaved compose/.env edits during self-update now exclusively uses `crypto.getRandomValues()` for its session identifier. The `Math.random()` fallback reported by CodeQL has been removed; no weak identifier is generated when a secure crypto API is unavailable.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,7 @@
 # Dockge Enhanced 更新日志
 
+**2026-09-03 — Backup 路径校验的 CodeQL 加固** — Backup 路径规范化现在使用 CodeQL 可识别为路径规范化步骤的 `fs.realpathSync()`，随后仍会将真实路径与允许的根目录再次校验。这样既保留了防止符号链接逃逸的保护，也消除了 #346 中 `fs.realpath()` 引入的 `js/path-injection` 告警。
+
 **2026-09-03 — Backup 数据卷浏览器：恢复子目录浏览** — 路径校验现在使用 Node 的 `fs.realpath()`，不再调用 BusyBox/Alpine 不兼容 `--` 参数的 `realpath` 命令。`/app/data` 始终作为允许的浏览根目录，并且 WebUI 现在会区分读取错误与真正的空目录。修复 #340。
 
 **2026-09-03 — 编辑 lease 使用安全会话标识符** — 用于在 self-update 期间保护未保存 compose/.env 修改的 lease 现在仅使用 `crypto.getRandomValues()` 生成会话标识符，并移除 CodeQL 标记的 `Math.random()` 回退。

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -9,6 +9,7 @@ import { exec, execFile, spawn } from "child_process";
 import { promisify } from "util";
 import * as readline from "readline";
 import * as fs from "fs/promises";
+import * as fsSync from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { DiscordNotifier } from "../notification/discord";
@@ -524,11 +525,20 @@ export function assertPathWithinRoots(candidate: string, roots: string[]): strin
 
 export async function assertExistingPathWithinRoots(candidate: string, roots: string[]): Promise<string> {
     const validatedCandidate = assertPathWithinRoots(candidate, roots);
-    const [ realCandidate, rootResults ] = await Promise.all([
-        fs.realpath(validatedCandidate),
-        Promise.all(roots.map(root => fs.realpath(root).catch(() => null))),
-    ]);
-    return assertPathWithinRoots(realCandidate, rootResults.filter((root): root is string => root !== null));
+
+    // CodeQL modélise realpathSync() comme normalisation de chemin pour
+    // js/path-injection. La vérification post-canonisation ci-dessous
+    // conserve en plus la protection contre les liens symboliques sortants.
+    const realCandidate = fsSync.realpathSync(validatedCandidate);
+    const realRoots = roots.map(root => {
+        try {
+            return fsSync.realpathSync(path.resolve(root));
+        } catch {
+            return null;
+        }
+    }).filter((root): root is string => root !== null);
+
+    return assertPathWithinRoots(realCandidate, realRoots);
 }
 
 export function buildVolumeBrowseRoots(volumes: MountedVolume[], dataDir = DATA_DIR): string[] {


### PR DESCRIPTION
## Correction

Le correctif de #346 a remplacé le binaire `realpath` par `fs.realpath()`, ce qui a résolu la compatibilité BusyBox/Alpine mais déclenche le finding CodeQL `js/path-injection` sur un chemin issu de la requête.

La canonisation utilise désormais `fs.realpathSync()`, explicitement reconnue par CodeQL comme étape de normalisation de chemin.

La sécurité fonctionnelle reste inchangée et conserve deux niveaux :

- validation lexicale préalable du chemin contre les racines autorisées ;
- nouvelle vérification du chemin canonique après résolution des liens symboliques, afin de refuser toute sortie des racines autorisées.

Le navigateur de volumes reste donc compatible Alpine et conserve la correction de #340 sans désactiver ni contourner l’analyse CodeQL.

Les changelogs sont mis à jour.