### PR TITLE
Corriger la page noire des stacks externes

### DIFF
--- a/frontend/src/pages/ExternalStacks.vue
+++ b/frontend/src/pages/ExternalStacks.vue
@@ -24,7 +24,7 @@
                         :value="entry.endpoint"
                         :disabled="entry.status && entry.status !== 'online'"
                     >
-                        {{ agentOptionLabel(entry) }}
+                        {{ entry.label }}
                     </option>
                 </select>
                 <button class="btn btn-primary external-scan-btn" :disabled="loading" @click="refresh">


### PR DESCRIPTION
## Correction

La page **Stacks externes** restait entièrement vide sur les installations avec plusieurs instances/agents.

Le sélecteur d'instance appelait `agentOptionLabel(entry)` alors que cette méthode n'existe pas dans `ExternalStacks.vue`. L'erreur se produisait au rendu uniquement lorsque le sélecteur multi-instance était affiché.

Le composant utilise désormais directement `entry.label`, déjà calculé par `agentEntries()`.

Aucun changement backend ni comportement d'adoption des stacks externes.