### PR TITLE
Ajouter le badge des installations actives

### DIFF
--- a/.github/workflows/usage-count-asset.yml
+++ b/.github/workflows/usage-count-asset.yml
@@ -12,6 +12,11 @@ jobs:
   prepare-monthly-asset:
     runs-on: ubuntu-latest
     steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Préparer la release technique
         env:
           GH_TOKEN: ${{ github.token }}
@@ -38,3 +43,48 @@ jobs:
           asset="$RUNNER_TEMP/${month}.txt"
           printf 'Dockge-Enhanced anonymous installation count %s\n' "$month" > "$asset"
           gh release upload usage-count "$asset" --repo "$GITHUB_REPOSITORY"
+
+      - name: Pointer les badges vers le mois courant
+        run: |
+          set -euo pipefail
+          month="$(date -u +%Y-%m)"
+          python3 - "$month" <<'PYBADGE'
+          import re
+          import sys
+          from pathlib import Path
+
+          month = sys.argv[1]
+          files = [
+              Path("README.md"),
+              Path("README.fr.md"),
+              Path("README.es-ES.md"),
+              Path("README.zh-CN.md"),
+          ]
+
+          pattern = re.compile(
+              r"(https://img\.shields\.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/)"
+              r"\d{4}-\d{2}"
+              r"(\.txt\?displayAssetName=false&label=)"
+          )
+
+          for file in files:
+              text = file.read_text(encoding="utf-8")
+              updated, count = pattern.subn(rf"\g<1>{month}\g<2>", text)
+              if count != 1:
+                  raise SystemExit(
+                      f"{file}: badge mensuel introuvable ou ambigu ({count})"
+                  )
+              file.write_text(updated, encoding="utf-8")
+          PYBADGE
+
+          if git diff --quiet -- README.md README.fr.md README.es-ES.md README.zh-CN.md; then
+            echo "Badges déjà positionnés sur ${month}."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README.fr.md README.es-ES.md README.zh-CN.md
+          git commit -m "docs: actualiser le badge des installations actives"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -46,8 +46,8 @@ Un fork de [Dockge](https://github.com/louislam/dockge) centrado en ampliar sus 
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
+  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=instalaciones%20activas&color=blue" alt="Instalaciones activas"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">

--- a/README.fr.md
+++ b/README.fr.md
@@ -44,8 +44,8 @@ Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnal
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
+  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=installations%20actives&color=blue" alt="Installations actives"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ A feature-focused fork of [Dockge](https://github.com/louislam/dockge) that turn
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
+  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=active%20installs&color=blue" alt="Active installations"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,8 +71,8 @@ Dockge-Enhanced 管理的 stacks 及其持久化数据不受此问题影响。
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
+  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=%E6%B4%BB%E8%B7%83%E5%AE%89%E8%A3%85&color=blue" alt="活跃安装"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">


### PR DESCRIPTION
## Objectif

Rendre le compteur mensuel d'installations actives visible directement sur la page GitHub du projet.

## Modifications

- suppression du badge `Docker ready`, redondant pour un projet distribué uniquement via Docker ;
- conservation du badge `Build` ;
- ajout d'un badge Shields.io basé directement sur le `download_count` de l'asset mensuel de la release `usage-count` ;
- libellé localisé dans les quatre README ;
- le badge pointe vers l'asset du mois courant, par exemple `2026-09.txt` ;
- le workflow mensuel existant met automatiquement les quatre README sur le nouvel asset lorsqu'il crée le mois suivant.

Le badge lit uniquement le compteur public GitHub de l'asset. Il ne déclenche aucun téléchargement supplémentaire de l'asset et ne change rien au mécanisme de comptage côté Enhanced.
