### PR TITLE
Documenter la migration depuis Dockge

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -5,36 +5,6 @@
 </p>
 
 # Dockge Enhanced
-> [!WARNING]
-> ## Corrección crítica de la autoactualización de Dockge-Enhanced
->
-> Varios builds publicados entre **el 31 de agosto de 2026 y el 2 de septiembre de 2026** contenían defectos en el mecanismo de actualización automática de Dockge-Enhanced.
->
-> En determinadas condiciones, el sidecar podía detener el contenedor Dockge-Enhanced, no conseguir crear la nueva versión y, en algunos builds, tampoco restaurar automáticamente la versión anterior.
->
-> El mecanismo ha sido corregido y reforzado. A partir del build **`0fc2564` / versión 1.5.4**, la actualización automática:
->
-> - descarga siempre el último `dockge-enhanced-updater:latest` antes de cada actualización;
-> - descarga explícitamente la imagen objetivo de Dockge-Enhanced;
-> - realiza una copia Restic obligatoria antes del reemplazo;
-> - verifica el nuevo contenedor antes de validar la actualización;
-> - conserva el rollback y un snapshot de recuperación.
->
-> **Si tu instalación utiliza un build anterior a `0fc2564` / versión 1.5.4, realiza una última actualización manual antes de activar o volver a activar las actualizaciones automáticas:**
->
-> ```bash
-> docker pull ghcr.io/aerya/dockge-enhanced:latest
-> docker compose up -d
-> ```
->
-> Una vez completada esta actualización, puedes activar **Automática mediante sidecar protegido**. Dockge-Enhanced gestionará automáticamente las siguientes actualizaciones.
->
-> **Las stacks gestionadas por Dockge-Enhanced y sus datos persistentes no se ven afectados por este problema.**
->
-> Mis disculpas a todos los usuarios afectados. Una función diseñada precisamente para hacer las actualizaciones más seguras no debería poder dejar Dockge-Enhanced fuera de servicio. Gracias a todos los que utilizan, prueban y reportan problemas: vuestros comentarios permitieron identificar y corregir rápidamente estos defectos.
-
----
-
 Un fork de [Dockge](https://github.com/louislam/dockge) centrado en ampliar sus funcionalidades, que convierte su sencilla experiencia de gestión de Docker Compose en una plataforma Docker más completa — con federación multiservidor, migración y replicación de stacks, copias Restic, actualizaciones de imágenes y de Dockge-Enhanced con rollback, análisis de seguridad, monitorización, automatización, notificaciones y gestión de recursos Docker, todo desde la interfaz web.
 Un fork de [Dockge](https://github.com/louislam/dockge) centrado en ampliar sus funcionalidades, que convierte su sencilla experiencia de gestión de Docker Compose en una plataforma Docker más completa — con federación multiservidor, migración y replicación de stacks, copias Restic, actualizaciones de imágenes y de Dockge-Enhanced con rollback, análisis de seguridad, monitorización, automatización, notificaciones y gestión de recursos Docker, todo desde la interfaz web.
 
@@ -47,7 +17,6 @@ Un fork de [Dockge](https://github.com/louislam/dockge) centrado en ampliar sus 
 
 <p align="center">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
-  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=instalaciones%20activas&color=blue" alt="Instalaciones activas"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
@@ -474,6 +443,58 @@ Abre **http://localhost:5001**, crea tu cuenta de administrador y luego haz clic
 > ```yaml
 >       - /mnt/data:/mnt/data:ro
 > ```
+
+### Probar Dockge-Enhanced junto a Dockge
+
+Dockge y Dockge-Enhanced pueden ejecutarse en el mismo host Docker, pero sus configuraciones Compose predeterminadas no pueden utilizarse sin cambios porque ambos publican el puerto `5001`.
+
+Para probarlos en paralelo:
+
+- instale Dockge-Enhanced desde un directorio Compose separado;
+- utilice otro puerto del host, por ejemplo `5002:5001`;
+- utilice un directorio `/app/data` separado;
+- utilice preferiblemente un directorio de stacks separado con una stack dedicada a la prueba.
+
+Ejemplo:
+
+```yaml
+ports:
+  - 5002:5001
+volumes:
+  - ./enhanced-data:/app/data
+  - /opt/dockge-enhanced-test-stacks:/opt/stacks
+environment:
+  - DOCKGE_STACKS_DIR=/opt/stacks
+  - DOCKGE_DATA_DIR=/app/data
+```
+
+Después puede abrir Dockge-Enhanced en **http://localhost:5002**, mientras su instalación de Dockge permanece disponible en el puerto `5001`.
+
+Ambas aplicaciones pueden acceder al mismo directorio de stacks, pero nunca deben editar, desplegar, actualizar ni realizar otra operación sobre la misma stack **simultáneamente**. Para una prueba prudente, es preferible utilizar un directorio de stacks separado.
+
+### Migrar de Dockge a Dockge-Enhanced
+
+La migración es sencilla porque Dockge-Enhanced comparte la misma base que Dockge:
+
+1. Detenga Dockge.
+2. Haga una copia de seguridad del archivo Compose, del directorio de datos y del directorio de stacks de Dockge.
+3. En el archivo Compose existente de Dockge, sustituya la imagen por:
+
+   ```yaml
+   image: ghcr.io/aerya/dockge-enhanced:latest
+   ```
+
+4. Conserve los montajes existentes de `/app/data` y del directorio de stacks.
+5. Descargue la imagen y reinicie el proyecto Compose:
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+Dockge-Enhanced se iniciará con su cuenta, configuración y stacks existentes.
+
+Conserve la copia de seguridad creada antes de la migración. Si decide volver a Dockge, detenga Dockge-Enhanced y restaure esa copia antes de reiniciar la imagen original de Dockge.
 
 ### Integración opcional PlugNPiN
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,36 +3,6 @@
 </p>
 
 # Dockge Enhanced
-> [!WARNING]
-> ## Correctif critique de l’auto-mise à jour de Dockge-Enhanced
->
-> Plusieurs builds publiés entre **le 31 août 2026 et le 2 septembre 2026** ont comporté des défauts dans le mécanisme d’auto-mise à jour de Dockge-Enhanced.
->
-> Dans certaines conditions, le sidecar pouvait arrêter le conteneur Dockge-Enhanced, échouer à recréer la nouvelle version et, sur certains builds, échouer également à restaurer automatiquement l’ancienne.
->
-> Le mécanisme a depuis été corrigé et renforcé. À partir du build **`0fc2564` / version 1.5.4**, l’auto-mise à jour :
->
-> - télécharge systématiquement le dernier `dockge-enhanced-updater:latest` avant chaque mise à jour ;
-> - télécharge explicitement l’image Dockge-Enhanced cible ;
-> - effectue un backup Restic obligatoire avant remplacement ;
-> - vérifie le nouveau conteneur avant de valider la mise à jour ;
-> - conserve un mécanisme de rollback et un snapshot de récupération.
->
-> **Si votre installation utilise un build antérieur à `0fc2564` / version 1.5.4, effectuez une dernière mise à jour manuelle avant d’activer ou réactiver les mises à jour automatiques :**
->
-> ```bash
-> docker pull ghcr.io/aerya/dockge-enhanced:latest
-> docker compose up -d
-> ```
->
-> Une fois cette mise à jour effectuée, vous pouvez activer **Automatique via sidecar protégé**. Les mises à jour suivantes seront alors prises en charge automatiquement par Dockge-Enhanced.
->
-> **Les stacks gérées par Dockge-Enhanced et leurs données persistantes ne sont pas concernées par ce problème.**
->
-> Toutes mes excuses aux utilisateurs concernés. Une fonction conçue précisément pour rendre les mises à jour plus sûres ne doit évidemment pas pouvoir laisser Dockge-Enhanced hors ligne. Merci à ceux qui utilisent, testent et signalent les problèmes : vos retours ont permis d’identifier puis de corriger rapidement ces défauts.
-
----
-
 Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnalités, qui transforme son expérience simple de gestion Docker Compose en une plateforme Docker plus complète — avec fédération multi-serveurs, migration et réplication de stacks, sauvegardes Restic, mises à jour des images et de Dockge-Enhanced avec rollback, scan de sécurité, supervision, automatisation, notifications et gestion des ressources Docker, le tout depuis l'interface web.
 
 <p align="center">
@@ -45,7 +15,6 @@ Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnal
 
 <p align="center">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
-  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=installations%20actives&color=blue" alt="Installations actives"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
@@ -53,8 +22,8 @@ Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnal
 </p>
 
 <p align="center">
-  <strong>Tu l'utilises ? Tu l'aimes ?</strong>
-  <a href="https://github.com/Aerya/Dockge-Enhanced"><strong>⭐ Mets une étoile !</strong></a>
+  <strong>Vous l'utilisez ? Vous l'appréciez ?</strong>
+  <a href="https://github.com/Aerya/Dockge-Enhanced"><strong>⭐ Ajoutez une étoile !</strong></a>
   — ça prend deux secondes.
 </p>
 
@@ -486,26 +455,78 @@ services:
 docker compose up -d
 ```
 
-Ouvre **http://localhost:5001**, crée ton compte admin, puis clique sur **Surveillance** dans la barre de navigation.
+Ouvrez **http://localhost:5001**, créez votre compte administrateur, puis cliquez sur **Surveillance** dans la barre de navigation.
 
-> Le volume `/backup:/backup` est optionnel mais recommandé si tu utilises **local** comme destination Restic — pointe la destination sur `/backup` pour que les snapshots atterrissent dans un répertoire dédié sur l'hôte, hors du container.
+> Le volume `/backup:/backup` est optionnel mais recommandé si vous utilisez **local** comme destination Restic — indiquez `/backup` comme destination afin que les snapshots soient enregistrés dans un répertoire dédié sur l'hôte, hors du conteneur.
 
-> **Tu veux sauvegarder plusieurs répertoires de données ?** Ajoute autant de volumes que nécessaire (ex : `../../media:/media-data`), puis enregistre chaque chemin dans l'onglet Backup sous **Chemins supplémentaires** — Restic les inclura tous à chaque exécution.
+> **Vous souhaitez sauvegarder plusieurs répertoires de données ?** Ajoutez autant de volumes que nécessaire (ex. : `../../media:/media-data`), puis enregistrez chaque chemin dans l'onglet Backup sous **Chemins supplémentaires** — Restic les inclura tous à chaque exécution.
 
-> **Tu veux surveiller une partition autre que `/` ?** Les stats disque sont lues depuis l'intérieur du container via `df`. Pour surveiller un chemin hôte comme `/mnt/data`, monte-le en lecture seule et ajoute-le dans l'onglet **Monitoring** sous *Partitions disque surveillées* :
+> **Vous souhaitez surveiller une partition autre que `/` ?** Les statistiques du disque sont lues depuis l'intérieur du conteneur avec `df`. Pour surveiller un chemin hôte comme `/mnt/data`, montez-le en lecture seule et ajoutez-le dans l'onglet **Monitoring** sous *Partitions disque surveillées* :
 > ```yaml
 >       - /mnt/data:/mnt/data:ro
 > ```
 
+### Tester Dockge-Enhanced à côté de Dockge
+
+Dockge et Dockge-Enhanced peuvent fonctionner sur le même hôte Docker, mais leurs configurations Compose par défaut ne peuvent pas être utilisées telles quelles, car les deux publient le port `5001`.
+
+Pour les tester côte à côte :
+
+- installez Dockge-Enhanced depuis un répertoire Compose séparé ;
+- utilisez un autre port sur l'hôte, par exemple `5002:5001` ;
+- utilisez un répertoire `/app/data` séparé ;
+- utilisez de préférence un répertoire de stacks séparé avec une stack dédiée au test.
+
+Exemple :
+
+```yaml
+ports:
+  - 5002:5001
+volumes:
+  - ./enhanced-data:/app/data
+  - /opt/dockge-enhanced-test-stacks:/opt/stacks
+environment:
+  - DOCKGE_STACKS_DIR=/opt/stacks
+  - DOCKGE_DATA_DIR=/app/data
+```
+
+Vous pouvez ensuite ouvrir Dockge-Enhanced sur **http://localhost:5002**, tout en conservant votre installation Dockge existante sur le port `5001`.
+
+Les deux applications peuvent accéder au même répertoire de stacks, mais elles ne doivent jamais modifier, déployer, mettre à jour ou effectuer une autre opération sur la même stack **simultanément**. Pour un test prudent, il est préférable d'utiliser un répertoire de stacks séparé.
+
+### Migrer de Dockge vers Dockge-Enhanced
+
+La migration est simple, car Dockge-Enhanced partage la même base que Dockge :
+
+1. Arrêtez Dockge.
+2. Sauvegardez le fichier Compose, le répertoire de données et le répertoire de stacks de Dockge.
+3. Dans le fichier Compose existant de Dockge, remplacez l'image par :
+
+   ```yaml
+   image: ghcr.io/aerya/dockge-enhanced:latest
+   ```
+
+4. Conservez les montages existants pour `/app/data` et le répertoire de stacks.
+5. Téléchargez l'image et redémarrez le projet Compose :
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+Dockge-Enhanced démarrera avec votre compte, vos paramètres et vos stacks existants.
+
+Conservez la sauvegarde réalisée avant la migration. Si vous souhaitez revenir à Dockge, arrêtez Dockge-Enhanced et restaurez cette sauvegarde avant de redémarrer l'image Dockge d'origine.
+
 ### Intégration PlugNPiN facultative
 
-Ouvre **Paramètres → Intégrations** pour configurer [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN). L’intégration reste totalement inactive tant que **Activer PlugNPiN** n’est pas sélectionné et sauvegardé. Son activation crée la stack gérée `plugnpin-dockge-enhanced` ; sa désactivation exécute Compose down puis retire le dossier généré.
+Ouvrez **Paramètres → Intégrations** pour configurer [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN). L’intégration reste totalement inactive tant que **Activer PlugNPiN** n’est pas sélectionné et sauvegardé. Son activation crée la stack gérée `plugnpin-dockge-enhanced` ; sa désactivation exécute Compose down puis retire le dossier généré.
 
 Les identifiants Nginx Proxy Manager sont obligatoires pour PlugNPiN. Pi-hole, AdGuard Home, les métriques et les logs debug restent facultatifs et indépendants. Les mots de passe sont écrits via l’entrée standard dans le volume Docker dédié `dockge_enhanced_plugnpin_secrets` ; ils ne sont jamais renvoyés au navigateur ni inclus dans le Compose généré.
 
-Pour publier un service, édite sa stack puis utilise **Publication PlugNPiN (facultative)** sous l’éditeur Compose. L’assistant génère et peut appliquer les labels obligatoires `plugNPiN.ip` et `plugNPiN.url`, ainsi que les options NPM sélectionnées. Les commentaires et labels existants sous forme de mapping sont préservés. Pour les labels sous forme de liste, Dockge fournit volontairement uniquement le YAML à copier au lieu de réécrire la structure existante.
+Pour publier un service, éditez sa stack puis utilisez **Publication PlugNPiN (facultative)** sous l’éditeur Compose. L’assistant génère et peut appliquer les labels obligatoires `plugNPiN.ip` et `plugNPiN.url`, ainsi que les options NPM sélectionnées. Les commentaires et labels existants sous forme de mapping sont préservés. Pour les labels sous forme de liste, Dockge fournit volontairement uniquement le YAML à copier au lieu de réécrire la structure existante.
 
-> La désactivation du contrôleur arrête ses conteneurs, mais ne peut pas garantir la suppression immédiate des entrées qu’il a créées lorsque les conteneurs applicatifs étiquetés fonctionnent encore. Retire les labels ou arrête les applications concernées pendant que PlugNPiN fonctionne si ces entrées doivent d’abord être supprimées.
+> La désactivation du contrôleur arrête ses conteneurs, mais ne peut pas garantir la suppression immédiate des entrées qu’il a créées lorsque les conteneurs applicatifs étiquetés fonctionnent encore. Retirez les labels ou arrêtez les applications concernées pendant que PlugNPiN fonctionne si ces entrées doivent d’abord être supprimées.
 
 > PlugNPiN `1.0.0` est actuellement publié en amont uniquement pour `amd64`. Dockge maintient l’intégration désactivée avec un message explicite sur les architectures non prises en charge ; le reste de Dockge Enhanced demeure multi-architecture.
 
@@ -538,9 +559,9 @@ Pour publier un service, édite sa stack puis utilise **Publication PlugNPiN (fa
 
 ### Authentification et premier setup
 
-**Installation existante : rien à changer.** Sans les variables ci-dessus, les comptes, la page de connexion, la 2FA et le réglage **Désactiver l’authentification** fonctionnent comme avant. Au premier démarrage d’une installation neuve, ouvre simplement `/setup` et crée l’administrateur. Une fois l’installation terminée, le serveur refuse toute nouvelle tentative de setup, même si l’URL SPA reste connue.
+**Installation existante : rien à changer.** Sans les variables ci-dessus, les comptes, la page de connexion, la 2FA et le réglage **Désactiver l’authentification** fonctionnent comme avant. Au premier démarrage d’une installation neuve, ouvrez simplement `/setup` et créez l’administrateur. Une fois l’installation terminée, le serveur refuse toute nouvelle tentative de setup, même si l’URL SPA reste connue.
 
-Pour un bootstrap non interactif, monte de préférence un secret puis renseigne uniquement ces variables optionnelles :
+Pour un bootstrap non interactif, montez de préférence un secret puis renseignez uniquement ces variables optionnelles :
 
 ```yaml
 services:
@@ -567,7 +588,7 @@ environment:
   - DOCKGE_AUTH_PROXY_TRUSTED_NETWORKS=172.20.0.0/24
 ```
 
-Remplace le CIDR d’exemple par le réseau exact de ton proxy et configure celui-ci pour transmettre le header choisi. Le port Dockge ne doit pas être accessible directement : seuls les proxies déclarés peuvent fournir une identité. Tous les utilisateurs autorisés par le proxy disposent des droits administrateur dans Dockge Enhanced, qui ne propose pas encore de rôles distincts. Ne place jamais `/setup`, `/socket.io` ou `/api/*` dans une règle sans authentification ; le proxy doit transmettre les WebSockets et protéger tout le host.
+Remplacez le CIDR d’exemple par le réseau exact de votre proxy et configurez celui-ci pour transmettre le header choisi. Le port Dockge ne doit pas être accessible directement : seuls les proxies déclarés peuvent fournir une identité. Tous les utilisateurs autorisés par le proxy disposent des droits administrateur dans Dockge Enhanced, qui ne propose pas encore de rôles distincts. Ne placez jamais `/setup`, `/socket.io` ou `/api/*` dans une règle sans authentification ; le proxy doit transmettre les WebSockets et protéger tout le host.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,39 +3,6 @@
 </p>
 
 # Dockge Enhanced
-> [!WARNING]
-> ## Critical Dockge-Enhanced self-update fix
->
-> Several builds published between **August 31, 2026 and September 2, 2026** contained defects in the Dockge-Enhanced self-update mechanism.
->
-> Under certain conditions, the sidecar could stop the Dockge-Enhanced container, fail to create the new version and, on some builds, also fail to automatically restore the previous one.
->
-> The mechanism has since been fixed and hardened. Starting with build **`0fc2564` / version 1.5.4**, self-update:
->
-> - always pulls the latest `dockge-enhanced-updater:latest` before each update;
-> - explicitly pulls the target Dockge-Enhanced image;
-> - performs a mandatory Restic backup before replacement;
-> - verifies the new container before confirming the update;
-> - keeps rollback support and a recovery snapshot.
->
-> **If your installation is running a build older than `0fc2564` / version 1.5.4, perform one final manual update before enabling or re-enabling automatic updates:**
->
-> ```bash
-> docker pull ghcr.io/aerya/dockge-enhanced:latest
-> docker compose up -d
-> ```
->
-> Once this update is complete, you can enable **Automatic via protected sidecar**. Subsequent updates are then handled automatically by Dockge-Enhanced.
->
-> **Stacks managed by Dockge-Enhanced and their persistent data are not affected by this issue.**
->
-> My apologies to everyone affected. A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helped identify and fix these defects quickly.
-
----
-
-**My apologies to everyone affected.** A feature specifically designed to make updates safer should obviously never be able to leave Dockge-Enhanced offline. Thank you to everyone using, testing and reporting issues — your feedback helped identify and fix these defects quickly.
-
-
 
 A feature-focused fork of [Dockge](https://github.com/louislam/dockge) that turns its simple Compose management experience into a broader Docker management platform — with multi-server federation, stack migration and replication, Restic backups, image and self-updates with rollback, security scanning, monitoring, automation, notifications, and Docker resource management, all from the web UI.
 
@@ -48,7 +15,6 @@ A feature-focused fork of [Dockge](https://github.com/louislam/dockge) that turn
 
 <p align="center">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
-  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=active%20installs&color=blue" alt="Active installations"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
@@ -499,6 +465,58 @@ Open **http://localhost:5001**, create your admin account, then click **Monitori
 > ```yaml
 >       - /mnt/data:/mnt/data:ro
 > ```
+
+### Testing Dockge-Enhanced alongside Dockge
+
+Dockge and Dockge-Enhanced can run on the same Docker host, but their default Compose configurations cannot be used unchanged because both publish port `5001`.
+
+To test them side by side:
+
+- install Dockge-Enhanced from a separate Compose directory;
+- use another host port, for example `5002:5001`;
+- use a separate `/app/data` directory;
+- preferably use a separate stacks directory with a dedicated test stack.
+
+Example:
+
+```yaml
+ports:
+  - 5002:5001
+volumes:
+  - ./enhanced-data:/app/data
+  - /opt/dockge-enhanced-test-stacks:/opt/stacks
+environment:
+  - DOCKGE_STACKS_DIR=/opt/stacks
+  - DOCKGE_DATA_DIR=/app/data
+```
+
+You can then open Dockge-Enhanced at **http://localhost:5002** while your existing Dockge installation remains available on port `5001`.
+
+Both applications may access the same stacks directory, but they should never edit, deploy, update or otherwise operate on the same stack **simultaneously**. Using a separate stacks directory for testing is safer.
+
+### Migrating from Dockge to Dockge-Enhanced
+
+Migration is straightforward because Dockge-Enhanced shares the same foundation as Dockge:
+
+1. Stop Dockge.
+2. Back up your Dockge Compose file, data directory and stacks directory.
+3. In your existing Dockge Compose file, replace the image with:
+
+   ```yaml
+   image: ghcr.io/aerya/dockge-enhanced:latest
+   ```
+
+4. Keep your existing `/app/data` and stacks volume mappings.
+5. Pull the image and restart the Compose project:
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+Dockge-Enhanced will start with your existing account, settings and stacks.
+
+Keep the backup created before migration. If you decide to return to Dockge, stop Dockge-Enhanced and restore that backup before restarting the original Dockge image.
 
 ### Optional PlugNPiN integration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,64 +3,6 @@
 </p>
 
 # Dockge Enhanced
-> [!WARNING]
-> ## Dockge-Enhanced 自动更新关键修复
->
-> **2026 年 8 月 31 日至 2026 年 9 月 2 日** 期间发布的多个 build 在 Dockge-Enhanced 自动更新机制中存在缺陷。
->
-> 在某些情况下，sidecar 可能会停止 Dockge-Enhanced 容器，但随后无法创建新版本；在部分 build 中，也可能无法自动恢复之前的版本。
->
-> 该机制现已修复并进一步加强。从 build **`0fc2564` / 版本 1.5.4** 开始，自动更新会：
->
-> - 在每次更新前始终拉取最新的 `dockge-enhanced-updater:latest`；
-> - 显式拉取目标 Dockge-Enhanced 镜像；
-> - 在替换前执行强制 Restic 备份；
-> - 在确认更新成功前验证新容器；
-> - 保留 rollback 机制和恢复 snapshot。
->
-> **如果您的安装版本早于 `0fc2564` / 1.5.4，请在启用或重新启用自动更新前，最后手动更新一次：**
->
-> ```bash
-> docker pull ghcr.io/aerya/dockge-enhanced:latest
-> docker compose up -d
-> ```
->
-> 完成此次更新后，即可启用 **通过受保护 sidecar 自动更新**；之后的更新将由 Dockge-Enhanced 自动处理。
->
-> **Dockge-Enhanced 管理的 stacks 及其持久化数据不受此问题影响。**
->
-> 对于受到影响的用户，我深表歉意。一个本应让更新更加安全的功能，不应该让 Dockge-Enhanced 自身处于离线状态。感谢所有使用、测试并反馈问题的用户，你们的反馈帮助我们快速定位并修复了这些缺陷。
-
----
-
-⚠️ **重要 — Dockge-Enhanced 自动更新关键修复**
-⚠️ **重要 — Dockge-Enhanced 自动更新关键修复**
-
-**2026 年 8 月 31 日至 2026 年 9 月 2 日** 期间发布的多个 build 在 Dockge-Enhanced 自动更新机制中存在缺陷。
-
-在某些情况下，sidecar 可能会停止 Dockge-Enhanced 容器，但随后无法创建新版本；在部分 build 中，也可能无法自动恢复之前的版本。
-
-该机制现已修复并进一步加强。从 build **`0fc2564` / 版本 1.5.4** 开始，自动更新会：
-
-- 在每次更新前始终拉取最新的 `dockge-enhanced-updater:latest`；
-- 显式拉取目标 Dockge-Enhanced 镜像；
-- 在替换前执行强制 Restic 备份；
-- 在确认更新成功前验证新容器；
-- 保留 rollback 机制和恢复 snapshot。
-
-**如果您的安装版本早于 `0fc2564` / 1.5.4，请在启用或重新启用自动更新前，最后手动更新一次：**
-
-```bash
-docker pull ghcr.io/aerya/dockge-enhanced:latest
-docker compose up -d
-```
-
-完成此次更新后，即可启用 **通过受保护 sidecar 自动更新**；之后的更新将由 Dockge-Enhanced 自动处理。
-
-Dockge-Enhanced 管理的 stacks 及其持久化数据不受此问题影响。
-
-**对于受到影响的用户，我深表歉意。** 一个本应让更新更加安全的功能，不应该让 Dockge-Enhanced 自身处于离线状态。感谢所有使用、测试并反馈问题的用户，你们的反馈帮助我们快速定位并修复了这些缺陷。
-
 [Dockge](https://github.com/louislam/dockge) 的功能增强分支，在保留简洁 Docker Compose 管理体验的基础上，将其扩展为更完整的 Docker 管理平台 —— 提供多服务器联邦、Stack 迁移与复制、Restic 备份、镜像与 Dockge-Enhanced 自更新及回滚、安全扫描、监控、自动化、通知和 Docker 资源管理，并全部集成于 Web UI。
 
 <p align="center">
@@ -72,7 +14,6 @@ Dockge-Enhanced 管理的 stacks 及其持久化数据不受此问题影响。
 
 <p align="center">
   <img src="https://github.com/Aerya/Dockge-Enhanced/actions/workflows/build-publish.yml/badge.svg?branch=main" alt="Build">
-  <a href="https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count"><img src="https://img.shields.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/2026-09.txt?displayAssetName=false&label=%E6%B4%BB%E8%B7%83%E5%AE%89%E8%A3%85&color=blue" alt="活跃安装"></a>
   <img src="https://img.shields.io/badge/arch-amd64%20%7C%20arm64-lightgrey" alt="multi-arch">
   <img src="https://img.shields.io/badge/i18n-EN%20%7C%20FR%20%7C%20ES%20%7C%20zh--CN-blue" alt="i18n">
   <img src="https://img.shields.io/badge/based%20on-Dockge-orange?logo=github&logoColor=white" alt="based on Dockge">
@@ -358,6 +299,58 @@ docker compose up -d
 > 如果要备份多个数据目录，可以添加多个 volume，然后在 **Backup** 页面中的 **Additional paths** 注册对应的容器路径。
 
 > 如果要监控 `/` 之外的主机磁盘分区，请把目标路径只读挂载到容器，并在 **Monitoring** 页面中加入该路径。
+
+### 与 Dockge 并行测试 Dockge-Enhanced
+
+Dockge 和 Dockge-Enhanced 可以运行在同一台 Docker 主机上，但不能直接同时使用默认 Compose 配置，因为两者都会发布端口 `5001`。
+
+如需并行测试：
+
+- 从单独的 Compose 目录安装 Dockge-Enhanced；
+- 使用另一个主机端口，例如 `5002:5001`；
+- 使用独立的 `/app/data` 目录；
+- 建议使用独立的 stacks 目录，并只放置专用于测试的 stack。
+
+示例：
+
+```yaml
+ports:
+  - 5002:5001
+volumes:
+  - ./enhanced-data:/app/data
+  - /opt/dockge-enhanced-test-stacks:/opt/stacks
+environment:
+  - DOCKGE_STACKS_DIR=/opt/stacks
+  - DOCKGE_DATA_DIR=/app/data
+```
+
+随后可通过 **http://localhost:5002** 打开 Dockge-Enhanced，同时原有 Dockge 仍可通过端口 `5001` 访问。
+
+两个应用可以访问同一个 stacks 目录，但绝不能**同时**编辑、部署、更新或以其他方式操作同一个 stack。使用独立的 stacks 目录进行测试更安全。
+
+### 从 Dockge 迁移到 Dockge-Enhanced
+
+Dockge-Enhanced 与 Dockge 基于相同的基础，因此迁移很简单：
+
+1. 停止 Dockge。
+2. 备份 Dockge 的 Compose 文件、数据目录和 stacks 目录。
+3. 在现有 Dockge Compose 文件中，将镜像替换为：
+
+   ```yaml
+   image: ghcr.io/aerya/dockge-enhanced:latest
+   ```
+
+4. 保留现有的 `/app/data` 和 stacks volume 映射。
+5. 拉取镜像并重新启动 Compose 项目：
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+Dockge-Enhanced 将使用您现有的账号、设置和 stacks 启动。
+
+请保留迁移前创建的备份。如果决定返回 Dockge，请先停止 Dockge-Enhanced，恢复该备份，然后再启动原始 Dockge 镜像。
 
 ### 可选 PlugNPiN 集成
 


### PR DESCRIPTION
## Résumé

- documente le test de Dockge-Enhanced à côté de Dockge et les répertoires qui doivent rester séparés ;
- ajoute une procédure de migration et de retour arrière en anglais, français, espagnol et chinois simplifié ;
- retire l’ancien avertissement d’auto-mise à jour et le badge d’installations actives des README ;
- harmonise le vouvoiement dans les instructions françaises concernées.

Closes #359
