### PR TITLE
Alléger les README et actualiser le catalogue

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -55,7 +55,10 @@ Un fork de [Dockge](https://github.com/louislam/dockge) centrado en ampliar sus 
 
 ## Últimas novedades
 
-Los cambios recientes más importantes permanecen visibles directamente en el README para entender rápidamente qué ha cambiado en Dockge-Enhanced.
+<details>
+<summary>Mostrar las últimas novedades</summary>
+
+Los cambios recientes más importantes se agrupan aquí para entender rápidamente qué ha cambiado en Dockge-Enhanced.
 
 ### 🆕 Septiembre de 2026
 
@@ -172,9 +175,14 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 
 ➡️ **[Consultar el changelog completo](CHANGELOG.es-ES.md)**
 
+</details>
+
 ---
 
 ## Catálogo de funcionalidades
+
+<details>
+<summary>Mostrar todas las funcionalidades</summary>
 
 ### Multiservidor y federación
 - Federación en malla completa
@@ -182,16 +190,22 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - Selección y agrupación de servidores
 - Estado remoto de stacks y actualizaciones
 - Tokens de federación dedicados y recuperación de enlaces
+- Vista general de las instancias vinculadas con disponibilidad y acceso directo a su WebUI
+- Búsqueda global multiinstancia en stacks, archivos Compose/.env, recursos Docker y snapshots Restic recientes
+- Negociación de capacidades entre distintas versiones de Dockge-Enhanced
 
 ### Gestión de stacks
 - Crear, editar, iniciar, detener y recrear stacks Compose
-- Stacks fijadas y ordenación avanzada
+- Stacks fijadas en el servidor, compartidas entre las WebUI vinculadas, y ordenación avanzada
+- Detección e integración de stacks Compose externas sin mover archivos ni datos
+- Autorización protegida en un clic para las rutas de stacks externas
 - Notas y herramientas Git
 - Build + Recreate
 - Acciones por servicio/contenedor
 - Operaciones programadas
 - Requisitos de host y protecciones VPN
 - Barra lateral redimensionable con indicadores de recursos
+- Compatibilidad del editor con la sintaxis larga de puertos Compose y conservación de permisos `tmpfs`
 
 ### Migración y replicación
 - Copia o movimiento entre instancias
@@ -215,6 +229,8 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - Rollback, programación y pausas
 - Autoactualización protegida de Dockge-Enhanced
 - Copia Restic, integridad, readiness y recuperación automática
+- Bloqueo de la autoactualización mientras haya cambios Compose o `.env` sin guardar
+- Reconciliación del nombre de proyecto Compose y uso del contexto exacto de la stack durante las actualizaciones
 
 ### Seguridad
 - Validación centralizada de nombres de stacks para bloquear path traversal fuera del directorio gestionado
@@ -230,6 +246,7 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - Crash loops y auto-heal
 - Logs live/pantalla completa
 - Kula y Dozzle
+- Estadísticas CPU/RAM por stack de instancias locales y vinculadas
 
 ### Recursos Docker
 - Imágenes, volúmenes, redes y contenedores no gestionados
@@ -253,14 +270,19 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 ### Notificaciones y acceso
 - Discord y Apprise
 - EN / FR / ES / zh-CN
+- Anuncios operativos remotos
+- Historial persistente de novedades no leídas
 - 2FA, trusted proxy, Turnstile
 - Clientes móviles de terceros
 
----
+</details>
 
 ---
 
 ## Flujo de actualización automática de Dockge-Enhanced
+
+<details>
+<summary>Mostrar el proceso de actualización protegida</summary>
 
 Dockge-Enhanced gestiona automáticamente todo el flujo: copia Restic obligatoria, verificación de integridad, reemplazo controlado del contenedor, healthcheck y confirmación final. Las notificaciones Discord/Apprise permiten seguir la operación sin mantener abierta la WebUI.
 
@@ -277,7 +299,12 @@ Antes de iniciar una autoactualización, Enhanced comprueba también que no haya
 </tr>
 </table>
 
+</details>
+
 ## Capturas de pantalla
+
+<details>
+<summary>Mostrar las capturas de pantalla</summary>
 
 <table>
   <tr>
@@ -403,6 +430,9 @@ Antes de iniciar una autoactualización, Enhanced comprueba también que no haya
     </td>
   </tr>
 </table>
+
+</details>
+
 ---
 
 ## Instalación
@@ -498,6 +528,9 @@ Conserve la copia de seguridad creada antes de la migración. Si decide volver a
 
 ### Integración opcional PlugNPiN
 
+<details>
+<summary>Mostrar las instrucciones de configuración</summary>
+
 Abre **Configuración → Integraciones** para configurar [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN). La integración permanece totalmente inactiva hasta que se selecciona **Habilitar PlugNPiN** y se guarda el formulario. Habilitarlo crea el stack gestionado `plugnpin-dockge-enhanced`; deshabilitarlo ejecuta Compose down y elimina el directorio de stack generado.
 
 Las credenciales de Nginx Proxy Manager son requeridas por PlugNPiN. Pi-hole, AdGuard Home, métricas y registro de depuración permanecen opcionalmente individuales. Las contraseñas se escriben a través de stdin en el volumen Docker dedicado `dockge_enhanced_plugnpin_secrets` y nunca se devuelven al navegador ni se incluyen en el archivo Compose generado.
@@ -507,6 +540,8 @@ Para publicar un servicio, edita su stack y usa **Publicación PlugNPiN (opciona
 > Deshabilitar el controlador detiene sus contenedores pero no puede garantizar la eliminación inmediata de entradas que creó mientras los contenedores de aplicación etiquetados aún se están ejecutando. Elimina las etiquetas o detén las aplicaciones afectadas mientras PlugNPiN se está ejecutando si esas entradas deben eliminarse primero.
 
 > PlugNPiN `1.0.0` está actualmente publicado upstream solo para `amd64`. Dockge mantiene la integración deshabilitada con un mensaje claro en arquitecturas no compatibles; el resto de Dockge Enhanced permanece multi-arquitectura.
+
+</details>
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -53,7 +53,10 @@ Un fork de [Dockge](https://github.com/louislam/dockge) axé sur les fonctionnal
 
 ## Dernières nouveautés
 
-Les évolutions majeures récentes restent visibles directement dans le README afin de comprendre rapidement ce qui vient d'arriver dans Dockge-Enhanced.
+<details>
+<summary>Afficher les dernières nouveautés</summary>
+
+Les évolutions majeures récentes sont regroupées ici afin de comprendre rapidement ce qui vient d'arriver dans Dockge-Enhanced.
 
 ### 🆕 Septembre 2026
 
@@ -170,9 +173,14 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 
 ➡️ **[Consulter le changelog complet](CHANGELOG.fr.md)**
 
+</details>
+
 ---
 
 ## Catalogue des fonctionnalités
+
+<details>
+<summary>Afficher toutes les fonctionnalités</summary>
 
 ### Multi-serveurs & fédération
 - Fédération en maillage complet entre instances Dockge-Enhanced
@@ -182,10 +190,15 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Jetons de fédération dédiés
 - Récupération d'une liaison de fédération cassée
 - Gestion multi-instance unifiée
+- Vue d’ensemble des instances liées avec accessibilité et accès direct à leur WebUI
+- Recherche globale multi-instance dans les stacks, fichiers Compose/.env, ressources Docker et snapshots Restic récents
+- Négociation des capacités entre différentes versions de Dockge-Enhanced
 
 ### Gestion des stacks
 - Création, édition, démarrage, arrêt et recréation des stacks Compose
-- Stacks épinglées
+- Stacks épinglées côté serveur et partagées entre les WebUI liées
+- Détection et intégration de stacks Compose externes sans déplacer leurs fichiers ni leurs données
+- Autorisation protégée en un clic des chemins de stacks externes
 - Tri par date de création ou dernière mise à jour
 - Notes par stack
 - Outils Git
@@ -196,6 +209,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Protections pour les services partageant le namespace réseau d'un VPN
 - Colonne des stacks repliable et redimensionnable
 - Indicateurs compacts d'état, CPU et RAM
+- Prise en charge des ports Compose en syntaxe longue et préservation des permissions `tmpfs` dans l’éditeur
 
 ### Migration & réplication
 - Copie ou déplacement de stacks entre instances
@@ -231,6 +245,8 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Auto-mise à jour protégée de Dockge-Enhanced
 - Backup Restic et contrôle d'intégrité obligatoires
 - Vérification de disponibilité et récupération automatique
+- Blocage du self-update tant que des modifications Compose ou `.env` ne sont pas enregistrées
+- Réconciliation du nom de projet Compose et respect du contexte exact de la stack pendant les mises à jour
 
 ### Sécurité
 - Validation centralisée des noms de stacks pour bloquer tout path traversal hors du répertoire géré
@@ -252,6 +268,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Logs live et plein écran
 - Pause de l'autoscroll et gestion des longues lignes
 - Intégrations Kula et Dozzle
+- Statistiques CPU/RAM par stack pour les instances locales et liées
 
 ### Ressources Docker
 - Images, volumes, réseaux et conteneurs non gérés
@@ -275,14 +292,19 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 ### Notifications & accès
 - Discord et Apprise
 - Notifications localisées en EN / FR / ES / zh-CN
+- Annonces opérationnelles distantes
+- Journal persistant des nouveautés non lues
 - 2FA, trusted proxy et Cloudflare Turnstile
 - Clients mobiles tiers
 
----
+</details>
 
 ---
 
 ## Déroulement d’une mise à jour automatique de Dockge-Enhanced
+
+<details>
+<summary>Afficher le fonctionnement de la mise à jour protégée</summary>
 
 Dockge-Enhanced gère automatiquement le workflow complet : backup Restic obligatoire, vérification d’intégrité, remplacement contrôlé du conteneur, healthcheck puis confirmation finale. Les notifications Discord/Apprise permettent aussi de suivre l’opération sans rester devant la WebUI.
 
@@ -299,7 +321,12 @@ Avant de démarrer une auto-mise à jour, Enhanced vérifie aussi qu’aucune op
 </tr>
 </table>
 
+</details>
+
 ## Captures d'écran
+
+<details>
+<summary>Afficher les captures d’écran</summary>
 
 <table>
   <tr>
@@ -425,6 +452,9 @@ Avant de démarrer une auto-mise à jour, Enhanced vérifie aussi qu’aucune op
     </td>
   </tr>
 </table>
+
+</details>
+
 ---
 
 ## Installation
@@ -520,6 +550,9 @@ Conservez la sauvegarde réalisée avant la migration. Si vous souhaitez revenir
 
 ### Intégration PlugNPiN facultative
 
+<details>
+<summary>Afficher les instructions de configuration</summary>
+
 Ouvrez **Paramètres → Intégrations** pour configurer [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN). L’intégration reste totalement inactive tant que **Activer PlugNPiN** n’est pas sélectionné et sauvegardé. Son activation crée la stack gérée `plugnpin-dockge-enhanced` ; sa désactivation exécute Compose down puis retire le dossier généré.
 
 Les identifiants Nginx Proxy Manager sont obligatoires pour PlugNPiN. Pi-hole, AdGuard Home, les métriques et les logs debug restent facultatifs et indépendants. Les mots de passe sont écrits via l’entrée standard dans le volume Docker dédié `dockge_enhanced_plugnpin_secrets` ; ils ne sont jamais renvoyés au navigateur ni inclus dans le Compose généré.
@@ -529,6 +562,8 @@ Pour publier un service, éditez sa stack puis utilisez **Publication PlugNPiN (
 > La désactivation du contrôleur arrête ses conteneurs, mais ne peut pas garantir la suppression immédiate des entrées qu’il a créées lorsque les conteneurs applicatifs étiquetés fonctionnent encore. Retirez les labels ou arrêtez les applications concernées pendant que PlugNPiN fonctionne si ces entrées doivent d’abord être supprimées.
 
 > PlugNPiN `1.0.0` est actuellement publié en amont uniquement pour `amd64`. Dockge maintient l’intégration désactivée avec un message explicite sur les architectures non prises en charge ; le reste de Dockge Enhanced demeure multi-architecture.
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ A feature-focused fork of [Dockge](https://github.com/louislam/dockge) that turn
 
 ## Latest updates
 
-Major recent changes remain visible directly in the README so you can quickly see what has changed in Dockge-Enhanced.
+<details>
+<summary>Show the latest changes</summary>
+
+The most important recent changes are grouped here so you can quickly see what has changed in Dockge-Enhanced.
 
 ### 🆕 September 2026
 
@@ -170,9 +173,14 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 
 ➡️ **[View the complete changelog](CHANGELOG.md)**
 
+</details>
+
 ---
 
 ## Feature catalogue
+
+<details>
+<summary>Show all features</summary>
 
 ### Multi-server & federation
 - Full-mesh federation between Dockge-Enhanced instances
@@ -182,10 +190,15 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Dedicated federation tokens
 - Recovery of broken federation links
 - Unified multi-instance management
+- Linked-instance overview with reachability and direct WebUI access
+- Global multi-instance search across stacks, Compose/.env files, Docker resources and recent Restic snapshots
+- Version-aware capability negotiation between mixed Dockge-Enhanced releases
 
 ### Stack management
 - Create, edit, start, stop and recreate Compose stacks
-- Pinned stacks
+- Server-persisted pinned stacks shared across linked WebUIs
+- External Compose stack discovery and adoption without moving files or data
+- Protected one-click authorization for external stack paths
 - Sort by creation date or last update
 - Per-stack notes
 - Git tools
@@ -196,6 +209,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Safeguards for shared VPN network namespaces
 - Collapsible and resizable stack sidebar
 - Compact status, CPU and RAM indicators
+- Compose editor support for long port syntax and preserved `tmpfs` permission modes
 
 ### Migration & replication
 - Copy or move stacks between instances
@@ -231,6 +245,8 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Protected Dockge-Enhanced self-update
 - Mandatory Restic backup and integrity verification
 - Readiness validation and automatic recovery
+- Protection against self-update while Compose or `.env` changes are unsaved
+- Compose project-name reconciliation and exact stack context during updates
 
 ### Security
 - Centralized stack-name validation blocks path traversal outside the managed stacks directory
@@ -252,6 +268,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Live and fullscreen logs
 - Autoscroll pause and long-line handling
 - Kula and Dozzle integrations
+- Per-stack CPU/RAM statistics from local and linked instances
 
 ### Docker resources
 - Images, volumes, networks and unmanaged containers
@@ -275,14 +292,19 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 ### Notifications & access
 - Discord and Apprise
 - Notifications localized in EN / FR / ES / zh-CN
+- Remote operational announcements
+- Persistent unread release-news journal
 - 2FA, trusted proxy and Cloudflare Turnstile
 - Third-party mobile clients
 
----
+</details>
 
 ---
 
 ## Dockge-Enhanced automatic update workflow
+
+<details>
+<summary>Show the protected update workflow</summary>
 
 Dockge-Enhanced handles the complete workflow automatically: mandatory Restic backup, integrity verification, controlled container replacement, health check and final confirmation. Discord/Apprise notifications also let users follow the operation without keeping the WebUI open.
 
@@ -299,7 +321,12 @@ Before an automatic self-update starts, Enhanced also checks that no sensitive o
 </tr>
 </table>
 
+</details>
+
 ## Screenshots
+
+<details>
+<summary>Show screenshots</summary>
 
 <table>
   <tr>
@@ -425,6 +452,9 @@ Before an automatic self-update starts, Enhanced also checks that no sensitive o
     </td>
   </tr>
 </table>
+
+</details>
+
 ---
 
 ## Installation
@@ -520,6 +550,9 @@ Keep the backup created before migration. If you decide to return to Dockge, sto
 
 ### Optional PlugNPiN integration
 
+<details>
+<summary>Show setup details</summary>
+
 Open **Settings → Integrations** to configure [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN). The integration remains fully inactive until **Enable PlugNPiN** is selected and the form is saved. Enabling it creates the managed `plugnpin-dockge-enhanced` stack; disabling it runs Compose down and removes the generated stack directory.
 
 Nginx Proxy Manager credentials are required by PlugNPiN. Pi-hole, AdGuard Home, metrics, and debug logging remain individually optional. Passwords are written through stdin into the dedicated `dockge_enhanced_plugnpin_secrets` Docker volume and are never returned to the browser or included in the generated Compose file.
@@ -529,6 +562,8 @@ To publish a service, edit its stack and use **PlugNPiN publication (optional)**
 > Disabling the controller stops its containers but cannot guarantee immediate removal of entries it created while labeled application containers are still running. Remove the labels or stop the affected applications while PlugNPiN is running if those entries must be deleted first.
 
 > PlugNPiN `1.0.0` is currently published upstream for `amd64` only. Dockge keeps the integration disabled with a clear message on unsupported architectures; the rest of Dockge Enhanced remains multi-architecture.
+
+</details>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,10 @@
 
 ## 最新动态
 
-README 会直接保留近期最重要的变化，方便快速了解 Dockge-Enhanced 最近新增了什么。
+<details>
+<summary>查看最新变化</summary>
+
+本节汇总近期最重要的变化，方便快速了解 Dockge-Enhanced 最近新增了什么。
 
 ### 🆕 2026 年 9 月
 
@@ -152,9 +155,14 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 
 ➡️ **[查看完整更新日志](CHANGELOG.zh-CN.md)**
 
+</details>
+
 ---
 
 ## 功能目录
+
+<details>
+<summary>查看全部功能</summary>
 
 ### 多服务器与联邦
 - 全网状联邦
@@ -162,15 +170,21 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - 服务器选择与分组
 - 远程 Stack 与更新状态
 - 专用联邦 Token 与连接恢复
+- 已连接实例概览、可达性状态和 WebUI 直达入口
+- 跨 Stack、Compose/.env 文件、Docker 资源和近期 Restic Snapshot 的全局多实例搜索
+- 不同 Dockge-Enhanced 版本之间的能力协商
 
 ### Stack 管理
 - 创建、编辑、启动、停止和重新创建 Compose Stack
-- 固定与排序
+- 服务端持久化并在关联 WebUI 间共享的固定 Stack 与排序
+- 无需移动文件或数据即可发现并接管外部 Compose Stack
+- 通过受保护的一键授权开放外部 Stack 路径
 - 备注和 Git 工具
 - Build + Recreate
 - 服务/容器级操作和计划任务
 - 主机前置条件与 VPN namespace 保护
 - 可折叠/调整大小的侧栏与资源指标
+- Compose 编辑器支持端口长语法并保留 `tmpfs` 权限模式
 
 ### 迁移与复制
 - 实例间复制或移动
@@ -195,6 +209,8 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - Dockge-Enhanced 受保护自动更新
 - 强制 Restic 备份、完整性和可用性检查
 - 失败时自动恢复
+- Compose 或 `.env` 存在未保存修改时阻止自更新
+- 更新时校准 Compose 项目名称并使用 Stack 的准确上下文
 
 ### 安全
 - 集中验证 Stack 名称，阻止路径遍历逃离受管理的 Stack 目录
@@ -210,6 +226,7 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - Crash loop 与 healthcheck 自动修复
 - 实时/全屏日志
 - Kula 与 Dozzle
+- 本地及已连接实例的每 Stack CPU/RAM 统计
 
 ### Docker 资源
 - 镜像、卷、网络和未管理容器
@@ -233,13 +250,19 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 ### 通知与访问
 - Discord 与 Apprise
 - EN / FR / ES / zh-CN
+- 远程运维公告
+- 持久化的未读版本新闻记录
 - 2FA、trusted proxy、Turnstile
 - 第三方移动客户端
 
----
+</details>
+
 ---
 
 ## Dockge-Enhanced 自动更新流程
+
+<details>
+<summary>查看受保护的更新流程</summary>
 
 Dockge-Enhanced 会自动处理完整流程：强制 Restic 备份、完整性验证、受控替换容器、健康检查和最终确认。Discord/Apprise 通知也可以在无需一直打开 WebUI 的情况下跟踪操作。
 
@@ -256,9 +279,16 @@ Dockge-Enhanced 会自动处理完整流程：强制 Restic 备份、完整性�
 </tr>
 </table>
 
+</details>
+
 ## 截图
 
+<details>
+<summary>查看截图</summary>
+
 项目截图位于 [`screens/`](screens/) 目录。主 README 中展示了界面、更新、备份、Trivy、Discord 通知和多实例功能的最新截图。
+
+</details>
 
 ---
 
@@ -354,9 +384,14 @@ Dockge-Enhanced 将使用您现有的账号、设置和 stacks 启动。
 
 ### 可选 PlugNPiN 集成
 
+<details>
+<summary>查看配置说明</summary>
+
 在 **Settings → Integrations** 中配置 [PlugNPiN](https://github.com/DeepSpace2/PlugNPiN)。只有明确启用并保存后，Dockge Enhanced 才会创建受管的 `plugnpin-dockge-enhanced` Stack。
 
 Nginx Proxy Manager 凭据是必需的；Pi-hole、AdGuard Home、metrics 和 debug 日志均可单独选择。密码通过 stdin 写入专用 Docker volume，不会返回浏览器，也不会写入生成的 Compose 文件。
+
+</details>
 
 ---
 


### PR DESCRIPTION
## Résumé

- replie par défaut les nouveautés, le catalogue, le workflow d’auto-mise à jour, les captures et les instructions PlugNPiN ;
- actualise le catalogue avec les fonctions récentes de Dockge-Enhanced dans les quatre README traduits ;
- supprime les séparateurs Markdown en double.
