### PR TITLE
Notifier le compteur anonyme sur Discord

### DIFF
--- a/.github/workflows/usage-count-asset.yml
+++ b/.github/workflows/usage-count-asset.yml
@@ -1,8 +1,9 @@
-name: Compteur mensuel anonyme
+name: Compteur anonyme et notifications
 
 on:
   schedule:
-    - cron: "17 0 1 * *"
+    - cron: "17 8 1 * *"
+    - cron: "27 8 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -44,47 +45,88 @@ jobs:
           printf 'Dockge-Enhanced anonymous installation count %s\n' "$month" > "$asset"
           gh release upload usage-count "$asset" --repo "$GITHUB_REPOSITORY"
 
-      - name: Pointer les badges vers le mois courant
+      - name: Préparer le rapport d'utilisation
+        id: report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
+          report_type="weekly"
           month="$(date -u +%Y-%m)"
-          python3 - "$month" <<'PYBADGE'
-          import re
-          import sys
-          from pathlib import Path
 
-          month = sys.argv[1]
-          files = [
-              Path("README.md"),
-              Path("README.fr.md"),
-              Path("README.es-ES.md"),
-              Path("README.zh-CN.md"),
-          ]
+          if [[ "$EVENT_NAME" == "schedule" && "$TRIGGER_SCHEDULE" == "17 8 1 * *" ]]; then
+            report_type="monthly"
+            month="$(date -u -d '1 month ago' +%Y-%m)"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            report_type="manual"
+          fi
 
-          pattern = re.compile(
-              r"(https://img\.shields\.io/github/downloads/Aerya/Dockge-Enhanced/usage-count/)"
-              r"\d{4}-\d{2}"
-              r"(\.txt\?displayAssetName=false&label=)"
-          )
-
-          for file in files:
-              text = file.read_text(encoding="utf-8")
-              updated, count = pattern.subn(rf"\g<1>{month}\g<2>", text)
-              if count != 1:
-                  raise SystemExit(
-                      f"{file}: badge mensuel introuvable ou ambigu ({count})"
-                  )
-              file.write_text(updated, encoding="utf-8")
-          PYBADGE
-
-          if git diff --quiet -- README.md README.fr.md README.es-ES.md README.zh-CN.md; then
-            echo "Badges déjà positionnés sur ${month}."
+          asset_json="$(gh release view usage-count --repo "$GITHUB_REPOSITORY" --json assets --jq ".assets[] | select(.name == \"${month}.txt\")")"
+          if [[ -z "$asset_json" ]]; then
+            echo "Aucun asset disponible pour ${month}; notification ignorée."
+            echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md README.fr.md README.es-ES.md README.zh-CN.md
-          git commit -m "docs: actualiser le badge des installations actives"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          count="$(jq -r '.downloadCount' <<<"$asset_json")"
+          created_at="$(jq -r '.createdAt' <<<"$asset_json")"
+          {
+            echo "available=true"
+            echo "report_type=$report_type"
+            echo "month=$month"
+            echo "count=$count"
+            echo "created_at=$created_at"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Envoyer le compteur sur Discord
+        if: steps.report.outputs.available == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.USAGE_COUNT_DISCORD_WEBHOOK }}
+          REPORT_TYPE: ${{ steps.report.outputs.report_type }}
+          REPORT_MONTH: ${{ steps.report.outputs.month }}
+          INSTALL_COUNT: ${{ steps.report.outputs.count }}
+          ASSET_CREATED_AT: ${{ steps.report.outputs.created_at }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$DISCORD_WEBHOOK" ]]; then
+            echo "Secret USAGE_COUNT_DISCORD_WEBHOOK absent; notification ignorée."
+            exit 0
+          fi
+
+          case "$DISCORD_WEBHOOK" in
+            https://discord.com/api/webhooks/*|https://discordapp.com/api/webhooks/*) ;;
+            *) echo "::error::USAGE_COUNT_DISCORD_WEBHOOK n'est pas un webhook Discord valide."; exit 1 ;;
+          esac
+
+          case "$REPORT_TYPE" in
+            monthly)
+              title="Dockge-Enhanced — bilan mensuel"
+              description="**${INSTALL_COUNT} installations actives estimées** pour ${REPORT_MONTH}."
+              ;;
+            manual)
+              title="Dockge-Enhanced — compteur demandé"
+              description="**${INSTALL_COUNT} installations actives estimées** pour ${REPORT_MONTH}, au moment de la demande."
+              ;;
+            *)
+              title="Dockge-Enhanced — point hebdomadaire"
+              description="**${INSTALL_COUNT} installations actives estimées** pour ${REPORT_MONTH}, à ce jour."
+              ;;
+          esac
+
+          description+=$'\nComptage anonyme basé sur les téléchargements de l’asset mensuel GitHub.'
+          if [[ "$REPORT_TYPE" != "monthly" ]]; then
+            description+=$'\nMesure commencée à la création de l’asset : '
+            description+="$ASSET_CREATED_AT"
+          fi
+
+          payload="$(jq -n \
+            --arg title "$title" \
+            --arg description "$description" \
+            '{username:"Dockge Enhanced", embeds:[{title:$title, description:$description, color:5793266, timestamp:(now | todateiso8601)}]}')"
+
+          curl --fail --silent --show-error \
+            -H "Content-Type: application/json" \
+            --data "$payload" \
+            "$DISCORD_WEBHOOK"

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -78,6 +78,8 @@ El mes ya contabilizado se guarda únicamente en el directorio de datos local pa
 
 El mecanismo es completamente público: [código en Enhanced](./backend/anonymous-install-count.ts), [workflow de GitHub que crea los assets mensuales](./.github/workflows/usage-count-asset.yml) y [contadores mensuales agregados](https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count).
 
+Los propietarios del repositorio pueden añadir un secreto de Actions llamado `USAGE_COUNT_DISCORD_WEBHOOK` para recibir un conteo provisional cada lunes y el total definitivo del mes anterior el primer día de cada mes. El workflow también puede ejecutarse manualmente para enviar el conteo actual de inmediato. El valor del webhook permanece cifrado por GitHub y nunca se guarda en el repositorio.
+
 **Búsqueda global multi-instancia V2 (`Ctrl+K`)**
 
 La paleta global admite ahora **búsqueda difusa** para pequeños errores de escritura y operadores asistidos como `type:`, `stack:`, `image:`, `port:`, `instance:` y filtros operativos `is:update`, `is:stopped`, `is:vulnerable`, `is:critical` e `is:backup-failed`. Los operadores aparecen como botones dentro de la propia paleta, por lo que no hace falta memorizar la sintaxis. Los resultados Compose y `.env` abren la stack correspondiente y llevan CodeMirror directamente a la línea encontrada. Las búsquedas recientes y fijadas se guardan localmente en el navegador.
@@ -272,6 +274,7 @@ La navegación, Logs/Compose, indicadores de recursos, tarjetas de salud, temas 
 - EN / FR / ES / zh-CN
 - Anuncios operativos remotos
 - Historial persistente de novedades no leídas
+- Informes opcionales semanales y mensuales del conteo anónimo mediante un webhook de Discord en GitHub Actions
 - 2FA, trusted proxy, Turnstile
 - Clientes móviles de terceros
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -76,6 +76,8 @@ Le mois déjà compté est mémorisé uniquement dans le répertoire de données
 
 Le mécanisme est entièrement public : [code côté Enhanced](./backend/anonymous-install-count.ts), [workflow GitHub qui crée les assets mensuels](./.github/workflows/usage-count-asset.yml) et [compteurs mensuels agrégés](https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count).
 
+Les propriétaires du dépôt peuvent ajouter un secret Actions nommé `USAGE_COUNT_DISCORD_WEBHOOK` pour recevoir un compteur provisoire chaque lundi et le total définitif du mois précédent le premier jour de chaque mois. Le workflow peut également être lancé manuellement afin d’envoyer immédiatement le compteur actuel. La valeur du webhook reste chiffrée par GitHub et n’est jamais enregistrée dans le dépôt.
+
 **Recherche globale multi-instance V2 (`Ctrl+K`)**
 
 La palette globale accepte désormais les **correspondances floues** pour tolérer de petites fautes de frappe et des opérateurs assistés comme `type:`, `stack:`, `image:`, `port:`, `instance:` ainsi que des filtres opérationnels `is:update`, `is:stopped`, `is:vulnerable`, `is:critical` et `is:backup-failed`. Des boutons d’aide sont affichés directement dans la palette : il n’est pas nécessaire de mémoriser cette syntaxe. Un résultat Compose ou `.env` ouvre la bonne stack et positionne directement CodeMirror sur la ligne trouvée. Les recherches récentes et les recherches épinglées sont conservées localement dans le navigateur.
@@ -294,6 +296,7 @@ La navigation des stacks, l'espace Logs/Compose, les indicateurs de ressources, 
 - Notifications localisées en EN / FR / ES / zh-CN
 - Annonces opérationnelles distantes
 - Journal persistant des nouveautés non lues
+- Rapports facultatifs hebdomadaires et mensuels du comptage anonyme via un webhook Discord GitHub Actions
 - 2FA, trusted proxy et Cloudflare Turnstile
 - Clients mobiles tiers
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The already-counted month is stored only in the local data directory so the same
 
 The mechanism is fully public: [Enhanced-side code](./backend/anonymous-install-count.ts), [GitHub workflow that creates the monthly assets](./.github/workflows/usage-count-asset.yml), and [aggregate monthly counters](https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count).
 
+Repository owners can add an Actions secret named `USAGE_COUNT_DISCORD_WEBHOOK` to receive a provisional count every Monday and the final count for the previous month on the first day of each month. The workflow can also be run manually to send the current count immediately. The webhook value remains encrypted by GitHub and is never committed to the repository.
+
 **Global multi-instance search V2 (`Ctrl+K`)**
 
 The global palette now supports **fuzzy matching** for small typing mistakes and assisted operators such as `type:`, `stack:`, `image:`, `port:`, `instance:` and operational filters including `is:update`, `is:stopped`, `is:vulnerable`, `is:critical` and `is:backup-failed`. Operator chips are displayed directly in the palette so the syntax does not need to be memorized. Compose and `.env` results open the matching stack and scroll CodeMirror directly to the matching line. Recent searches and pinned searches are stored locally in the browser.
@@ -294,6 +296,7 @@ Stack navigation, the Logs/Compose workspace, resource indicators, health cards,
 - Notifications localized in EN / FR / ES / zh-CN
 - Remote operational announcements
 - Persistent unread release-news journal
+- Optional weekly and monthly anonymous installation-count reports via a GitHub Actions Discord webhook
 - 2FA, trusted proxy and Cloudflare Turnstile
 - Third-party mobile clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,8 @@ Enhanced 现在可以检测现有 Docker Compose 项目，并在**不移动 Comp
 
 整个机制完全公开：[Enhanced 端代码](./backend/anonymous-install-count.ts)、[创建每月 asset 的 GitHub workflow](./.github/workflows/usage-count-asset.yml)以及[每月聚合计数](https://github.com/Aerya/Dockge-Enhanced/releases/tag/usage-count)。
 
+仓库所有者可以添加名为 `USAGE_COUNT_DISCORD_WEBHOOK` 的 Actions Secret，以便每周一接收当月暂定计数，并在每月第一天接收上个月的最终计数。也可以手动运行 workflow，立即发送当前计数。Webhook 值由 GitHub 加密，绝不会提交到仓库。
+
 **多实例全局搜索 V2（`Ctrl+K`）**
 
 全局搜索现在支持用于小型输入错误的**模糊匹配**，以及 `type:`、`stack:`、`image:`、`port:`、`instance:` 和 `is:update`、`is:stopped`、`is:vulnerable`、`is:critical`、`is:backup-failed` 等辅助筛选。面板会直接显示可点击的操作符提示，无需记忆语法。Compose 和 `.env` 结果会打开对应 Stack，并让 CodeMirror 直接定位到匹配行。最近搜索和固定搜索只保存在当前浏览器中。
@@ -252,6 +254,7 @@ Stack 导航、Logs/Compose、资源指标、健康卡片、主题和移动端�
 - EN / FR / ES / zh-CN
 - 远程运维公告
 - 持久化的未读版本新闻记录
+- 通过 GitHub Actions Discord Webhook 可选发送每周和每月匿名安装计数报告
 - 2FA、trusted proxy、Turnstile
 - 第三方移动客户端
 


### PR DESCRIPTION
## Résumé

- envoie chaque lundi le compteur provisoire des installations actives sur Discord ;
- envoie le premier jour du mois le bilan définitif du mois précédent ;
- permet un rapport immédiat par lancement manuel du workflow ;
- remplace l’ancienne mise à jour du badge supprimé et documente le secret nécessaire.
