### PR TITLE
Correction des tests de restauration sur les gros snapshots

### DIFF
--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -18,7 +18,7 @@ import { getNotificationLang, getNotificationLocale, notificationText, Notificat
 import { Settings } from "../settings";
 import { ValidationError } from "../util-server";
 import { log } from "../log";
-import { selectRestoreTestCandidate } from "./backup-restore-test";
+import { RestoreTestCandidateSelector } from "./backup-restore-test";
 import { ExternalStackManager } from "../external-stacks";
 
 const execAsync = promisify(exec);
@@ -955,17 +955,14 @@ export class BackupManager {
      * Timeout configurable (défaut 120 s).
      */
     /**
-     * lineFilter : filtre appliqué sur chaque ligne brute PENDANT le streaming,
-     * avant JSON.parse — évite d'accumuler des millions de lignes en mémoire.
-     * Utiliser des checks sur les chaînes (ex: line.includes('"type":"file"'))
-     * plutôt que JSON.parse pour rester rapide.
+     * onLine traite chaque ligne au fil de l'eau sans accumuler la sortie en mémoire.
      */
     private resticLsLines(
         dest: BackupDestination,
         snapshotId: string,
         timeoutMs: number = 120_000,
-        lineFilter?: (line: string) => boolean,
-    ): Promise<string[]> {
+        onLine: (line: string) => void,
+    ): Promise<void> {
         return new Promise(async (resolve, reject) => {
             const repoEnv = buildResticEnv(dest);
             const repo    = buildRepoUrl(dest);
@@ -1012,12 +1009,10 @@ export class BackupManager {
                     fail(new Error(`restic ls timed out after ${timeoutMs / 1000}s`), tmpFile);
                 }, timeoutMs);
 
-                const lines: string[] = [];
                 const rl = readline.createInterface({ input: proc.stdout, crlfDelay: Infinity });
                 rl.on("line", (line: string) => {
                     if (!line) return;
-                    if (lineFilter && !lineFilter(line)) return;
-                    lines.push(line);
+                    onLine(line);
                 });
 
                 let exitCode: number | null = null;
@@ -1033,8 +1028,8 @@ export class BackupManager {
                     settled = true;
                     cleanup(tmpFile);
                     if (exitCode === 0 || exitCode === null) {
-                        console.log(`[BackupManager] resticLsLines: ${lines.length} lignes reçues`);
-                        resolve(lines);
+                        console.log("[BackupManager] resticLsLines terminé");
+                        resolve();
                     } else {
                         reject(new Error(`restic ls exited with code ${exitCode}: ${stderr.slice(0, 500)}`));
                     }
@@ -2226,17 +2221,16 @@ export class BackupManager {
     private async runRestoreTest(dest: BackupDestination, snapshotId: string): Promise<RestoreTestResult> {
         try {
             const safeId = assertSafeResticId(snapshotId);
-            // Streaming via resticLsLines : un snapshot volumineux (100k+ fichiers)
-            // fait dépasser le maxBuffer de execFileAsync (20 Mo) si on accumule
-            // tout le `restic ls --json --long` en mémoire. On ne garde que les
-            // lignes de type fichier, ce qui suffit pour choisir un candidat.
-            const lsLines = await this.resticLsLines(
+            // Sélection au fil de l'eau : la consommation mémoire reste constante,
+            // quelle que soit la taille de la sortie de `restic ls`.
+            const selector = new RestoreTestCandidateSelector();
+            await this.resticLsLines(
                 dest,
                 safeId,
                 120_000,
-                (line) => line.includes('"type":"file"'),
+                (line) => selector.addLine(line),
             );
-            const candidate = selectRestoreTestCandidate(lsLines);
+            const candidate = selector.getCandidate();
 
             if (!candidate) {
                 return { ok: false, error: "Aucun fichier trouvé dans le snapshot" };

--- a/backend/watchers/backup-manager.ts
+++ b/backend/watchers/backup-manager.ts
@@ -2226,8 +2226,17 @@ export class BackupManager {
     private async runRestoreTest(dest: BackupDestination, snapshotId: string): Promise<RestoreTestResult> {
         try {
             const safeId = assertSafeResticId(snapshotId);
-            const lsOut = await this.resticFor(dest, [ "ls", safeId, "--json", "--long" ]);
-            const candidate = selectRestoreTestCandidate(lsOut);
+            // Streaming via resticLsLines : un snapshot volumineux (100k+ fichiers)
+            // fait dépasser le maxBuffer de execFileAsync (20 Mo) si on accumule
+            // tout le `restic ls --json --long` en mémoire. On ne garde que les
+            // lignes de type fichier, ce qui suffit pour choisir un candidat.
+            const lsLines = await this.resticLsLines(
+                dest,
+                safeId,
+                120_000,
+                (line) => line.includes('"type":"file"'),
+            );
+            const candidate = selectRestoreTestCandidate(lsLines);
 
             if (!candidate) {
                 return { ok: false, error: "Aucun fichier trouvé dans le snapshot" };

--- a/backend/watchers/backup-restore-test.test.ts
+++ b/backend/watchers/backup-restore-test.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { selectRestoreTestCandidate } from "./backup-restore-test";
+import { RestoreTestCandidateSelector, selectRestoreTestCandidate } from "./backup-restore-test";
 
 const node = (path: string, size: number) => JSON.stringify({
     struct_type: "node",
@@ -56,4 +56,13 @@ test("accepte un tableau de lignes JSON (mode streaming)", () => {
 
 test("accepte un tableau vide", () => {
     assert.equal(selectRestoreTestCandidate([]), null);
+});
+
+test("sélectionne un candidat au fil de l'eau sans conserver toutes les lignes", () => {
+    const selector = new RestoreTestCandidateSelector();
+    selector.addLine(node("/opt/dockge/data/settings.json", 120));
+    selector.addLine("ligne invalide");
+    selector.addLine(node("/opt/stacks/app/compose.yaml", 80));
+
+    assert.deepEqual(selector.getCandidate(), { path: "/opt/stacks/app/compose.yaml", size: 80 });
 });

--- a/backend/watchers/backup-restore-test.test.ts
+++ b/backend/watchers/backup-restore-test.test.ts
@@ -45,3 +45,15 @@ test("ne choisit un fichier vide que si aucun fichier non vide n'existe", () => 
 test("retourne null pour un snapshot sans fichier", () => {
     assert.equal(selectRestoreTestCandidate(""), null);
 });
+
+test("accepte un tableau de lignes JSON (mode streaming)", () => {
+    const result = selectRestoreTestCandidate([
+        node("/opt/dockge/data/settings.json", 120),
+        node("/opt/stacks/app/compose.yaml", 80),
+    ]);
+    assert.deepEqual(result, { path: "/opt/stacks/app/compose.yaml", size: 80 });
+});
+
+test("accepte un tableau vide", () => {
+    assert.equal(selectRestoreTestCandidate([]), null);
+});

--- a/backend/watchers/backup-restore-test.ts
+++ b/backend/watchers/backup-restore-test.ts
@@ -9,10 +9,11 @@ export interface RestoreTestCandidate {
  * backup Dockge valide peut ne contenir aucun Compose : dans ce cas, n'importe
  * quel autre fichier non vide convient pour tester le chiffrement/déchiffrement.
  */
-export function selectRestoreTestCandidate(lsOutput: string): RestoreTestCandidate | null {
+export function selectRestoreTestCandidate(lsOutput: string | string[]): RestoreTestCandidate | null {
     const files: RestoreTestCandidate[] = [];
 
-    for (const line of lsOutput.split("\n").filter(Boolean)) {
+    const lines = Array.isArray(lsOutput) ? lsOutput : lsOutput.split("\n");
+    for (const line of lines.filter(Boolean)) {
         try {
             const obj = JSON.parse(line) as Record<string, unknown>;
             if (obj.struct_type !== "node" || obj.type !== "file" || typeof obj.path !== "string") continue;

--- a/backend/watchers/backup-restore-test.ts
+++ b/backend/watchers/backup-restore-test.ts
@@ -3,6 +3,41 @@ export interface RestoreTestCandidate {
     size: number;
 }
 
+export class RestoreTestCandidateSelector {
+    private firstFile: RestoreTestCandidate | null = null;
+    private firstNonEmpty: RestoreTestCandidate | null = null;
+    private firstCompose: RestoreTestCandidate | null = null;
+    private firstNonEmptyCompose: RestoreTestCandidate | null = null;
+
+    addLine(line: string): void {
+        if (!line) return;
+
+        try {
+            const obj = JSON.parse(line) as Record<string, unknown>;
+            if (obj.struct_type !== "node" || obj.type !== "file" || typeof obj.path !== "string") return;
+
+            const rawSize = Number(obj.size ?? 0);
+            const candidate = {
+                path: obj.path,
+                size: Number.isFinite(rawSize) && rawSize >= 0 ? rawSize : 0,
+            };
+            const isCompose = /^(compose|docker-compose)(\.ya?ml)?$/.test(candidate.path.split("/").pop() ?? "");
+
+            this.firstFile ??= candidate;
+            if (candidate.size > 0) this.firstNonEmpty ??= candidate;
+            if (isCompose) this.firstCompose ??= candidate;
+            if (candidate.size > 0 && isCompose) this.firstNonEmptyCompose ??= candidate;
+        } catch { /* ignore non-node / malformed lines */ }
+    }
+
+    getCandidate(): RestoreTestCandidate | null {
+        return this.firstNonEmptyCompose
+            ?? this.firstNonEmpty
+            ?? this.firstCompose
+            ?? this.firstFile;
+    }
+}
+
 /**
  * Choisit un fichier réel du snapshot pour vérifier que Restic sait le relire.
  * Un Compose non vide est préféré pour conserver le test historique, mais un
@@ -10,28 +45,8 @@ export interface RestoreTestCandidate {
  * quel autre fichier non vide convient pour tester le chiffrement/déchiffrement.
  */
 export function selectRestoreTestCandidate(lsOutput: string | string[]): RestoreTestCandidate | null {
-    const files: RestoreTestCandidate[] = [];
-
+    const selector = new RestoreTestCandidateSelector();
     const lines = Array.isArray(lsOutput) ? lsOutput : lsOutput.split("\n");
-    for (const line of lines.filter(Boolean)) {
-        try {
-            const obj = JSON.parse(line) as Record<string, unknown>;
-            if (obj.struct_type !== "node" || obj.type !== "file" || typeof obj.path !== "string") continue;
-            const rawSize = Number(obj.size ?? 0);
-            files.push({
-                path: obj.path,
-                size: Number.isFinite(rawSize) && rawSize >= 0 ? rawSize : 0,
-            });
-        } catch { /* ignore non-node / malformed lines */ }
-    }
-
-    if (files.length === 0) return null;
-
-    const isCompose = (candidate: RestoreTestCandidate) =>
-        /^(compose|docker-compose)(\.ya?ml)?$/.test(candidate.path.split("/").pop() ?? "");
-
-    return files.find(candidate => candidate.size > 0 && isCompose(candidate))
-        ?? files.find(candidate => candidate.size > 0)
-        ?? files.find(isCompose)
-        ?? files[0];
+    for (const line of lines) selector.addLine(line);
+    return selector.getCandidate();
 }

--- a/extra/self-update-sidecar/Dockerfile
+++ b/extra/self-update-sidecar/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3
 
-RUN apk add --no-cache docker-cli docker-cli-compose \
+RUN apk upgrade --no-cache libcrypto3 libssl3 \
+    && apk add --no-cache docker-cli docker-cli-compose \
     && rm -rf /usr/local/lib/node_modules/npm
 WORKDIR /updater
 COPY --chown=node:node extra/self-update-sidecar/index.js ./index.js


### PR DESCRIPTION
## Contexte

Clôt #363.

`runRestoreTest` accumulait toute la sortie de `restic ls --json --long` via `execFileAsync`, limitée à 20 Mo. Les snapshots contenant un grand nombre de fichiers dépassaient cette limite alors que la sauvegarde elle-même réussissait.

## Changements

- consommation de la sortie Restic ligne par ligne via le helper de streaming existant ;
- sélection du fichier de test avec une mémoire constante, sans tableau contenant toutes les entrées du snapshot ;
- conservation de la priorité historique : Compose non vide, premier fichier non vide, Compose vide, premier fichier ;
- tests unitaires couvrant les entrées en tableau et la sélection incrémentale ;
- mise à niveau ciblée de `libcrypto3` et `libssl3` dans le sidecar afin de corriger la CVE détectée par la validation Docker.

Tests exécutés localement :

- `npx tsx --test backend/watchers/backup-restore-test.test.ts` : 8/8 réussis ;
- `npm run check-ts` : réussi ;
- build du sidecar : réussi ;
- scan Trivy HIGH/CRITICAL du sidecar : 0 vulnérabilité ;
- `npm run lint` : échec sur la dette de lint préexistante du dépôt (5 899 problèmes, hors portée de cette PR).
