### PR TITLE
Alléger le nom affiché des stacks externes

### DIFF
--- a/frontend/src/components/StackListItem.vue
+++ b/frontend/src/components/StackListItem.vue
@@ -17,7 +17,7 @@
         ></span>
         <div class="title">
             <div class="name-row">
-                <span class="name">{{ stackName }}</span>
+                <span class="name">{{ displayName }}</span>
                 <span v-if="stack.isExternal" class="external-badge"><font-awesome-icon icon="external-link-square-alt" />{{ $t("externalStacks.external") }}</span>
                 <font-awesome-icon v-if="scheduled" icon="calendar-days" class="scheduled-indicator" :title="$t('stackScheduler.scheduledTooltip')" />
             </div>
@@ -60,6 +60,7 @@
 import { EXITED, RUNNING, statusNameShort } from "../../../common/util-common";
 import StackUpdateBadge from "./StackUpdateBadge.vue";
 import StackStatsBadge from "./StackStatsBadge.vue";
+import { externalStackDisplayName } from "../util-external-stack-name";
 
 export default {
     components: {
@@ -116,6 +117,9 @@ export default {
         },
         stackName() {
             return this.stack.name;
+        },
+        displayName() {
+            return this.stack.isExternal ? externalStackDisplayName(this.stackName) : this.stackName;
         },
         active() {
             return this.$route.path === this.url;

--- a/frontend/src/util-external-stack-name.test.ts
+++ b/frontend/src/util-external-stack-name.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { suggestedExternalStackName } from "./util-external-stack-name";
+import { externalStackDisplayName, suggestedExternalStackName } from "./util-external-stack-name";
 
 test("conserve le nom normalisé du projet", () => {
     assert.equal(suggestedExternalStackName("My Compose App"), "my-compose-app");
@@ -9,6 +9,11 @@ test("conserve le nom normalisé du projet", () => {
 test("retire le préfixe external devenu redondant", () => {
     assert.equal(suggestedExternalStackName("external-radarr"), "radarr");
     assert.equal(suggestedExternalStackName("external-external-sonarr"), "sonarr");
+});
+
+test("masque le préfixe des stacks déjà intégrées sans modifier leur identifiant", () => {
+    assert.equal(externalStackDisplayName("external-radarr"), "radarr");
+    assert.equal(externalStackDisplayName("native-stack"), "native-stack");
 });
 
 test("fournit un nom neutre si le projet ne contient aucun caractère exploitable", () => {

--- a/frontend/src/util-external-stack-name.ts
+++ b/frontend/src/util-external-stack-name.ts
@@ -1,4 +1,8 @@
+export function externalStackDisplayName(name: string): string {
+    return name.replace(/^(external-)+/i, "") || name;
+}
+
 export function suggestedExternalStackName(project: string): string {
     const clean = project.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
-    return (clean.replace(/^(external-)+/, "") || "stack").slice(0, 96);
+    return (externalStackDisplayName(clean) || "stack").slice(0, 96);
 }


### PR DESCRIPTION
Les stacks externes déjà intégrées peuvent conserver un identifiant historique préfixé par `external-`, mais ce préfixe est redondant dans la navigation puisque le badge **Externe** est déjà affiché.

Cette modification :
- masque les préfixes `external-` répétés dans le libellé visible ;
- conserve strictement l’identifiant interne pour les routes, statistiques et opérations ;
- partage la même normalisation avec la suggestion de nom à l’intégration ;
- ajoute une couverture de test dédiée.

Contrôles effectués : tests unitaires ciblés, vérification TypeScript, build frontend et `git diff --check`.